### PR TITLE
Fixes an issue with writing temporary files to a different directory than expected

### DIFF
--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -262,7 +262,6 @@ module Sprockets
     # Returns nothing.
     def atomic_write(filename)
       randomname = [
-        File.dirname(filename),
         Thread.current.object_id,
         Process.pid,
         rand(1000000)

--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -261,12 +261,14 @@ module Sprockets
     #
     # Returns nothing.
     def atomic_write(filename)
-      tmpname = [
+      randomname = [
         File.dirname(filename),
         Thread.current.object_id,
         Process.pid,
         rand(1000000)
       ].join('.')
+
+      tmpname = File.join(File.dirname(filename), randomname)
 
       File.open(tmpname, 'wb+') do |f|
         yield f


### PR DESCRIPTION
In sprockets 3.0.0.rc.1 the `PathUtils#atomic_write` function appears to create it's temporary file one level higher than the target file. This can cause problems if the user you are using to compile assets does not have write access to that higher level directory.

For example, when compiling assets, atomic_write will attempt to write files like this:
```
/srv/my_app/releases/20150407233453/public/assets.15733540.23334.180138
```

However, I believe the expected behavior would be to write the temporary file in the target directory, like so:
```
/srv/my_app/releases/20150407233453/public/assets/15733540.23334.180138
```

I did not write a failing test case for this since the randomized temp file name makes it somewhat difficult to assert that the temp file has been written where expected.