### PR TITLE
Use absolute module ids for AMD and System modules.

### DIFF
--- a/lib/sprockets/babel_processor.rb
+++ b/lib/sprockets/babel_processor.rb
@@ -36,7 +36,6 @@ module Sprockets
       result = input[:cache].fetch(@cache_key + [data]) do
         Autoload::Babel::Transpiler.transform(data, @options.merge(
           'sourceRoot' => input[:load_path],
-          'moduleRoot' => '',
           'filename' => input[:filename],
           'filenameRelative' => PathUtils.split_subpath(input[:load_path], input[:filename])
         ))

--- a/test/test_babel_processor.rb
+++ b/test/test_babel_processor.rb
@@ -80,7 +80,7 @@ define(["exports", "foo"], function (exports, _foo) {});
 
     assert js = Sprockets::BabelProcessor.new('modules' => 'amd', 'moduleIds' => true).call(input)[:data]
     assert_equal <<-JS.chomp, js.strip
-define("mod", ["exports", "foo"], function (exports, _foo) {});
+define("#{File.expand_path("../fixtures/mod", __FILE__)}", ["exports", "foo"], function (exports, _foo) {});
     JS
   end
 
@@ -117,7 +117,7 @@ System.register(["foo"], function (_export) {
 
     assert js = Sprockets::BabelProcessor.new('modules' => 'system', 'moduleIds' => true).call(input)[:data]
     assert_equal <<-JS.chomp, js.strip
-System.register("mod", ["foo"], function (_export) {
+System.register("#{File.expand_path("../fixtures/mod", __FILE__)}", ["foo"], function (_export) {
   return {
     setters: [function (_foo) {}],
     execute: function () {}


### PR DESCRIPTION
Recent versions of Babel use a default prefix ('/') for AMD and System module ids as the [specification](https://github.com/amdjs/amdjs-api/blob/master/AMD.md#id-) states that module IDs must be absolute.

Therfore, I removed the `moduleRoot` option in order to make the tests pass on both, the latest versions of Babel as well as the ones in which the default prefix was not yet introduced.