### PR TITLE
fix to cast Pathname to String

### DIFF
--- a/lib/sprockets/context.rb
+++ b/lib/sprockets/context.rb
@@ -108,6 +108,8 @@ module Sprockets
     # the dependency file with invalidate the cache of the
     # source file.
     def depend_on(path)
+      path = path.to_s if path.is_a?(Pathname)
+
       if environment.absolute_path?(path) && environment.directory?(path)
         @dependencies << environment.build_file_digest_uri(path)
       else


### PR DESCRIPTION
depend_on(<Pathname >) fails in absolute_path?