### PR TITLE
Add support for JSmin

### DIFF
--- a/lib/sprockets/autoload.rb
+++ b/lib/sprockets/autoload.rb
@@ -5,6 +5,7 @@ module Sprockets
     autoload :CoffeeScript, 'sprockets/autoload/coffee_script'
     autoload :Eco, 'sprockets/autoload/eco'
     autoload :EJS, 'sprockets/autoload/ejs'
+    autoload :JSMinC, 'sprockets/autoload/jsminc'    
     autoload :Sass, 'sprockets/autoload/sass'
     autoload :Uglifier, 'sprockets/autoload/uglifier'
     autoload :YUI, 'sprockets/autoload/yui'

--- a/lib/sprockets/autoload/jsminc.rb
+++ b/lib/sprockets/autoload/jsminc.rb
@@ -1,0 +1,7 @@
+require 'jsminc'
+
+module Sprockets
+  module Autoload
+    JSMinC = ::JSMinC
+  end
+end

--- a/lib/sprockets/jsminc_compressor.rb
+++ b/lib/sprockets/jsminc_compressor.rb
@@ -1,0 +1,31 @@
+require 'sprockets/autoload'
+require 'sprockets/digest_utils'
+
+module Sprockets
+  class JSMincCompressor
+    VERSION = '1'
+
+    def self.instance
+      @instance ||= new
+    end
+
+    def self.call(input)
+      instance.call(input)
+    end
+
+    def self.cache_key
+      instance.cache_key
+    end
+
+    attr_reader :cache_key
+
+    def initialize(options = {})
+      @compressor_class = Autoload::JSMinC
+      @cache_key = "#{self.class.name}:#{Autoload::JSMinC::VERSION}:#{VERSION}:#{DigestUtils.digest(options)}".freeze
+    end
+
+    def call(input)
+      @compressor_class.minify(input[:data])
+    end
+  end
+end

--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "eco", "~> 1.0"
   s.add_development_dependency "ejs", "~> 1.0"
   s.add_development_dependency "execjs", "~> 2.0"
+  s.add_development_dependency "jsminc", "~> 1.1"
   s.add_development_dependency "minitest", "~> 5.0"
   s.add_development_dependency "nokogiri", "~> 1.3"
   s.add_development_dependency "rack-test", "~> 0.6"

--- a/test/test_jsminc_compressor.rb
+++ b/test/test_jsminc_compressor.rb
@@ -1,0 +1,21 @@
+require 'minitest/autorun'
+require 'sprockets/cache'
+require 'sprockets/jsminc_compressor'
+
+class TestJSMincCompressor < MiniTest::Test
+
+  def test_compress_javascript
+    input = {
+      content_type: 'application/javascript',
+      data: "function foo() {\n  return true;\n}",
+      cache: Sprockets::Cache.new
+    }
+    output = "function foo(){return true;}"
+
+    assert_equal output, Sprockets::JSMincCompressor.call(input)
+  end
+
+  def test_cache_key
+    assert Sprockets::JSMincCompressor.cache_key
+  end
+end


### PR DESCRIPTION
As part of my Google Summer of Code project I've added support to Sprockets for JSMinC as an alterntive to the Uglifier implementation. I've added the JSMincCompressor class based on the work of  https://github.com/rf-/jsminc and inspired by this article http://lithostech.com/2014/03/is-uglifyjs-really-worth-it/
>Any sane person who’s delivering a lot of JavaScript to clients on the web is going to be using some kind of HTTP compression algorithm like gzip or deflate. And hardcore file size optimizations prior to compression seem like exactly the kind of things that would make regular file compression less efficient. So wouldn’t we be better off with something fast and simple like Douglas Crockford’s good old JSMin? We could just rely more on the file compression than minification or uglification to reduce file size.

My pull request passes all tests and I hand checked results from a set of moderately big JavaScript libraries.

compressing time:

| file |   Uglifier[1]   |   JSMinC   | Results |	
| ------------------- | ------------- | -------------- | ----------------------- |
|  jquery-1.11.3  | 0m2.573s | 0m0.465s | [1] is 5.53 times slower |
|  ember.debug  | 0m7.855s | 0m0.527s | [1] is 14.9 times slower |

size after compressing:
				
|file | original size|Uglifier | JSMinC | Results |	
| ------------------- | ---------------------- | -------------------- | ------------------- | --------------------- |
|  jquery-1.11.3  | 284.394 bytes |   97.134 bytes  | 149.679 bytes | 35.13 % smaller |
|  ember.debug  | 1.689.869 bytes |  473.834 bytes | 771.365 bytes | 38.58 % smaller |

size after compressing + gzip:

| file |       Uglifier       |      JSMinC      |        Results        |	
| ------------------- | -------------------- | ------------------- | --------------------- |
|  jquery-1.11.3  |   33.943 bytes  | 42.373 bytes | 20 % smaller |
|  ember.debug  |  123.820 bytes | 159.520 bytes | 22.4 % smaller |

