### PR TITLE
#19 Add more extnames

### DIFF
--- a/lib/sprockets/mime.rb
+++ b/lib/sprockets/mime.rb
@@ -112,7 +112,7 @@ module Sprockets
         ([nil] + pipelines.keys.map(&:to_s)).each do |pipeline|
           pipeline_extname = ".#{pipeline}" if pipeline
           ([[nil, nil]] + config[:mime_exts].to_a).each do |format_extname, format_type|
-            3.times do |n|
+            4.times do |n|
               config[:engines].keys.permutation(n).each do |engine_extnames|
                 key = "#{pipeline_extname}#{format_extname}#{engine_extnames.join}"
                 type = format_type || config[:engine_mime_types][engine_extnames.first]


### PR DESCRIPTION
Increase number of available engines to use. So, for example, now there are avalable .jst.ejs.erb and .jst.eco.erb extnames.