### PR TITLE
Kinda support manifest.compile with simple path

### DIFF
--- a/lib/sprockets/legacy.rb
+++ b/lib/sprockets/legacy.rb
@@ -291,6 +291,12 @@ module Sprockets
       end
     end
 
+    def self.simple_logical_path?(str)
+      str.is_a?(String) &&
+        !PathUtils.absolute_path?(str) &&
+        str !~ /\*|\*\*|\?|\[|\]|\{|\}/
+    end
+
     # Deprecated: Filter logical paths in environment. Useful for selecting what
     # files you want to compile.
     #

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -191,6 +191,26 @@ class TestManifest < Sprockets::TestCase
     assert_equal gallery_digest_path, data['assets']['gallery.css']
   end
 
+  test "compile with transformed asset" do
+    assert svg_digest_path = @env['logo.svg'].digest_path
+    assert png_digest_path = @env['logo.png'].digest_path
+
+    assert !File.exist?("#{@dir}/#{svg_digest_path}")
+    assert !File.exist?("#{@dir}/#{png_digest_path}")
+
+    @manifest.compile('logo.svg', 'logo.png')
+
+    assert File.exist?("#{@dir}/manifest.json")
+    assert File.exist?("#{@dir}/#{svg_digest_path}")
+    assert File.exist?("#{@dir}/#{png_digest_path}")
+
+    data = JSON.parse(File.read(@manifest.filename))
+    assert data['files'][svg_digest_path]
+    assert data['files'][png_digest_path]
+    assert_equal svg_digest_path, data['assets']['logo.svg']
+    assert_equal png_digest_path, data['assets']['logo.png']
+  end
+
   test "compile asset with links" do
     manifest = Sprockets::Manifest.new(@env, File.join(@dir, 'manifest.json'))
 

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -192,19 +192,21 @@ class TestManifest < Sprockets::TestCase
   end
 
   test "compile with transformed asset" do
+    manifest = Sprockets::Manifest.new(@env, File.join(@dir, 'manifest.json'))
+
     assert svg_digest_path = @env['logo.svg'].digest_path
     assert png_digest_path = @env['logo.png'].digest_path
 
     assert !File.exist?("#{@dir}/#{svg_digest_path}")
     assert !File.exist?("#{@dir}/#{png_digest_path}")
 
-    @manifest.compile('logo.svg', 'logo.png')
+    manifest.compile('logo.svg', 'logo.png')
 
     assert File.exist?("#{@dir}/manifest.json")
     assert File.exist?("#{@dir}/#{svg_digest_path}")
     assert File.exist?("#{@dir}/#{png_digest_path}")
 
-    data = JSON.parse(File.read(@manifest.filename))
+    data = JSON.parse(File.read(manifest.filename))
     assert data['files'][svg_digest_path]
     assert data['files'][png_digest_path]
     assert_equal svg_digest_path, data['assets']['logo.svg']


### PR DESCRIPTION
Theres been a few issues around `Manifest#compile` targeting assets using transformers.

* https://github.com/josh/sprockets-es6/issues/9
* https://github.com/rails/sprockets/issues/10#issuecomment-84733066

The issue has to do with how 2.x and 3.x implement `manifest.compile`. To support arbitrary procs and fnmatch syntax, sprockets has to iterate over every darn file in the load path to check it against these filters. Its terribly slow. It also works on full path names rather than logical path names. So `manifest.compile "application.js"` isn't the same as `find_asset("application.js")`, even though it *mostly* acts the same. The *other times* causes these reported bugs.

On 4.x, I removed all the compile magic and made `manifest.compile "application.js"` just do `find_asset("application.js")`. Its much simpler and faster but means you can't do this fnmatch stuff anymore.

For 3.x I was just leaving things how they worked on 2.x cause I couldn't really figure out how to still support the 2.x behavior without it. But, I think we can maybe detect if a path passed to `compile` is "simple" and doesn't use any fnmatch magic and we can just do a direct lookup. I feel like theres some other gotcha to this, but I think it might fix most the causing issues people are actually hitting.

Again, this hacks don't need to stick around in 4.x, this code path is basically deleted. This test case was actually cherry picked from the 4.x branch cause it already works there.

/cc @tricknotes @praxxis @rafaelfranca @lucasmazza