### PR TITLE
Save String allocations by freezing them

### DIFF
--- a/lib/sprockets/dependencies.rb
+++ b/lib/sprockets/dependencies.rb
@@ -62,7 +62,14 @@ module Sprockets
     #
     # Returns resolved Object.
     def resolve_dependency(str)
-      scheme = str[/([^:]+)/, 1]
+      # Optimize for the most common scheme to
+      # save 22k allocations on an average Spree app.
+      scheme = if str.start_with?('file-digest:'.freeze)
+        'file-digest'.freeze
+      else
+        str[/([^:]+)/, 1]
+      end
+
       if resolver = config[:dependency_resolvers][scheme]
         resolver.call(self, str)
       else

--- a/lib/sprockets/digest_utils.rb
+++ b/lib/sprockets/digest_utils.rb
@@ -66,7 +66,7 @@ module Sprockets
         elsif klass == FalseClass
           digest << 'FalseClass'
         elsif klass == NilClass
-          digest << 'NilClass'
+          digest << 'NilClass'.freeze
         elsif klass == Array
           digest << 'Array'
           queue.concat(obj)

--- a/lib/sprockets/uri_utils.rb
+++ b/lib/sprockets/uri_utils.rb
@@ -48,7 +48,7 @@ module Sprockets
       path.force_encoding(Encoding::UTF_8)
 
       # Hack for parsing Windows "file:///C:/Users/IEUser" paths
-      path.gsub!(/^\/([a-zA-Z]:)/, '\1')
+      path.gsub!(/^\/([a-zA-Z]:)/, '\1'.freeze)
 
       [scheme, host, path, query]
     end
@@ -125,7 +125,7 @@ module Sprockets
     def parse_file_digest_uri(uri)
       scheme, _, path, _ = split_file_uri(uri)
 
-      unless scheme == 'file-digest'
+      unless scheme == 'file-digest'.freeze
         raise URI::InvalidURIError, "expected file-digest scheme: #{uri}"
       end
 
@@ -143,7 +143,7 @@ module Sprockets
     #
     # Returns String URI.
     def build_file_digest_uri(path)
-      join_file_uri("file-digest", nil, path, nil)
+      join_file_uri('file-digest'.freeze, nil, path, nil)
     end
 
     # Internal: Serialize hash of params into query string.


### PR DESCRIPTION
Inspired by the great work done by @schneems on rails.

Here are some numbers taken from the current (Spree) app I’m working on:

'file-digest'   39k > 11k
'\1'            11k > 59
'NilClass'      10k > (less than 24)