### PR TITLE
Allow to set a file store cache root using CLI

### DIFF
--- a/bin/sprockets
+++ b/bin/sprockets
@@ -51,6 +51,10 @@ OptionParser.new do |opts|
   opts.on("--noenv", "Disables .sprocketsrc file") do
   end
 
+  opts.on("--cache=DIRECTORY", "Enables the FileStore cache using the specified directory") do |directory|
+    environment.cache = Sprockets::Cache::FileStore.new(directory)
+  end
+
   opts.on_tail("-h", "--help", "Shows this help message") do
     opts.show_usage
   end


### PR DESCRIPTION
I think this has value by itself, but also to help debugging #59.

E.g. using the assets provided [here](https://github.com/rails/sprockets/issues/59#issuecomment-126731074) I get these results:

```bash
➋➁ sprockets:cli-cache-option> time be bin/sprockets -I __javascripts/ -o __out/ --js-compressor=uglifier --cache ./__cache application

real	0m21.864s
user	0m26.822s
sys	0m2.143s
➋➁ sprockets:cli-cache-option> time be bin/sprockets -I __javascripts/ -o __out/ --js-compressor=uglifier --cache ./__cache application

real	0m1.114s
user	0m0.915s
sys	0m0.186s
➋➁ sprockets:cli-cache-option> mv __javascripts{,2}/
➋➁ sprockets:cli-cache-option> time be bin/sprockets -I __javascripts2/ -o __out/ --js-compressor=uglifier --cache ./__cache application

real	0m22.907s
user	0m27.118s
sys	0m2.970s
➋➁ sprockets:cli-cache-option>
```