### PR TITLE
Seriously maybe no absolute paths in cache

### DIFF
--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -78,8 +78,16 @@ module Sprockets
           asset[:uri]       = expand_from_root(asset[:uri])
           asset[:load_path] = expand_from_root(asset[:load_path])
           asset[:filename]  = expand_from_root(asset[:filename])
-          asset[:metadata][:included].map!     { |uri| expand_from_root(uri) } if asset[:metadata][:included]
-          asset[:metadata][:dependencies].map! { |uri| uri.start_with?("file-digest://") ? expand_from_root(uri) : uri } if asset[:metadata][:dependencies]
+          asset[:metadata][:included].map!          { |uri| expand_from_root(uri) } if asset[:metadata][:included]
+          asset[:metadata][:links].map!             { |uri| expand_from_root(uri) } if asset[:metadata][:links]
+          asset[:metadata][:stubbed].map!           { |uri| expand_from_root(uri) } if asset[:metadata][:stubbed]
+          asset[:metadata][:required].map!          { |uri| expand_from_root(uri) } if asset[:metadata][:required]
+          asset[:metadata][:dependencies].map!      { |uri| uri.start_with?("file-digest://") ? expand_from_root(uri) : uri } if asset[:metadata][:dependencies]
+
+          asset[:metadata].each_key do |k|
+            next unless k =~ /_dependencies\z/
+            asset[:metadata][k].map! { |uri| expand_from_root(uri) }
+          end
         end
         asset
       end
@@ -196,16 +204,38 @@ module Sprockets
         if cached_asset[:metadata]
           # Deep dup to avoid modifying `asset`
           cached_asset[:metadata] = cached_asset[:metadata].dup
-          if cached_asset[:metadata][:included]
+          if cached_asset[:metadata][:included] && !cached_asset[:metadata][:included].empty?
             cached_asset[:metadata][:included] = cached_asset[:metadata][:included].dup
-            cached_asset[:metadata][:included] = cached_asset[:metadata][:included].map {|uri| compress_from_root(uri) }
+            cached_asset[:metadata][:included].map! { |uri| compress_from_root(uri) }
           end
 
-          if cached_asset[:metadata][:dependencies]
+          if cached_asset[:metadata][:links] && !cached_asset[:metadata][:links].empty?
+            cached_asset[:metadata][:links] = cached_asset[:metadata][:links].dup
+            cached_asset[:metadata][:links].map! { |uri| compress_from_root(uri) }
+          end
+
+          if cached_asset[:metadata][:stubbed] && !cached_asset[:metadata][:stubbed].empty?
+            cached_asset[:metadata][:stubbed] = cached_asset[:metadata][:stubbed].dup
+            cached_asset[:metadata][:stubbed].map! { |uri| compress_from_root(uri) }
+          end
+
+          if cached_asset[:metadata][:required] && !cached_asset[:metadata][:required].empty?
+            cached_asset[:metadata][:required] = cached_asset[:metadata][:required].dup
+            cached_asset[:metadata][:required].map! { |uri| compress_from_root(uri) }
+          end
+
+          if cached_asset[:metadata][:dependencies] && !cached_asset[:metadata][:dependencies].empty?
             cached_asset[:metadata][:dependencies] = cached_asset[:metadata][:dependencies].dup
             cached_asset[:metadata][:dependencies].map! do |uri|
               uri.start_with?("file-digest://".freeze) ? compress_from_root(uri) : uri
             end
+          end
+
+          # compress all _dependencies in metadata like `sass_dependencies`
+          cached_asset[:metadata].each do |key, value|
+            next unless key =~ /_dependencies\z/
+            cached_asset[:metadata][key] = value.dup
+            cached_asset[:metadata][key].map! {|uri| compress_from_root(uri) }
           end
         end
 
@@ -256,7 +286,7 @@ module Sprockets
       #
       #   [["environment-version", "environment-paths", "processors:type=text/css&file_type=text/css",
       #     "file-digest:///Full/path/app/assets/stylesheets/application.css",
-      #     "processors:type=text/css&file_type=text/css&pipeline=self",
+      #     "processors:type=text/css&file_digesttype=text/css&pipeline=self",
       #     "file-digest:///Full/path/app/assets/stylesheets"]]
       #
       # Where the first entry is a Set of dependencies for last generated version of that asset.
@@ -276,7 +306,7 @@ module Sprockets
 
         history = cache.get(key) || []
         history.each_with_index do |deps, index|
-          deps = deps.map { |path| path.start_with?("file-digest://") ? expand_from_root(path) : path }
+          deps.map! { |path| path.start_with?("file-digest://") ? expand_from_root(path) : path }
           if asset = yield(deps)
             cache.set(key, history.rotate!(index)) if index > 0
             return asset
@@ -284,7 +314,7 @@ module Sprockets
         end
 
         asset = yield
-        deps = asset[:metadata][:dependencies].map do |uri|
+        deps  = asset[:metadata][:dependencies].dup.map! do |uri|
           uri.start_with?("file-digest://") ? compress_from_root(uri) : uri
         end
         cache.set(key, history.unshift(deps).take(limit))

--- a/test/fixtures/default/schneems.js
+++ b/test/fixtures/default/schneems.js
@@ -1,0 +1,6 @@
+//= stub interpolation.js
+//= require ./noreturn.js
+//= require_self
+//= link logo.svg
+
+var dog = "cinco";

