### PR TITLE
Add support for SassC

### DIFF
--- a/lib/sprockets/autoload.rb
+++ b/lib/sprockets/autoload.rb
@@ -6,6 +6,7 @@ module Sprockets
     autoload :Eco, 'sprockets/autoload/eco'
     autoload :EJS, 'sprockets/autoload/ejs'
     autoload :Sass, 'sprockets/autoload/sass'
+    autoload :SassC, 'sprockets/autoload/sassc'
     autoload :Uglifier, 'sprockets/autoload/uglifier'
     autoload :YUI, 'sprockets/autoload/yui'
   end

--- a/lib/sprockets/autoload/sassc.rb
+++ b/lib/sprockets/autoload/sassc.rb
@@ -1,0 +1,7 @@
+require 'sassc'
+
+module Sprockets
+  module Autoload
+    SassC = ::SassC
+  end
+end

--- a/lib/sprockets/sassc_compressor.rb
+++ b/lib/sprockets/sassc_compressor.rb
@@ -1,6 +1,7 @@
 require 'sprockets/autoload'
 require 'sprockets/sassc_importer'
 require 'sprockets/sass_compressor'
+require 'base64'
 
 module Sprockets
   class SasscCompressor < SassCompressor
@@ -9,11 +10,23 @@ module Sprockets
         syntax: :scss,
         style: :compressed,
         importer: SasscImporter,
+        source_map_embed: true,
+        source_map_file: '.'
       }.merge(options).freeze
     end
 
     def call(input)
