### PR TITLE
[ci skip] Version 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**3.3.0** (August 12, 2015)
+
+* Change internal cache lookup to use relative asset paths instead of absolute paths.
+
 **3.2.0** (June 2, 2015)
 
 * Updated SRI integrity to align with spec changes

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,3 +1,3 @@
 module Sprockets
-  VERSION = "3.2.0"
+  VERSION = "3.3.0"
 end


### PR DESCRIPTION
There's only 8 commits between 3.2.0 and the 3.x branch 

![](https://www.dropbox.com/s/3c0cgzay9uyhpc1/Screenshot%202015-08-12%2012.12.42.png?dl=1)

https://github.com/rails/sprockets/compare/v3.2.0...3.x

I think this is the only thing that needs to be documented in the changelog.