### PR TITLE
Hack to support sourcemaps on Sass-3.3.

### DIFF
--- a/lib/sprockets/sass_compressor.rb
+++ b/lib/sprockets/sass_compressor.rb
@@ -1,6 +1,7 @@
 require 'sprockets/autoload'
 require 'sprockets/digest_utils'
 require 'sprockets/source_map_utils'
+require 'sprockets/sass_importer'
 
 module Sprockets
   # Public: Sass CSS minifier.
@@ -40,7 +41,8 @@ module Sprockets
         syntax: :scss,
         cache: false,
         read_cache: false,
-        style: :compressed
+        style: :compressed,
+        importer: SassImporter.new(''),
       }.merge(options).freeze
       @cache_key = "#{self.class.name}:#{Autoload::Sass::VERSION}:#{VERSION}:#{DigestUtils.digest(options)}".freeze
     end

--- a/lib/sprockets/sass_importer.rb
+++ b/lib/sprockets/sass_importer.rb
@@ -1,2 +1,8 @@
-# Deprecated: Require sprockets/sass_processor instead
-require 'sprockets/sass_processor'
+require 'sprockets/autoload'
+
+module Sprockets
+  class SassImporter < Autoload::Sass::Importers::Filesystem
+    # NOTE: Hack to support sourcemap generation in Sass-3.3
+    def public_url(*);'';end
+  end
+end

--- a/lib/sprockets/sass_processor.rb
+++ b/lib/sprockets/sass_processor.rb
@@ -1,6 +1,7 @@
 require 'rack/utils'
 require 'sprockets/autoload'
 require 'sprockets/source_map_utils'
+require 'sprockets/sass_importer'
 require 'uri'
 
 module Sprockets
@@ -46,7 +47,7 @@ module Sprockets
     def initialize(options = {}, &block)
       @cache_version = options[:cache_version]
       @cache_key = "#{self.class.name}:#{VERSION}:#{Autoload::Sass::VERSION}:#{@cache_version}".freeze
-      @importer_class = options[:importer] || Sass::Importers::Filesystem
+      @importer_class = options[:importer] || SassImporter
       @functions = Module.new do
         include Functions
         include options[:functions] if options[:functions]


### PR DESCRIPTION
Sass-3.3 requires importers to define the #public_url method (https://github.com/sass/sass/blob/3.3.0/lib/sass/engine.rb#L363).

In Sass-3.4 it is not required.

This PR stubs the method in order to support Sass-3.3