### PR TITLE
Port up-to-date CHANGELOG from v3 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+**3.3.1** (August 15, 2015)
+
+* Fix legacy Tilt integration when locals is required argument.
+
+**3.3.0** (August 12, 2015)
+
+* Change internal cache lookup to use relative asset paths instead of absolute paths.
+
 **3.2.0** (June 2, 2015)
 
 * Updated SRI integrity to align with spec changes


### PR DESCRIPTION
See https://github.com/rails/sprockets/blob/bae6aa70ac6bfc8887ad4d1c814881d24fac5c09/CHANGELOG.md

The CHANGELOG on the master branch is lagging behind.