### PR TITLE
Allow HEAD query

### DIFF
--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -23,7 +23,7 @@ module Sprockets
       start_time = Time.now.to_f
       time_elapsed = lambda { ((Time.now.to_f - start_time) * 1000).to_i }
 
-      if env['REQUEST_METHOD'] != 'GET'
+      if env['REQUEST_METHOD'] != 'GET' && env['REQUEST_METHOD'] != 'HEAD'
         return method_not_allowed_response
       end
 


### PR DESCRIPTION
I'm using JS library and it uses HEAD query for checking file.
https://github.com/emaiax/scriptcam-rails/blob/master/app/assets/javascripts/scriptcam.js.erb#L113.
when I updated 'sprockets' the 'scriptcam' stopped working.