### PR TITLE
[close #96] Remove all absolute paths from cache

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -144,7 +144,7 @@ module Sprockets
     env.version
   end
   register_dependency_resolver 'environment-paths' do |env|
-    env.paths
+    env.paths.map {|path| env.compress_from_root(path) }
   end
   register_dependency_resolver 'file-digest' do |env, str|
     env.file_digest(env.parse_file_digest_uri(str))

--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -11,6 +11,7 @@ require 'sprockets/path_utils'
 require 'sprockets/resolve'
 require 'sprockets/server'
 require 'sprockets/loader'
+require 'sprockets/uri_tar'
 
 module Sprockets
   # `Base` class for `Environment` and `Cached`.
@@ -96,6 +97,14 @@ module Sprockets
       "#<#{self.class}:0x#{object_id.to_s(16)} " +
         "root=#{root.to_s.inspect}, " +
         "paths=#{paths.inspect}>"
+    end
+
+    def compress_from_root(uri)
+      URITar.new(uri, self).compress
+    end
+
+    def expand_from_root(uri)
+      URITar.new(uri, self).expand
     end
   end
 end

--- a/lib/sprockets/unloaded_asset.rb
+++ b/lib/sprockets/unloaded_asset.rb
@@ -1,0 +1,137 @@
+require 'sprockets/uri_utils'
+require 'sprockets/uri_tar'
+
+module Sprockets
+  # Internal: Used to parse and store the URI to an unloaded asset
+  # Generates keys used to store and retrieve items from cache
+  class UnloadedAsset
+
+    # Internal: Initialize object for generating cache keys
+    #
+    # uri - A String containing complete URI to a file including scheme
+    #       and full path such as
+    #       "file:///Path/app/assets/js/app.js?type=application/javascript"
+    # env - The current "environment" that assets are being loaded into.
+    #       We need it so we know where the +root+ (directory where sprockets
+    #       is being invoked). We also need for the `file_digest` method,
+    #       since, for some strange reason, memoization is provided by
+    #       overriding methods such as `stat` in the `PathUtils` module.
+    #
+    # Returns UnloadedAsset.
+    def initialize(uri, env)
+      @uri               = uri
+      @env               = env
+      @compressed_path   = URITar.new(uri, env).compressed_path
+      @params            = nil # lazy loaded
+      @filename          = nil # lazy loaded
+    end
+    attr_reader :compressed_path, :uri
+
+    # Internal: Full file path without schema
+    #
+    # This returns a string containing the full path to the asset without the schema.
+    # Information is loaded lazilly since we want `UnloadedAsset.new(dep, self).relative_path`
+    # to be fast. Calling this method the first time allocates an array and a hash.
+    #
+    # Example
+    #
+    # If the URI is `file:///Full/path/app/assets/javascripts/application.js"` then the
+    # filename would be `"/Full/path/app/assets/javascripts/application.js"`
+    #
+    # Returns a String.
+    def filename
+      unless @filename
+        load_file_params
+      end
+      @filename
+    end
+
+    # Internal: Hash of param values
+    #
+    # This information is generated and used internally by sprockets.
+    # Known keys include `:type` which store the asset's mime-type, `:id` which is a fully resolved
+    # digest for the asset (includes dependency digest as opposed to a digest of only file contents)
+    # and `:pipeline`. Hash may be empty.
+    #
+    # Example
+    #
+    # If the URI is `file:///Full/path/app/assets/javascripts/application.js"type=application/javascript`
+    # Then the params would be `{type: "application/javascript"}`
+    #
+    # Returns a Hash.
+    def params
+      unless @params
+        load_file_params
+      end
+      @params
+    end
+
+    # Internal: Key of asset
+    #
+    # Used to retrieve an asset from the cache based on "compressed" path to asset.
+    # A "compressed" path can either be relative to the root of the project or an
+    # absolute path.
+    #
+    # Returns a String.
+    def asset_key
+      "asset-uri:#{compressed_path}"
+    end
+
+    # Public: Dependency History key
+    #
+    # Used to retrieve an array of "histories" each of which contain a set of stored dependencies
+    # for a given asset path and filename digest.
+    #
+    # A dependency can refer to either an asset i.e. index.js
+    # may rely on jquery.js (so jquery.js is a dependency), or other factors that may affect
+    # compilation, such as the VERSION of sprockets (i.e. the environment) and what "processors"
+    # are used.
+    #
+    # For example a history array with one Set of dependencies may look like:
+    #
+    # [["environment-version", "environment-paths", "processors:type=text/css&file_type=text/css",
+    #   "file-digest:///Full/path/app/assets/stylesheets/application.css",
+    #   "processors:type=text/css&file_type=text/css&pipeline=self",
+    #   "file-digest:///Full/path/app/assets/stylesheets"]]
+    #
+    # This method of asset lookup is used to ensure that none of the dependencies have been modified
+    # since last lookup. If one of them has, the key will be different and a new entry must be stored.
+    #
+    # URI depndencies are later converted to "compressed" paths
+    #
+    # Returns a String.
+    def dependency_history_key
+      "asset-uri-cache-dependencies:#{compressed_path}:#{ @env.file_digest(filename) }"
+    end
+
+    # Internal: Digest key
+    #
+    # Used to retrieve a string containing the "compressed" path to an asset based on
+    # a digest. The digest is generated from dependencies stored via information stored in
+    # the `dependency_history_key` after each of the "dependencies" is "resolved" for example
+    # "environment-version" may be resolved to "environment-1.0-3.2.0" for version "3.2.0" of sprockets
+    #
+    # Returns a String.
+    def digest_key(digest)
+      "asset-uri-digest:#{compressed_path}:#{digest}"
+    end
+
+    # Internal: File digest key
+    #
+    # The digest for a given file won't change if the path and the stat time hasn't changed
+    # We can save time by not re-computing this information and storing it in the cache
+    #
+    # Returns a String.
+    def file_digest_key(stat)
+      "file_digest:#{compressed_path}:#{stat}"
+    end
+
+    private
+      # Internal: Parses uri into filename and params hash
+      #
+      # Returns Array with filename and params hash
+      def load_file_params
+        @filename, @params = URIUtils.parse_asset_uri(uri)
+      end
+  end
+end

--- a/lib/sprockets/uri_tar.rb
+++ b/lib/sprockets/uri_tar.rb
@@ -1,0 +1,76 @@
+module Sprockets
+ # Internal: used to "expand" and "compress" values for storage
+  class URITar
+    attr_reader :scheme, :root, :path
+
+    # Internal: Initialize object for compression or expansion
+    #
+    # uri - A String containing URI that may or may not contain the scheme
+    # env - The current "environment" that assets are being loaded into.
+    def initialize(uri, env)
+      @root = env.root
+      @env  = env
+      if uri.include?("://".freeze)
+        uri_array = uri.split("://".freeze)
+        @scheme   = uri_array.shift
+        @scheme   << "://".freeze
+        @path     = uri_array.join("".freeze)
+      else
+        @scheme = "".freeze
+        @path   = uri
+      end
+    end
+
+    # Internal: Converts full uri to a "compressed" uri
+    #
+    # If a uri is inside of an environment's root it will
+    # be shortened to be a relative path.
+    #
+    # If a uri is outside of the environment's root the original
+    # uri will be returned.
+    #
+    # Returns String
+    def compress
+      scheme + compressed_path
+    end
+
+    # Internal: Convert a "compressed" uri to an absolute path
+    #
+    # If a uri is inside of the environment's root it will not
+    # start with a slash for example:
+    #
+    #   file://this/is/a/relative/path
+    #
+    # If a uri is outside the root, it will start with a slash:
+    #
+    #   file:///This/is/an/absolute/path
+    #
+    # Returns String
+    def expand
+      if path.start_with?("/".freeze)
+        # Stored path was absolute, don't add root
+        scheme + path
+      else
+        # Stored path was relative, add root
+        scheme + File.join(root, path)
+      end
+    end
+
+    # Internal: Returns "compressed" path
+    #
+    # If the input uri is relative to the environment root
+    # it will return a path relative to the environment root.
+    # Otherwise an absolute path will be returned.
+    #
+    # Only path information is returned, and not scheme.
+    #
+    # Returns String
+    def compressed_path
+      if compressed_path = @env.split_subpath(root, path)
+        compressed_path
+      else
+        path
+      end
+    end
+  end
+end


### PR DESCRIPTION
[close #96] Remove all absolute paths from cache

The patch in #92 was incomplete, it converted all cache keys to use relative paths, but didn't fully remove all absolute paths from cache contents. The test case was accidentally passing since we didn't check to make sure any of the paths from cache were different from the original ones stored. This patch eliminates these absolute paths stored in the cache:

- [x] dependency paths
- [x] filename
- [x] asset uris
- [x] "included" paths (no idea what these are)
- [x] load paths

### URITar

This patch works by introducing a utility class URITar which can "compress" or "expand" a given uri. A "compressed" uri can either be one that is relative to the root, or an absolute path if it is outside of the root. An expanded uri will always be an absolute path.

A uri that is relative to the root will be compressed with no beginning slash

    file://relative/to/root/file.js

A uri that is outside of the root will be compressed with a beginning slash

    file:///absolute/path/to/file.js

Even though I'm using "uri" here the URITar class can also operate on file paths without a valid URI scheme name. Like:

    relative/to/root/file.js

and

    /absolute/path/to/file.js

The UnloadedAsset class was moved to it's own file and refactored to use the new URITar class.

## Fix

Before putting anything in the cache, we will "compress" all uris  and paths so that no absolute paths are in the cache (unless they're not relative to the root which would indicate they're somewhere global e.g. from a gem or shared directory). 

Upon loading an asset in memory, we "expand" all uris since sprockets relies on absolute paths for just about everything. 

Almost all the business logic is limited to the loader, so the rest of sprockets has no clue if relative or absolute paths were used to build the asset.

We are also compressing the "environment-paths" so that dependencies in different paths will differ. I think this is needed, but the tests don't fail when it's taken out.

ATP