### PR TITLE
Change manifest filename

### DIFF
--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -19,7 +19,7 @@ module Sprockets
     # path to the manifest json file. The file may or may not already exist. The
     # dirname of the `filename` will be used to write compiled assets to.
     # Otherwise, if the path is a directory, the filename will default a random
-    # "manifest-123.json" file in that directory.
+    # ".sprockets-manifest-*.json" file in that directory.
     #
     #   Manifest.new(environment, "./public/assets/manifest.json")
     #
@@ -33,7 +33,7 @@ module Sprockets
       # Name of a new manifest
       @new_manifest_name = ".sprockets-manifest-#{SecureRandom.hex(16)}.json"
 
-      # Whether the manifest file is using the old manifest.json naming convention
+      # Whether the manifest file is using the old manifest-*.json naming convention
       @legacy_manifest = false
 
       # Expand paths
@@ -48,13 +48,14 @@ module Sprockets
       # Default dir to the directory of the filename
       @directory ||= File.dirname(@filename) if @filename
 
-      # If directory is given w/o filename, pick a random manifest.json location
+      # If directory is given w/o filename, pick a random manifest location
       if @directory && @filename.nil?
-        # Find the first manifest.json in the directory
         filenames = Dir[File.join(@directory, ".sprockets-manifest*.json")]
         legacy_filenames = Dir[File.join(@directory, "manifest*.json")]
+        # Find the first manifest file in the directory
         if filenames.select{ |f| f[/.sprockets-manifest-[0-9a-f]{32}.json/] }.any?
           @filename = filenames.first
+        # Look for a legacy filename if none found
         elsif legacy_filenames.select{ |f| f[/.sprockets-manifest-[0-9a-f]{32}.json/] }.any?
           @filename = legacy_filenames.first
           @legacy_manifest = true
@@ -244,16 +245,16 @@ module Sprockets
 
     # The path to the filename to write out - for legacy manifest.json files
     # this will be a new .sprockets-manifest.json file
-    def output_filename
-      @legacy_manifest ? @new_manifest_name : @filename
+    def output_path
+      @legacy_manifest ? File.join(@directory,@new_manifest_name) : @filename
     end
 
     protected
       # Persist manfiest back to FS
       def save
         data = json_encode(@data)
-        FileUtils.mkdir_p File.dirname(output_filename)
-        PathUtils.atomic_write(output_filename) do |f|
+        FileUtils.mkdir_p File.dirname(output_path)
+        PathUtils.atomic_write(output_path) do |f|
           f.write(data)
         end
       end

--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -53,9 +53,9 @@ module Sprockets
         # Find the first manifest.json in the directory
         filenames = Dir[File.join(@directory, ".sprockets-manifest*.json")]
         legacy_filenames = Dir[File.join(@directory, "manifest*.json")]
-        if filenames.any?
+        if filenames.select{ |f| f[/.sprockets-manifest-[0-9a-f]{32}.json/] }.any?
           @filename = filenames.first
-        elsif legacy_filenames.any?
+        elsif legacy_filenames.select{ |f| f[/.sprockets-manifest-[0-9a-f]{32}.json/] }.any?
           @filename = legacy_filenames.first
           @legacy_manifest = true
         else

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -59,7 +59,7 @@ class TestManifest < Sprockets::TestCase
     assert_match @manifest_regexp, manifest.output_filename
   end
 
-  test "specify manifest directory with existing .sprockets-manifest-123.json" do
+  test "specify manifest directory with existing .sprockets-manifest-*.json" do
     dir  = Dir::tmpdir
     path = File.join(dir, ".sprockets-manifest-#{SecureRandom.hex(16)}.json")
 

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -10,7 +10,7 @@ class TestManifest < Sprockets::TestCase
     end
     @dir = File.join(Dir::tmpdir, 'sprockets/custom_manifest')
     @manifest = Sprockets::Manifest.new(@env, File.join(@dir, 'manifest.json'))
-    @manifest_regexp = %r{.sprockets-manifest-[a-f0-9]+\.json}
+    @manifest_regexp = %r{.sprockets-manifest-[a-f0-9]{32}.json}
   end
 
   def teardown
@@ -34,6 +34,7 @@ class TestManifest < Sprockets::TestCase
   test "specify manifest directory yields random .sprockets-manifest-*.json" do
     dir = Dir::tmpdir
 
