### PR TITLE
Remove special "index" logical path normalization case

### DIFF
--- a/lib/sprockets/legacy.rb
+++ b/lib/sprockets/legacy.rb
@@ -107,7 +107,6 @@ module Sprockets
 
           path = split_subpath(load_path, filename)
           path, mime_type, _, _ = parse_path_extnames(path)
-          path = normalize_logical_path(path)
           path += mime_types[mime_type][:extensions].first if mime_type
 
           if !seen.include?(path)

--- a/lib/sprockets/legacy.rb
+++ b/lib/sprockets/legacy.rb
@@ -107,6 +107,7 @@ module Sprockets
 
           path = split_subpath(load_path, filename)
           path, mime_type, _, _ = parse_path_extnames(path)
+          path = normalize_logical_path(path)
           path += mime_types[mime_type][:extensions].first if mime_type
 
           if !seen.include?(path)
@@ -125,6 +126,12 @@ module Sprockets
 
     def cache_set(key, value)
       cache.set(key, value)
+    end
+
+    def normalize_logical_path(path)
+      dirname, basename = File.split(path)
+      path = dirname if basename == 'index'
+      path
     end
 
     private

--- a/lib/sprockets/legacy.rb
+++ b/lib/sprockets/legacy.rb
@@ -303,6 +303,16 @@ module Sprockets
         str !~ /\*|\*\*|\?|\[|\]|\{|\}/
     end
 
+    def self.compute_alias_logical_path(path)
+      dirname, basename = File.split(path)
+      extname = File.extname(basename)
+      if File.basename(basename, extname) == 'index'
+        "#{dirname}#{extname}"
+      else
+        nil
+      end
+    end
+
     # Deprecated: Filter logical paths in environment. Useful for selecting what
     # files you want to compile.
     #

--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -78,7 +78,6 @@ module Sprockets
         end
 
         logical_path, file_type, engine_extnames, _ = parse_path_extnames(logical_path)
-        logical_path = normalize_logical_path(logical_path)
         name = logical_path
 
         if pipeline = params[:pipeline]

--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -169,6 +169,10 @@ module Sprockets
         }
         assets[asset.logical_path] = asset.digest_path
 
+        if alias_logical_path = self.class.compute_alias_logical_path(asset.logical_path)
+          assets[alias_logical_path] = asset.digest_path
+        end
+
         target = File.join(dir, asset.digest_path)
 
         if File.exist?(target)

--- a/lib/sprockets/resolve.rb
+++ b/lib/sprockets/resolve.rb
@@ -151,12 +151,6 @@ module Sprockets
         accepts
       end
 
-      def normalize_logical_path(path)
-        dirname, basename = File.split(path)
-        path = dirname if basename == 'index'
-        path
-      end
-
       def path_matches(load_path, logical_name, logical_basename)
         dirname    = File.dirname(File.join(load_path, logical_name))
         candidates = dirname_matches(dirname, logical_basename)

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -1243,7 +1243,7 @@ class AssetLogicalPathTest < Sprockets::TestCase
     assert_equal "bower/main.js", logical_path("bower/main.js")
     assert_equal "bower/bower.json", logical_path("bower/bower.json")
 
-    assert_equal "coffee.js", logical_path("coffee/index.js")
+    assert_equal "coffee/index.js", logical_path("coffee/index.js")
     assert_equal "coffee/foo.js", logical_path("coffee/foo.coffee")
 
     assert_equal "jquery.js", logical_path("jquery.js")
@@ -1253,7 +1253,7 @@ class AssetLogicalPathTest < Sprockets::TestCase
     assert_equal "jquery.foo.min.js", logical_path("jquery.foo.min.js")
     assert_equal "jquery.tmpl.js", logical_path("jquery.tmpl.js")
     assert_equal "jquery.tmpl.min.js", logical_path("jquery.tmpl.min.js")
-    assert_equal "jquery.ext.js", logical_path("jquery.ext/index.js")
+    assert_equal "jquery.ext/index.js", logical_path("jquery.ext/index.js")
     assert_equal "jquery.ext/form.js", logical_path("jquery.ext/form.js")
     assert_equal "jquery-coffee.min.js", logical_path("jquery-coffee.min.coffee")
     assert_equal "jquery-custom.min.js", logical_path("jquery-custom.min.js.erb")
