### PR TITLE
Ensure legacy tilt handlers return downcasted Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Ensure legacy Tilt handlers return String class data. Fixes issues with Haml
+  Tilt handler.
 * Type check and improve error messages raised on bad processor returned results.
 * Changed HTML encoding fallback from ISO-8859-1 to default external.
 

--- a/lib/sprockets/legacy_proc_processor.rb
+++ b/lib/sprockets/legacy_proc_processor.rb
@@ -29,7 +29,7 @@ module Sprockets
     def call(input)
       context = input[:environment].context_class.new(input)
       data = @proc.call(context, input[:data])
-      context.metadata.merge(data: data)
+      context.metadata.merge(data: data.to_str)
     end
   end
 end

--- a/lib/sprockets/legacy_tilt_processor.rb
+++ b/lib/sprockets/legacy_tilt_processor.rb
@@ -23,7 +23,7 @@ module Sprockets
       context  = input[:environment].context_class.new(input)
 
       data = @klass.new(filename) { data }.render(context)
-      context.metadata.merge(data: data)
+      context.metadata.merge(data: data.to_str)
     end
   end
 end


### PR DESCRIPTION
Closes #33.

Needs verifications by @zdraganov or @kamen-hursev.