+    system "rm -rf #{dir}/.sprockets-manifest*.json"
     system "rm -rf #{dir}/manifest*.json"
     assert !File.exist?("#{dir}/manifest.json")
     manifest = Sprockets::Manifest.new(@env, dir)
@@ -42,10 +43,11 @@ class TestManifest < Sprockets::TestCase
     assert_match @manifest_regexp, manifest.output_filename
   end
 
-  test "specify manifest directory with existing manifest.json" do
+  test "specify manifest directory with existing legacy manifest.json" do
     dir  = Dir::tmpdir
-    path = File.join(dir, 'manifest.json')
+    path = File.join(dir, "manifest-#{SecureRandom.hex(16)}.json")
 
+    system "rm -rf #{dir}/.sprockets-manifest*.json"
     system "rm -rf #{dir}/manifest*.json"
     FileUtils.mkdir_p(dir)
     File.open(path, 'w') { |f| f.write "{}" }
@@ -57,24 +59,11 @@ class TestManifest < Sprockets::TestCase
     assert_match @manifest_regexp, manifest.output_filename
   end
 
-  test "specify manifest directory with existing manifest-123.json" do
-    dir  = Dir::tmpdir
-    path = File.join(dir, 'manifest-123.json')
-
-    system "rm -rf #{dir}/manifest*.json"
-    File.open(path, 'w') { |f| f.write "{}" }
-
-    assert File.exist?(path)
-    manifest = Sprockets::Manifest.new(@env, dir)
-
-    assert_equal dir, manifest.directory
-    assert_match @manifest_regexp, manifest.output_filename
-  end
-
   test "specify manifest directory with existing .sprockets-manifest-123.json" do
     dir  = Dir::tmpdir
-    path = File.join(dir, '.sprockets-manifest-123.json')
+    path = File.join(dir, ".sprockets-manifest-#{SecureRandom.hex(16)}.json")
 
+    system "rm -rf #{dir}/.sprockets-manifest*.json"
     system "rm -rf #{dir}/manifest*.json"
     File.open(path, 'w') { |f| f.write "{}" }
 

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -8,8 +8,9 @@ class TestManifest < Sprockets::TestCase
     @env = Sprockets::Environment.new(".") do |env|
       env.append_path(fixture_path('default'))
     end
-    @dir = File.join(Dir::tmpdir, 'sprockets/manifest')
+    @dir = File.join(Dir::tmpdir, 'sprockets/custom_manifest')
     @manifest = Sprockets::Manifest.new(@env, File.join(@dir, 'manifest.json'))
+    @manifest_regexp = %r{.sprockets-manifest-[a-f0-9]+\.json}
   end
 
   def teardown
@@ -30,7 +31,7 @@ class TestManifest < Sprockets::TestCase
     assert_equal filename, manifest.path
   end
 
-  test "specify manifest directory yields random manifest-*.json" do
+  test "specify manifest directory yields random .sprockets-manifest-*.json" do
     dir = Dir::tmpdir
 
     system "rm -rf #{dir}/manifest*.json"
@@ -38,7 +39,7 @@ class TestManifest < Sprockets::TestCase
     manifest = Sprockets::Manifest.new(@env, dir)
 
     assert_equal dir, manifest.directory
-    assert_match %r{manifest-[a-f0-9]+\.json}, manifest.filename
+    assert_match @manifest_regexp, manifest.output_filename
   end
 
   test "specify manifest directory with existing manifest.json" do
@@ -53,7 +54,7 @@ class TestManifest < Sprockets::TestCase
     manifest = Sprockets::Manifest.new(@env, dir)
 
     assert_equal dir, manifest.directory
-    assert_equal path, manifest.filename
+    assert_match @manifest_regexp, manifest.output_filename
   end
 
   test "specify manifest directory with existing manifest-123.json" do
@@ -67,7 +68,21 @@ class TestManifest < Sprockets::TestCase
     manifest = Sprockets::Manifest.new(@env, dir)
 
     assert_equal dir, manifest.directory
-    assert_equal path, manifest.filename
+    assert_match @manifest_regexp, manifest.output_filename
+  end
+
+  test "specify manifest directory with existing .sprockets-manifest-123.json" do
+    dir  = Dir::tmpdir
+    path = File.join(dir, '.sprockets-manifest-123.json')
+
+    system "rm -rf #{dir}/manifest*.json"
+    File.open(path, 'w') { |f| f.write "{}" }
+
+    assert File.exist?(path)
+    manifest = Sprockets::Manifest.new(@env, dir)
+
+    assert_equal dir, manifest.directory
+    assert_equal path, manifest.output_filename
   end
 
   test "specify manifest directory and seperate location" do