@@ -1261,7 +1261,7 @@ class AssetLogicalPathTest < Sprockets::TestCase
 
     assert_equal "all.coffee/plain.js", logical_path("all.coffee/plain.js")
     assert_equal "all.coffee/hot.js", logical_path("all.coffee/hot.coffee")
-    assert_equal "all.coffee.js", logical_path("all.coffee/index.coffee")
+    assert_equal "all.coffee/index.js", logical_path("all.coffee/index.coffee")
 
     assert_equal "foo-ng.js", logical_path("foo-ng.ngt")
     assert_equal "bar-ng.js", logical_path("bar-ng.ngt.haml")

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -411,7 +411,7 @@ $app.run(function($templateCache) {
   end
 
   test "mobile index logical path shorthand" do
-    assert_equal "mobile.js",
+    assert_equal "mobile/index.js",
       @env[fixture_path("default/mobile/index.js")].logical_path
     assert_equal "mobile-min/index.min.js",
       @env[fixture_path("default/mobile-min/index.min.js")].logical_path
@@ -428,7 +428,7 @@ $app.run(function($templateCache) {
 
     assert paths.include?("application.js")
     assert paths.include?("coffee/foo.js")
-    assert paths.include?("coffee.js")
+    assert paths.include?("coffee/index.js")
     assert !paths.include?("coffee")
   end
 
@@ -444,7 +444,7 @@ $app.run(function($templateCache) {
 
     assert paths.include?("application.js")
     assert paths.include?("coffee/foo.js")
-    assert paths.include?("coffee.js")
+    assert paths.include?("coffee/index.js")
     assert !paths.include?("coffee")
 
     assert filenames.any? { |p| p =~ /application.js.coffee/ }

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -428,7 +428,7 @@ $app.run(function($templateCache) {
 
     assert paths.include?("application.js")
     assert paths.include?("coffee/foo.js")
-    assert paths.include?("coffee/index.js")
+    assert paths.include?("coffee.js")
     assert !paths.include?("coffee")
   end
 
@@ -444,7 +444,7 @@ $app.run(function($templateCache) {
 
     assert paths.include?("application.js")
     assert paths.include?("coffee/foo.js")
-    assert paths.include?("coffee/index.js")
+    assert paths.include?("coffee.js")
     assert !paths.include?("coffee")
 
     assert filenames.any? { |p| p =~ /application.js.coffee/ }

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -507,8 +507,8 @@ class TestManifest < Sprockets::TestCase
     manifest.find("coffee.js").each do |asset|
       paths << asset.logical_path
     end
-    assert paths.include?("coffee.js")
-    assert !paths.include?("coffee/index.js")
+    assert paths.include?("coffee/index.js")
+    assert !paths.include?("coffee.js")
   end
 
   test "each logical path enumerator matching fnmatch filters" do

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -271,6 +271,25 @@ class TestManifest < Sprockets::TestCase
     assert_equal subdep_digest_path, data['assets']['gallery.js']
   end
 
+  test "compile index asset" do
+    manifest = Sprockets::Manifest.new(@env, File.join(@dir, 'manifest.json'))
+
+    digest_path = @env['coffee.js'].digest_path
+    assert_match /coffee\/index-\w+.js/, digest_path
+
+    assert !File.exist?("#{@dir}/#{digest_path}")
+
+    manifest.compile('coffee.js')
+
+    assert File.exist?("#{@dir}/#{digest_path}")
+
+    data = JSON.parse(File.read(manifest.filename))
+    assert data['files'][digest_path]
+    assert_equal "coffee/index.js", data['files'][digest_path]['logical_path']
+    assert_equal digest_path, data['assets']['coffee/index.js']
+    assert_equal digest_path, data['assets']['coffee.js']
+  end
+
   test "compile with regex" do
     manifest = Sprockets::Manifest.new(@env, File.join(@dir, 'manifest.json'))
 


### PR DESCRIPTION
"index" files create too special edge cases in Sprockets.

1. Resolving with a directory name like "foo" will find "foo/index.js"
2. A resolved "foo/index.js" will have a normalized logical path of "foo"

I'd like to get rid of case 2.

It may make the compiled output a little uglier on some peoples bundles, but definitely simplifies things.

See discussion on #27 and #29.

This is a minor*ish* change, we'll probably release a 3.1.0.

/cc @aaronchi @vmoravec @elia @arthurnn @rafaelfranca 