### PR TITLE
Include CHANGELOG.md in gemspec

### DIFF
--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.description = "Sprockets is a Rack-based asset packaging system that concatenates and serves JavaScript, CoffeeScript, CSS, LESS, Sass, and SCSS."
   s.license = "MIT"
 
-  s.files = Dir["README.md", "LICENSE", "lib/**/*.rb"]
+  s.files = Dir["README.md", "CHANGELOG.md", "LICENSE", "lib/**/*.rb"]
   s.executables = ["sprockets"]
 
   s.add_dependency "rack", "~> 1.0"


### PR DESCRIPTION
To easily keep track of changes with `bundle open sprockets` after doing a `bundle update`.