@@ -81,7 +96,7 @@ class TestManifest < Sprockets::TestCase
     manifest = Sprockets::Manifest.new(@env, dir, path)
 
     assert_equal dir, manifest.directory
-    assert_equal path, manifest.filename
+    assert_equal path, manifest.output_filename
   end
 
   test "compile asset" do

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -40,7 +40,7 @@ class TestManifest < Sprockets::TestCase
     manifest = Sprockets::Manifest.new(@env, dir)
 
     assert_equal dir, manifest.directory
-    assert_match @manifest_regexp, manifest.output_filename
+    assert_match @manifest_regexp, manifest.output_path
   end
 
   test "specify manifest directory with existing legacy manifest.json" do
@@ -56,7 +56,7 @@ class TestManifest < Sprockets::TestCase
     manifest = Sprockets::Manifest.new(@env, dir)
 
     assert_equal dir, manifest.directory
-    assert_match @manifest_regexp, manifest.output_filename
+    assert_match @manifest_regexp, manifest.output_path
   end
 
   test "specify manifest directory with existing .sprockets-manifest-*.json" do
@@ -71,7 +71,7 @@ class TestManifest < Sprockets::TestCase
     manifest = Sprockets::Manifest.new(@env, dir)
 
     assert_equal dir, manifest.directory
-    assert_equal path, manifest.output_filename
+    assert_equal path, manifest.output_path
   end
 
   test "specify manifest directory and seperate location" do
@@ -85,7 +85,7 @@ class TestManifest < Sprockets::TestCase
     manifest = Sprockets::Manifest.new(@env, dir, path)
 
     assert_equal dir, manifest.directory
-    assert_equal path, manifest.output_filename
+    assert_equal path, manifest.output_path
   end
 
   test "compile asset" do
@@ -120,6 +120,28 @@ class TestManifest < Sprockets::TestCase
     manifest.compile('application.js')
     assert File.directory?(manifest.directory)
     assert File.file?(manifest.filename)
+  end
+
+  test "compile with legacy manifest" do
+    root  = File.join(Dir::tmpdir, 'public')
+    dir   = File.join(root, 'assets')
+    path  = File.join(root, "manifest-#{SecureRandom.hex(16)}.json")
+
+    system "rm -rf #{root}"
+    assert !File.exist?(root)
+
+    system "rm -rf #{dir}/.sprockets-manifest*.json"
+    system "rm -rf #{dir}/manifest*.json"
+    FileUtils.mkdir_p(dir)
+    File.open(path, 'w') { |f| f.write "{}" }
+
+
+    manifest = Sprockets::Manifest.new(@env, dir)
+
+    manifest.compile('application.js')
+    assert File.directory?(manifest.directory)
+    assert File.file?(manifest.output_path)
+    assert_match @manifest_regexp, manifest.output_path
   end
 
   test "compile asset with absolute path" do

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -12,7 +12,7 @@ class TestRakeTask < Sprockets::TestCase
       env.append_path(fixture_path('default'))
     end
 
-    @dir = File.join(Dir::tmpdir, 'sprockets/manifest')
+    @dir = File.join(Dir::tmpdir, 'sprockets/custom_manifest')
 
     @manifest = Sprockets::Manifest.new(@env, @dir)
 
@@ -39,7 +39,7 @@ class TestRakeTask < Sprockets::TestCase
 
     @rake[:assets].invoke
 
-    assert Dir["#{@dir}/manifest-*.json"].first
+    assert Dir["#{@dir}/.sprockets-manifest-*.json"].first
     assert File.exist?("#{@dir}/#{digest_path}")
   end
 
@@ -66,7 +66,7 @@ class TestRakeTask < Sprockets::TestCase
 
     @rake[:assets].invoke
 
-    assert Dir["#{@dir}/manifest-*.json"].first
+    assert Dir["#{@dir}/.sprockets-manifest-*.json"].first
     assert File.exist?("#{@dir}/#{digest_path}")
   end
 
@@ -83,7 +83,7 @@ class TestRakeTask < Sprockets::TestCase
 
     @rake[:assets].invoke
 
-    assert Dir["#{@dir}/manifest-*.json"].first
+    assert Dir["#{@dir}/.sprockets-manifest-*.json"].first
     assert File.exist?("#{@dir}/#{digest_path}")
   end
 end

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -12,9 +12,11 @@ class TestRakeTask < Sprockets::TestCase
       env.append_path(fixture_path('default'))
     end
 