-      Autoload::SassC::Engine.new(input[:data], @options.merge(filename: 'filename')).render
+      data = Autoload::SassC::Engine.new(input[:data], @options.merge(filename: 'filename')).render
+
+      match_data = data.match(/(.*)\n\/\*# sourceMappingURL=data:application\/json;base64,(.+) \*\//m)
+      css, map = match_data[1], Base64.decode64(match_data[2])
+
+      map = SourceMapUtils.combine_source_maps(
+        input[:metadata][:map],
+        SourceMapUtils.decode_json_source_map(map)["mappings"]
+      )
+
+      { data: css, map: map }
     end
   end
 end

--- a/lib/sprockets/sassc_compressor.rb
+++ b/lib/sprockets/sassc_compressor.rb
@@ -1,0 +1,19 @@
+require 'sprockets/autoload'
+require 'sprockets/sassc_importer'
+require 'sprockets/sass_compressor'
+
+module Sprockets
+  class SasscCompressor < SassCompressor
+    def initialize(options = {})
+      @options = {
+        syntax: :scss,
+        style: :compressed,
+        importer: SasscImporter,
+      }.merge(options).freeze
+    end
+
+    def call(input)
+      Autoload::SassC::Engine.new(input[:data], @options.merge(filename: 'filename')).render
+    end
+  end
+end

--- a/lib/sprockets/sassc_importer.rb
+++ b/lib/sprockets/sassc_importer.rb
@@ -1,0 +1,186 @@
+require 'sprockets/autoload'
+
+module Sprockets
+  class SasscImporter < Autoload::SassC::Importer
+    class Extension
+      attr_reader :postfix
+
+      def initialize(postfix=nil)
+        @postfix = postfix
+      end
+
+      def import_for(full_path, parent_dir, options)
+        SassC::Importer::Import.new(full_path)
+      end
+    end
+
+    class CSSExtension
+      def postfix
+        ".css"
+      end
+
+      def import_for(full_path, parent_dir, options)
+        import_path = full_path.gsub(/\.css$/,"")
+        SassC::Importer::Import.new(import_path)
+      end
+    end
+
+    class CssScssExtension < Extension
+      def postfix
+        ".css.scss"
+      end
+
+      def import_for(full_path, parent_dir, options)
+        source = File.read(full_path, 'rb')
+        SassC::Importer::Import.new(full_path, source: source)
+      end
+    end
+
+    class CssSassExtension < Extension
+      def postfix
+        ".css.sass"
+      end
+
+      def import_for(full_path, parent_dir, options)
+        sass = File.read(full_path, 'rb')
+        parsed_scss = SassC::Sass2Scss.convert(sass)
+        SassC::Importer::Import.new(full_path, source: parsed_scss)
+      end
+    end
+
+    class SassERBExtension < Extension
+      def postfix
+        ".sass.erb"
+      end
+
+      def import_for(full_path, parent_dir, options)
+        input = {
+          filename: full_path,
+          environment: options[:sprockets][:context].environment,
+          content_type: "text/erb",
+          metadata: {}
+        }
+        processors = [Sprockets::ERBProcessor, Sprockets::FileReader]
+        result = Sprockets::ProcessorUtils.call_processors(processors, input)
+        parsed_scss = SassC::Sass2Scss.convert(result)
+        SassC::Importer::Import.new(full_path, source: parsed_scss)
+      end
+    end
+
+    class ERBExtension < Extension
+      def import_for(full_path, parent_dir, options)
+        input = {
+          filename: full_path,
+          environment: options[:sprockets][:context].environment,
+          content_type: "text/erb",
+          metadata: {}
+        }
+        processors = [Sprockets::ERBProcessor, Sprockets::FileReader]
+        result = Sprockets::ProcessorUtils.call_processors(processors, input)
+        SassC::Importer::Import.new(full_path, source: result)
+      end
+    end
+
+    EXTENSIONS = [
+      CssScssExtension.new,
+      CssSassExtension.new,
+      Extension.new(".scss"),
+      Extension.new(".sass"),
+      CSSExtension.new,
+      ERBExtension.new(".scss.erb"),
+      ERBExtension.new(".css.erb"),
+      SassERBExtension.new
+    ]
+
+    PREFIXS = [ "", "_" ]
+    GLOB = /(\A|\/)(\*|\*\*\/\*)\z/
+
+    def imports(path, parent_path)
+      parent_dir, _ = File.split(parent_path)
+      specified_dir, specified_file = File.split(path)
+
+      if m = path.match(GLOB)
+        path = path.sub(m[0], "")
+        base = File.expand_path(path, File.dirname(parent_path))
+        return glob_imports(base, m[2], parent_path)
+      end
+
+      search_paths = ([parent_dir] + load_paths).uniq
+
+      if specified_dir != "."
+        search_paths.map! do |path|
+          File.join(path, specified_dir)
+        end
+      end
+
+      search_paths.each do |search_path|
+        PREFIXS.each do |prefix|
+          file_name = prefix + specified_file
+
+          EXTENSIONS.each do |extension|
+            try_path = File.join(search_path, file_name + extension.postfix)
+            if File.exists?(try_path)
+              record_import_as_dependency try_path
+              return extension.import_for(try_path, parent_dir, options)
+            end
+          end
+        end
+      end
+
+      SassC::Importer::Import.new(path)
+    end
+
+    private
+
+    def extension_for_file(file)
+      EXTENSIONS.detect do |extension|
+       file.include? extension.postfix
+      end
+    end
+
+    def record_import_as_dependency(path)
+      context.depend_on path
+    end
+
+    def context
+      options[:sprockets][:context]
+    end
+
+    def load_paths
+      options[:load_paths]
+    end
+
+    def glob_imports(base, glob, current_file)
+      files = globbed_files(base, glob)
+      files = files.reject { |f| f == current_file }
+
+      files.map do |filename|
+       record_import_as_dependency(filename)
+       extension = extension_for_file(filename)
+       extension.import_for(filename, base, options)
+      end
+    end
+
+    def globbed_files(base, glob)
+      # TODO: Raise an error from SassC here
+      raise ArgumentError unless glob == "*" || glob == "**/*"
+
+      extensions = EXTENSIONS.map(&:postfix)
+      exts = extensions.map { |ext| Regexp.escape("#{ext}") }.join("|")
+      sass_re = Regexp.compile("(#{exts})$")
+
+      record_import_as_dependency(base)
+
+      files = Dir["#{base}/#{glob}"].sort.map do |path|
+        if File.directory?(path)
+          record_import_as_dependency(path)
+          nil
+        elsif sass_re =~ path
+          path
+        end
+      end
+
+      files.compact
+    end
+  end
+end

--- a/lib/sprockets/sassc_processor.rb
+++ b/lib/sprockets/sassc_processor.rb
@@ -1,5 +1,6 @@
 require 'sprockets/sassc_importer'
 require 'sprockets/sass_processor'
+require 'base64'
 
 module Sprockets
   class SasscProcessor < SassProcessor
@@ -23,6 +24,8 @@ module Sprockets
         syntax: self.class.syntax,
         load_paths:  input[:environment].paths,
         importer: @importer_class,
+        source_map_embed: true,
+        source_map_file: '.',
         sprockets: {
           context: context,
           environment: input[:environment],
@@ -32,11 +35,19 @@ module Sprockets
 
       engine = Autoload::SassC::Engine.new(input[:data], options)
 
-      css = Utils.module_include(Autoload::SassC::Script::Functions, @functions) do
+      data = Utils.module_include(Autoload::SassC::Script::Functions, @functions) do
         engine.render
       end
 
-      context.metadata.merge(data: css)
+      match_data = data.match(/(.*)\n\/\*# sourceMappingURL=data:application\/json;base64,(.+) \*\//m)
+      css, map = match_data[1], Base64.decode64(match_data[2])
+
+      map = SourceMapUtils.combine_source_maps(
+        input[:metadata][:map],
+        SourceMapUtils.decode_json_source_map(map)["mappings"]
+      )
+
+      context.metadata.merge(data: css, map: map)
     end
 
     module Functions

--- a/lib/sprockets/sassc_processor.rb
+++ b/lib/sprockets/sassc_processor.rb
@@ -1,0 +1,70 @@
+require 'sprockets/sassc_importer'
+require 'sprockets/sass_processor'
+
+module Sprockets
+  class SasscProcessor < SassProcessor
+    def initialize(options = {}, &block)
+      @cache_version = options[:cache_version]
+      @cache_key = "#{self.class.name}:#{VERSION}:#{Autoload::SassC::VERSION}:#{@cache_version}".freeze
+      @importer_class = options[:importer] || SasscImporter
+      @functions = Module.new do
+        include SassProcessor::Functions
+        include Functions
+        include options[:functions] if options[:functions]
+        class_eval(&block) if block_given?
+      end
+    end
+
+    def call(input)
+      context = input[:environment].context_class.new(input)
+
+      options = {
+        filename: input[:filename],
+        syntax: self.class.syntax,
+        load_paths:  input[:environment].paths,
+        importer: @importer_class,
+        sprockets: {
+          context: context,
+          environment: input[:environment],
+          dependencies: context.metadata[:dependencies]
+        }
+      }
+
+      engine = Autoload::SassC::Engine.new(input[:data], options)
+
+      css = Utils.module_include(Autoload::SassC::Script::Functions, @functions) do
+        engine.render
+      end
+
+      context.metadata.merge(data: css)
+    end
+
+    module Functions
+      def asset_path(path, options = {})
+        path = path.value
+
+        path, _, query, fragment = URI.split(path)[5..8]
+        path     = sprockets_context.asset_path(path, options)
+        query    = "?#{query}" if query
+        fragment = "##{fragment}" if fragment
+
+        Autoload::SassC::Script::String.new("#{path}#{query}#{fragment}", :string)
+      end
+
+      def asset_url(path, options = {})
+        Autoload::SassC::Script::String.new("url(#{asset_path(path, options).value})")
+      end
+
+      def asset_data_url(path)
+        url = sprockets_context.asset_data_uri(path.value)
+        Autoload::SassC::Script::String.new("url(" + url + ")")
+      end
+    end
+  end
+
+  class ScsscProcessor < SasscProcessor
+    def self.syntax
+      :scss
+    end
+  end
+end

--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rack-test", "~> 0.6"
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "sass", "~> 3.1"
+  s.add_development_dependency "sassc", "~> 1.6"
   s.add_development_dependency "uglifier", "~> 2.3"
   s.add_development_dependency "yui-compressor", "~> 0.12"
 

--- a/test/test_sassc.rb
+++ b/test/test_sassc.rb
@@ -1,0 +1,352 @@
+require 'sprockets_test'
+
+silence_warnings do
+  require 'sassc'
+end
+
+require 'sprockets/sassc_processor'
+require 'sprockets/sassc_compressor'
+
+class TestBaseSassc < Sprockets::TestCase
+  CACHE_PATH = File.expand_path("../../.sass-cache", __FILE__)
+  COMPASS_PATH = File.join(FIXTURE_ROOT, 'compass')
+
+  def teardown
+    refute ::SassC::Script::Functions.instance_methods.include?(:asset_path)
+    FileUtils.rm_r(CACHE_PATH) if File.exist?(CACHE_PATH)
+    assert !File.exist?(CACHE_PATH)
+  end
+end
+
+class TestNoSasscFunction < TestBaseSass
+  module ::SassC::Script::Functions
+    def javascript_path(path)
+      ::SassC::Script::String.new("/js/#{path.value}", :string)
+    end
+
+    module Compass
+      def stylesheet_path(path)
+        ::SassC::Script::String.new("/css/#{path.value}", :string)
+      end
+    end
+    include Compass
+  end
+
+  test "aren't included globally" do
+    silence_warnings do
+      assert ::SassC::Script::Functions.instance_methods.include?(:javascript_path)
+      assert ::SassC::Script::Functions.instance_methods.include?(:stylesheet_path)
+
+      filename = fixture_path('sass/paths.scss')
+      assert data = File.read(filename)
+      engine = ::SassC::Engine.new(data, {
+        filename: filename,
+        syntax: :scss
+      })
+
+      assert ::SassC::Script::Functions.instance_methods.include?(:javascript_path)
+      assert ::SassC::Script::Functions.instance_methods.include?(:stylesheet_path)
+
+      assert_equal <<-EOS, engine.render
+div {
+  url: url(asset-path("foo.svg"));
+  url: url(image-path("foo.png"));
+  url: url(video-path("foo.mov"));
+  url: url(audio-path("foo.mp3"));
+  url: url(font-path("foo.woff"));
+  url: url("/js/foo.js");
+  url: url("/css/foo.css"); }
+      EOS
+    end
+  end
+end
+
+class TestSprocketsSassc < TestBaseSass
+  def setup
+    super
+
+    @env = Sprockets::Environment.new(".") do |env|
+      env.cache = {}
+      env.append_path(fixture_path('.'))
+      env.append_path(fixture_path('compass'))
+      env.append_path(fixture_path('octicons'))
+      env.register_transformer 'text/sass', 'text/css', Sprockets::SasscProcessor.new
+    end
+  end
+
+  def teardown
+    assert !File.exist?(CACHE_PATH)
+  end
+
+  def render(path)
+    path = fixture_path(path)
+    silence_warnings do
+      @env.find_asset(path, accept: 'text/css').to_s
+    end
+  end
+
+  test "process variables" do
+    assert_equal <<-EOS, render('sass/variables.sass')
+.content-navigation {
+  border-color: #3bbfce;
+  color: #2ca2af; }
+
+.border {
+  padding: 8px;
+  margin: 8px;
+  border-color: #3bbfce; }
+    EOS
+  end
+
+  test "process nesting" do
+    assert_equal <<-EOS, render('sass/nesting.scss')
+table.hl {
+  margin: 2em 0; }
+  table.hl td.ln {
+    text-align: right; }
+
+li {
+  font-family: serif;
+  font-weight: bold;
+  font-size: 1.2em; }
+    EOS
+  end
+
+  test "@import scss partial from scss" do
+    assert_equal <<-EOS, render('sass/import_partial.scss')
+#navbar li {
+  border-top-radius: 10px;
+  -moz-border-radius-top: 10px;
+  -webkit-border-top-radius: 10px; }
+
+#footer {
+  border-top-radius: 5px;
+  -moz-border-radius-top: 5px;
+  -webkit-border-top-radius: 5px; }
+
+#sidebar {
+  border-left-radius: 8px;
+  -moz-border-radius-left: 8px;
+  -webkit-border-left-radius: 8px; }
+    EOS
+  end
+
+  test "@import scss partial from sass" do
+    assert_equal <<-EOS, render('sass/import_partial.sass')
+#navbar li {
+  border-top-radius: 10px;
+  -moz-border-radius-top: 10px;
+  -webkit-border-top-radius: 10px; }
+
+#footer {
+  border-top-radius: 5px;
+  -moz-border-radius-top: 5px;
+  -webkit-border-top-radius: 5px; }
+
+#sidebar {
+  border-left-radius: 8px;
+  -moz-border-radius-left: 8px;
+  -webkit-border-left-radius: 8px; }
+    EOS
+  end
+
+  test "@import sass non-partial from scss" do
+    assert_equal <<-EOS, render('sass/import_nonpartial.scss')
+.content-navigation {
+  border-color: #3bbfce;
+  color: #2ca2af; }
+
+.border {
+  padding: 8px;
+  margin: 8px;
+  border-color: #3bbfce; }
+    EOS
+  end
+
+  test "@import css file from load path" do
+    assert_equal "\n", render('sass/import_load_path.scss')
+  end
+
+  test "process css file" do
+    assert_equal <<-EOS, render('sass/reset.css')
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+  display: block; }
+    EOS
+  end
+
+  test "@import relative file" do
+    assert_equal <<-EOS, render('sass/shared/relative.scss')
+#navbar li {
+  border-top-radius: 10px;
+  -moz-border-radius-top: 10px;
+  -webkit-border-top-radius: 10px; }
+
+#footer {
+  border-top-radius: 5px;
+  -moz-border-radius-top: 5px;
+  -webkit-border-top-radius: 5px; }
+
+#sidebar {
+  border-left-radius: 8px;
+  -moz-border-radius-left: 8px;
+  -webkit-border-left-radius: 8px; }
+    EOS
+  end
+
+  test "@import relative nested file" do
+    assert_equal <<-EOS, render('sass/relative.scss')
+body {
+  background: #666666; }
+    EOS
+  end
+
+  test "modify file causes it to recompile" do
+    filename = fixture_path('sass/test.scss')
+
+    sandbox filename do
+      File.open(filename, 'w') { |f| f.write "body { background: red; };" }
+      assert_equal "body {\n  background: red; }\n", render(filename)
+
+      File.open(filename, 'w') { |f| f.write "body { background: blue; };" }
+      mtime = Time.now + 1
+      File.utime(mtime, mtime, filename)
+
+      assert_equal "body {\n  background: blue; }\n", render(filename)
+    end
+  end
+
+  test "modify partial causes it to recompile" do
+    filename, partial = fixture_path('sass/test.scss'), fixture_path('sass/_partial.scss')
+
+    sandbox filename, partial do
+      File.open(filename, 'w') { |f| f.write "@import 'partial';" }
+      File.open(partial, 'w') { |f| f.write "body { background: red; };" }
+      assert_equal "body {\n  background: red; }\n", render(filename)
+
+      File.open(partial, 'w') { |f| f.write "body { background: blue; };" }
+      mtime = Time.now + 1
+      File.utime(mtime, mtime, partial)
+
+      assert_equal "body {\n  background: blue; }\n", render(filename)
+    end
+  end
+
+  test "reference @import'd variable" do
+    assert_equal <<-EOS, render('sass/links.scss')
+a:link {
+  color: "red"; }
+    EOS
+  end
+
+  test "@import reference variable" do
+    assert_equal <<-EOS, render('sass/main.scss')
+#header {
+  color: "blue"; }
+    EOS
+  end
+
+  test "raise sass error with line number" do
+    begin
+      ::Sass::Util.silence_sass_warnings do
+        render('sass/error.sass')
+      end
+      flunk
+    rescue SassC::SyntaxError => error
+      assert error.message.include?("invalid")
+      assert error.message.include?("error.sass")
+      assert error.message.include?("on line 5")
+    end
+  end
+end
+
+class TestSasscCompressor < TestBaseSass
+  test "compress css" do
+    silence_warnings do
+      uncompressed = "p {\n  margin: 0;\n  padding: 0;\n}\n"
+      compressed   = "p{margin:0;padding:0}\n"
+      input = {
+        data: uncompressed,
+        metadata: {},
+        cache: Sprockets::Cache.new
+      }
+      assert_equal compressed, Sprockets::SasscCompressor.call(input)
+    end
+  end
+end
+
+class TestSasscFunctions < TestSprocketsSass
+  def setup
+    super
+    define_asset_path
+  end
+
+  def define_asset_path
+    @env.context_class.class_eval do
+      def asset_path(path, options = {})
+        link_asset(path)
+        "/#{path}"
+      end
+    end
+  end
+
+  test "path functions" do
+    assert_equal <<-EOS, render('sass/paths.scss')
+div {
+  url: url("/foo.svg");
+  url: url("/foo.png");
+  url: url("/foo.mov");
+  url: url("/foo.mp3");
+  url: url("/foo.woff");
+  url: url("/foo.js");
+  url: url("/foo.css"); }
+    EOS
+  end
+
+  test "url functions" do
+    assert_equal <<-EOS, render('sass/urls.scss')
+div {
+  url: url(/foo.svg);
+  url: url(/foo.png);
+  url: url(/foo.mov);
+  url: url(/foo.mp3);
+  url: url(/foo.woff);
+  url: url(/foo.js);
+  url: url(/foo.css); }
+    EOS
+  end
+
+  test "url functions with query and hash parameters" do
+    assert_equal <<-EOS, render('octicons/octicons.scss')
+@font-face {
+  font-family: 'octicons';
+  src: url(/octicons.eot?#iefix) format("embedded-opentype"), url(/octicons.woff) format("woff"), url(/octicons.ttf) format("truetype"), url(/octicons.svg#octicons) format("svg");
+  font-weight: normal;
+  font-style: normal; }
+    EOS
+  end
+
+  test "path function generates links" do
+    asset = silence_warnings do
+      @env.find_asset('sass/paths.css')
+    end
+    assert asset
+
+    assert_equal [
+      "file://#{fixture_path('compass/foo.css')}?type=text/css&id=xxx",
+      "file://#{fixture_path('compass/foo.js')}?type=application/javascript&id=xxx",
+      "file://#{fixture_path('compass/foo.mov')}?id=xxx",
+      "file://#{fixture_path('compass/foo.mp3')}?type=audio/mpeg&id=xxx",
+      "file://#{fixture_path('compass/foo.svg')}?type=image/png&id=xxx",
+      "file://#{fixture_path('compass/foo.svg')}?type=image/svg+xml&id=xxx",
+      "file://#{fixture_path('compass/foo.woff')}?type=application/font-woff&id=xxx"
+    ], asset.links.to_a.map { |uri| uri.sub(/id=\w+/, 'id=xxx') }.sort
+  end
+
+  test "data-url function" do
+    assert_equal <<-EOS, render('sass/data_url.scss')
+div {
+  url: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAMAAAAoyzS7AAAABlBMVEUFO2sAAADPfNHpAAAACklEQVQIW2NgAAAAAgABYkBPaAAAAABJRU5ErkJggg%3D%3D); }
+    EOS
+  end
+end

--- a/test/test_sassc.rb
+++ b/test/test_sassc.rb
@@ -270,7 +270,7 @@ class TestSasscCompressor < TestBaseSass
         metadata: {},
         cache: Sprockets::Cache.new
       }
-      assert_equal compressed, Sprockets::SasscCompressor.call(input)
+      assert_equal compressed, Sprockets::SasscCompressor.call(input)[:data]
     end
   end
 end


### PR DESCRIPTION
As part of my Google Summer of Code project I've added support to Sprockets for SassC as an alterntive to the Ruby Sass implementation. I've added the SasscProcessor, SasscImporter and SasscCompressor classes based on the work of @bolandrm https://github.com/sass/sassc-ruby and https://github.com/sass/sassc-rails. 

My pull request passes all tests and I hand checked results from a moderately complicated set of Sass style sheets. 

Sadly, this strategy doesn't yet support source maps, but with the help of @guilleiguaran I'm trying to investigate how this can be done.