--- a/test/test_caching.rb
+++ b/test/test_caching.rb
@@ -365,7 +365,13 @@ class TestFileStoreCaching < Sprockets::TestCase
   def setup
     @cache_dir = File.join(Dir::tmpdir, 'sprockets')
     @cache     = Sprockets::Cache::FileStore.new(@cache_dir)
+  end
 
+  def teardown
+    FileUtils.remove_entry(@cache_dir)
+  end
+
+  test "shared cache objects are eql" do
     @env1 = Sprockets::Environment.new(fixture_path('default')) do |env|
       env.append_path(".")
       env.cache = @cache
@@ -375,13 +381,7 @@ class TestFileStoreCaching < Sprockets::TestCase
       env.append_path(".")
       env.cache = @cache
     end
-  end
 
-  def teardown
-    FileUtils.remove_entry(@cache_dir)
-  end
-
-  test "shared cache objects are eql" do
     asset1 = @env1['gallery.js']
     asset2 = @env2['gallery.js']
 
@@ -393,8 +393,15 @@ class TestFileStoreCaching < Sprockets::TestCase
     assert !asset1.equal?(asset2)
   end
 
-  test "no absolute paths are retuned from cache" do
-    asset1 = @env1['gallery.js']
+   test "no absolute paths are retuned from cache using sass" do
+    env1 = Sprockets::Environment.new(fixture_path('sass')) do |env|
+      env.append_path(".")
+      env.cache = @cache
+    end
+
+    asset1 = silence_warnings do
+      env1['variables.scss']
+    end
 
     Dir.mktmpdir do |dir|
       env2 = Sprockets::Environment.new(dir) do |env|
@@ -402,9 +409,40 @@ class TestFileStoreCaching < Sprockets::TestCase
         env.cache = @cache
       end
 
-      FileUtils.cp_r(@env1.root + "/.", env2.root)
+      FileUtils.cp_r(env1.root + "/.", env2.root)
 
-      asset2 = env2['gallery.js']
+      asset2 = silence_warnings do
+        env2['variables.scss']
+      end
+
+      assert asset1.metadata[:sass_dependencies]
+      assert asset2.metadata[:sass_dependencies]
+
+      assert_equal asset1.digest_path,              asset2.digest_path
+      assert_equal asset1.source,                   asset2.source
+      assert_equal asset1.hexdigest,                asset2.hexdigest
+
+      # Absolute paths should be different
+      refute_equal asset1.metadata[:sass_dependencies],  asset2.metadata[:sass_dependencies]
+    end
+  end
+
+  test "no absolute paths are retuned from cache" do
+    env1 = Sprockets::Environment.new(fixture_path('default')) do |env|
+      env.append_path(".")
+      env.cache = @cache
+    end
+    asset1 = env1['schneems.js']
+
+    Dir.mktmpdir do |dir|
+      env2 = Sprockets::Environment.new(dir) do |env|
+        env.append_path(dir)
+        env.cache = @cache
+      end
+
+      FileUtils.cp_r(env1.root + "/.", env2.root)
+
+      asset2 = env2['schneems.js']
 
       assert asset1
       assert asset2
@@ -419,6 +457,33 @@ class TestFileStoreCaching < Sprockets::TestCase
       refute_equal asset1.included,                 asset2.included
       refute_equal asset1.to_hash[:load_path],      asset2.to_hash[:load_path]
       refute_equal asset1.metadata[:dependencies],  asset2.metadata[:dependencies]
+      refute_equal asset1.metadata[:links],         asset2.metadata[:links]
+
+      # The metadata[:stubbed] and metadata[:required] cannot be
+      # observed directly, they are included in the `dependencies`.
+      # We must use private APIs to test this behavior
+      # https://github.com/rails/sprockets/issues/96#issuecomment-133097865
+      cache_entries = @cache.send(:find_caches).map do |file, _|
+        key    = file.gsub(/\.cache\z/, ''.freeze).split(@cache_dir).last
+        result = @cache.get(key)
+        result.is_a?(Hash) ? result : nil
+      end.compact
+
+      required = cache_entries.map do |asset|
+        asset[:metadata][:required] if asset[:metadata]
+      end.compact
+
+      required.each do |set|
+        refute set.any? {|uri| uri.include?(env1.root) || uri.include?(env2.root)}, "Expected 'required' entry in cache to not include absolute paths but did: #{set.inspect}"
+      end
+
+      stubbed = cache_entries.map do |asset|
+        asset[:metadata][:stubbed] if asset[:metadata]
+      end.compact
+
+      stubbed.each do |set|
+        refute set.any? {|uri| uri.include?(env1.root) || uri.include?(env2.root)}, "Expected 'stubbed' entry in cache to not include absolute paths but did: #{set.inspect}"
+      end
     end
   end
 end


### PR DESCRIPTION
Previous pull requests (#92 & #101) did not properly "compress": `links`, `stubbed`, or `required` keys in the metadata. Also external processors can put arbitrary in the metadata hash, we now have a convention where anything that ends in `_dependencies` such as `sass_dependencies` will also be compressed. This change properly compresses and expand uris.

We also need to expand uris in the `fetch_asset_from_dependency_cache` before they are resolved to generate a digest. We must also make sure to compress them before they are stored back in the cache. There might be a better place to put this logic somewhere in the future, but for now it makes sense to put both expansion and compression in the same method, though this does mean we have to "compress" the dependencies twice.

Tests are written that will fail without this patch and pass with it. The "stubbed" and "required" sets in the metadata are not directly exposed, we must use private methods to observe them. I think it is better to do this for now, I believe this file has some refactor potential in the future, but don't want to mix bug fixes with refactoring.