-    @dir = File.join(Dir::tmpdir, 'sprockets/custom_manifest')
+    @dir = File.join(Dir::tmpdir, 'sprockets/manifest')
 
-    @manifest = Sprockets::Manifest.new(@env, @dir)
+    @manifest_custom_dir = Sprockets::Manifest.new(@env, @dir)
+
+    @manifest_custom_path = Sprockets::Manifest.new(@env, @dir, File.join(@dir, 'manifest.json'))
 
     Rake::SprocketsTask.new do |t|
       t.environment = @env
@@ -53,10 +55,10 @@ class TestRakeTask < Sprockets::TestCase
     assert !File.exist?("#{@dir}/#{digest_path}")
   end
 
-  test "custom manifest" do
+  test "custom manifest directory" do
     Rake::SprocketsTask.new do |t|
       t.environment = nil
-      t.manifest    = @manifest
+      t.manifest    = @manifest_custom_dir
       t.assets      = ['application.js']
       t.log_level   = :fatal
     end
@@ -70,10 +72,27 @@ class TestRakeTask < Sprockets::TestCase
     assert File.exist?("#{@dir}/#{digest_path}")
   end
 
+  test "custom manifest path" do
+    Rake::SprocketsTask.new do |t|
+      t.environment = nil
+      t.manifest    = @manifest_custom_path
+      t.assets      = ['application.js']
+      t.log_level   = :fatal
+    end
+
+    digest_path = @env['application.js'].digest_path
+    assert !File.exist?("#{@dir}/#{digest_path}")
+
+    @rake[:assets].invoke
+
+    assert Dir["#{@dir}/manifest.json"].first
+    assert File.exist?("#{@dir}/#{digest_path}")
+  end
+
   test "lazy custom manifest" do
     Rake::SprocketsTask.new do |t|
       t.environment = nil
-      t.manifest    = lambda { @manifest }
+      t.manifest    = lambda { @manifest_custom_dir }
       t.assets      = ['application.js']
       t.log_level   = :fatal
     end

--- a/test/test_sprocketize.rb
+++ b/test/test_sprocketize.rb
@@ -57,7 +57,7 @@ class TestSprockets < Sprockets::TestCase
     digest_path = @env['gallery.js'].digest_path
     output = sprockets "-I", fixture_path("default"), "-o", @dir, fixture_path("default/gallery.js")
     assert_equal "", output
-    assert Dir["#{@dir}/manifest-*.json"].first
+    assert Dir["#{@dir}/.sprockets-manifest-*.json"].first
     assert File.exist?("#{@dir}/#{digest_path}")
   end
 
@@ -65,7 +65,7 @@ class TestSprockets < Sprockets::TestCase
     digest_path1, digest_path2 = @env['gallery.js'].digest_path, @env['gallery.css'].digest_path
     output = sprockets "-I", fixture_path("default"), "-o", @dir, fixture_path("default/gallery.js"), fixture_path("default/gallery.css.erb")
     assert_equal "", output
-    assert Dir["#{@dir}/manifest-*.json"].first
+    assert Dir["#{@dir}/.sprockets-manifest-*.json"].first
     assert File.exist?("#{@dir}/#{digest_path1}")
     assert File.exist?("#{@dir}/#{digest_path2}")
   end


### PR DESCRIPTION
Hi @josh, per rails/sprockets#7 this chiefly changes the manifest filename from `manifest-*` to `.sprockets-manifest-*`. 

The main strategy is the one you discussed in the issue, with the addition of a random 32c string:
1. Look for `.sprockets-manifest-*.json`, if it exists use it.
2. Look for legacy manifest, if it exists use it set some sort of internal legacy flag
3. Else create a new file called `.sprockets-manifest-*.json`

As discussed, I added a `select` to discriminate beyond the dir globs, which will only match the 32c hex instead of the new asset fingerprints - this should entirely avoid collisions like the one I encountered. 

In addition:
1. Added a test in the rake task to discriminate between a custom manifest dir (which would contain the default manifest filename) and a full-on custom path
2. Streamlined the tests a bit in `test_manifest.rb` - there was currently a test for an existing `manifest-123.json` and `manifest.json`, which seemingly were effectively the same (please advise if not!)
3. Tweaked tests for the case of legacy vs. non-legacy manifest filenames

Let me know what you think!