### PR TITLE
Freeze non-mutated string literals (conti.)

### DIFF
--- a/lib/sprockets/bower.rb
+++ b/lib/sprockets/bower.rb
@@ -17,7 +17,7 @@ module Sprockets
       candidates, deps = super
 
       # bower.json can only be nested one level deep
-      if !logical_path.index('/')
+      if !logical_path.index('/'.freeze)
         dirname = File.join(load_path, logical_path)
 
         if directory?(dirname)

--- a/lib/sprockets/uri_utils.rb
+++ b/lib/sprockets/uri_utils.rb
@@ -59,7 +59,7 @@ module Sprockets
     def join_file_uri(scheme, host, path, query)
       str = "#{scheme}://"
       str << host if host
-      path = "/#{path}" unless path.start_with?("/")
+      path = "/#{path}" unless path.start_with?("/".freeze)
       str << URI::Generic::DEFAULT_PARSER.escape(path)
       str << "?#{query}" if query
       str
@@ -72,7 +72,7 @@ module Sprockets
     # Returns true or false.
     def valid_asset_uri?(str)
       # Quick prefix check before attempting a full parse
-      str.start_with?("file://") && parse_asset_uri(str) ? true : false
+      str.start_with?("file://".freeze) && parse_asset_uri(str) ? true : false
     rescue URI::InvalidURIError
       false
     end
@@ -168,7 +168,7 @@ module Sprockets
         end
       end
 
-      "#{query.join('&')}" if query.any?
+      "#{query.join('&'.freeze)}" if query.any?
     end
 
     # Internal: Parse query string into hash of params
@@ -177,8 +177,8 @@ module Sprockets
     #
     # Return Hash of params.
     def parse_uri_query_params(query)
-      query.to_s.split('&').reduce({}) do |h, p|
-        k, v = p.split('=', 2)
+      query.to_s.split('&'.freeze).reduce({}) do |h, p|
+        k, v = p.split('='.freeze, 2)
         v = URI::Generic::DEFAULT_PARSER.unescape(v) if v
         h[k.to_sym] = v || true
         h


### PR DESCRIPTION
Used https://github.com/schneems/let_it_go to find easy places for `String#freeze` optimization.

Following results from my rails app:

- Saves 8327-3146-102 = 5079 strings in uri_utils.rb on every request

  ```
  8327) /Users/Juan/.gem/ruby/2.2.2/gems/sprockets-3.2.0/lib/sprockets/uri_utils.rb
    - 4129) String#start_with? on line 62
    - 3146) String#gsub! on line 51 (already frozen)
    - 502) String#split on line 181
    - 149) String#start_with? on line 75
    - 102) String#split on line 180
    - 102) String#gsub! on line 51 (already frozen)
    - 87) String#split on line 180
    - 55) String#start_with? on line 62
    - 55) Array#join on line 171
  ```

- Another project

  ```
  5598) /Users/Juan/.gem/ruby/2.2.2/gems/sprockets-3.2.0/lib/sprockets/uri_utils.rb
  - 2947) String#gsub! on line 51
  - 1512) String#start_with? on line 62
  - 592) String#split on line 181
  - 120) String#gsub! on line 51
  - 120) String#split on line 180
  - 112) String#split on line 180
  - 67) String#start_with? on line 75
  - 64) String#start_with? on line 62
  - 64) Array#join on line 171
  ```

- Saves 2037 strings bower.rb on every request

  ```
  2037) /Users/Juan/.gem/ruby/2.2.2/gems/sprockets-3.2.0/lib/sprockets/bower.rb
    - 2037) String#index on line 20
  ```