### PR TITLE
Compile aliased index assets.

### DIFF
--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -54,7 +54,8 @@ module Sprockets
           raise FileNotFound, "could not find file: #{filename}"
         end
 
-        load_path, logical_path = paths_split(config[:paths], filename)
+        path_to_split = params[:index_alias] || filename
+        load_path, logical_path = paths_split(config[:paths], path_to_split)
 
         unless load_path
           raise FileOutsidePaths, "#{filename} is no longer under a load path: #{self.paths.join(', ')}"

--- a/lib/sprockets/resolve.rb
+++ b/lib/sprockets/resolve.rb
@@ -168,7 +168,7 @@ module Sprockets
           candidates = find_matching_path_for_extensions(dirname, "index", mime_exts)
         end
         return candidates.map { |c|
-          { filename: c[0], type: c[1], index_alias: c[0].sub(/\/index/, '') }
+          { filename: c[0], type: c[1], index_alias: c[0].gsub(/\/index(\.\w{2,4})$/, '\1') }
         }, deps
       end
 

--- a/test/fixtures/default/alias-index-link.js
+++ b/test/fixtures/default/alias-index-link.js
@@ -1,0 +1,1 @@
+//= link coffee.js

--- a/test/fixtures/index-assets/bar/index.js
+++ b/test/fixtures/index-assets/bar/index.js
@@ -1,0 +1,1 @@
+var t = 'test'

--- a/test/fixtures/index-assets/index/foo/index.js
+++ b/test/fixtures/index-assets/index/foo/index.js
@@ -1,0 +1,1 @@
+var t = 'test'

--- a/test/test_path_utils.rb
+++ b/test/test_path_utils.rb
@@ -32,6 +32,7 @@ class TestPathUtils < MiniTest::Test
       "directives",
       "encoding",
       "errors",
+      "index-assets",
       "manifest_utils",
       "octicons",
       "paths",

--- a/test/test_resolve.rb
+++ b/test/test_resolve.rb
@@ -21,6 +21,20 @@ class TestResolve < Sprockets::TestCase
     refute resolve("null")
   end
 
+  test "resolve index assets" do
+    @env.append_path(fixture_path('index-assets'))
+
+    assert_equal "file://#{fixture_path('index-assets/bar/index.js')}?type=application/javascript",
+      resolve("bar/index.js")
+    assert_equal "file://#{fixture_path('index-assets/bar/index.js')}?type=application/javascript&index_alias=#{fixture_path('index-assets/bar.js')}",
+      resolve("bar.js")
+
+    assert_equal "file://#{fixture_path('index-assets/index/foo/index.js')}?type=application/javascript",
+      resolve("index/foo/index.js")
+    assert_equal "file://#{fixture_path('index-assets/index/foo/index.js')}?type=application/javascript&index_alias=#{fixture_path('index-assets/index/foo.js')}",
+      resolve("index/foo.js")
+  end
+
   test "resolve accept type list before paths" do
     @env.append_path(fixture_path('resolve/javascripts'))
     @env.append_path(fixture_path('resolve/stylesheets'))


### PR DESCRIPTION
The purpose ot this code is to give the possibility to compile the alias variant of an 'index' asset.
Suppose we have a file `something/index.js`. Sprockets can yield this file in two ways at the moment:
```
assets['something/index.js'].logical_path == 'something/index.js'
assets['something.js'].logical_path == 'something/index.js'
```
The thing is that when we precompile our asset we get only the 'index' version of it, regardless of how we list it in the manifest. This is because the location of the compiled file is derived from the logical path of the asset.

So, what this PR introduces is the ability do get a desired logical path depending on the way we request the asset:
```
assets['something/index.js'].logical_path == 'something/index.js'
assets['something.js'].logical_path == 'something.js'
```
This gives us the possibility to compile both versions, depending on our needs.