### PR TITLE
freeze more strings

### DIFF
--- a/lib/sprockets/digest_utils.rb
+++ b/lib/sprockets/digest_utils.rb
@@ -93,7 +93,7 @@ module Sprockets
     #
     # Returns hex String.
     def pack_hexdigest(bin)
-      bin.unpack('H*').first
+      bin.unpack('H*'.freeze).first
     end
 
     # Internal: Unpack a hex encoded digest string into binary bytes.

--- a/lib/sprockets/http_utils.rb
+++ b/lib/sprockets/http_utils.rb
@@ -13,8 +13,8 @@ module Sprockets
     # Returns true if the given value is a mime match for the given mime match
     # specification, false otherwise.
     def match_mime_type?(value, matcher)
-      v1, v2 = value.split('/', 2)
-      m1, m2 = matcher.split('/', 2)
+      v1, v2 = value.split('/'.freeze, 2)
+      m1, m2 = matcher.split('/'.freeze, 2)
       (m1 == '*' || v1 == m1) && (m2.nil? || m2 == '*' || m2 == v2)
     end
 

--- a/lib/sprockets/path_digest_utils.rb
+++ b/lib/sprockets/path_digest_utils.rb
@@ -15,7 +15,7 @@ module Sprockets
     def stat_digest(path, stat)
       if stat.directory?
         # If its a directive, digest the list of filenames
-        digest_class.digest(self.entries(path).join(','))
+        digest_class.digest(self.entries(path).join(','.freeze))
       elsif stat.file?
         # If its a file, digest the contents
         digest_class.file(path.to_s).digest

--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -294,7 +294,7 @@ module Sprockets
         Thread.current.object_id,
         Process.pid,
         rand(1000000)
-      ].join('.')
+      ].join('.'.freeze)
       tmpname = File.join(dirname, basename)
 
       File.open(tmpname, 'wb+') do |f|


### PR DESCRIPTION
While using [Let it Go](https://github.com/schneems/let_it_go) I was able to catch a few missing spots from #94.

```ruby
387) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sprockets-3.3.1/lib/sprockets/path_utils.rb
  - 387) Array#join on line 270
194) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sprockets-3.2.0/lib/sprockets/http_utils.rb
  - 50) String#split on line 16
  - 50) String#split on line 17
  - 47) String#split on line 16
  - 47) String#split on line 17
40) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sprockets-3.2.0/lib/sprockets/digest_utils.rb
  - 40) String#unpack on line 96
17) /Users/BenAMorgan/.rvm/gems/ruby-2.2.2/gems/sprockets-3.3.1/lib/sprockets/path_digest_utils.rb
  - 17) Array#join on line 18
```

638 less allocations... (for me at least)