### PR TITLE
Seriously maybe no absolute paths in cache

### DIFF
--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -77,8 +77,16 @@ module Sprockets
           asset[:uri]       = expand_from_root(asset[:uri])
           asset[:load_path] = expand_from_root(asset[:load_path])
           asset[:filename]  = expand_from_root(asset[:filename])
-          asset[:metadata][:included].map!     { |uri| expand_from_root(uri) } if asset[:metadata][:included]
-          asset[:metadata][:dependencies].map! { |uri| uri.start_with?("file-digest://") ? expand_from_root(uri) : uri } if asset[:metadata][:dependencies]
+          asset[:metadata][:included].map!          { |uri| expand_from_root(uri) } if asset[:metadata][:included]
+          asset[:metadata][:links].map!             { |uri| expand_from_root(uri) } if asset[:metadata][:links]
+          asset[:metadata][:stubbed].map!           { |uri| expand_from_root(uri) } if asset[:metadata][:stubbed]
+          asset[:metadata][:required].map!          { |uri| expand_from_root(uri) } if asset[:metadata][:required]
+          asset[:metadata][:dependencies].map!      { |uri| uri.start_with?("file-digest://") ? expand_from_root(uri) : uri } if asset[:metadata][:dependencies]
+
+          asset[:metadata].each_key do |k|
+            next unless k =~ /_dependencies\z/
+            asset[:metadata][k].map! { |uri| expand_from_root(uri) }
+          end
         end
         asset
       end
@@ -197,16 +205,38 @@ module Sprockets
         if cached_asset[:metadata]
           # Deep dup to avoid modifying `asset`
           cached_asset[:metadata] = cached_asset[:metadata].dup
-          if cached_asset[:metadata][:included]
+          if cached_asset[:metadata][:included] && !cached_asset[:metadata][:included].empty?
             cached_asset[:metadata][:included] = cached_asset[:metadata][:included].dup
-            cached_asset[:metadata][:included] = cached_asset[:metadata][:included].map {|uri| compress_from_root(uri) }
+            cached_asset[:metadata][:included].map! { |uri| compress_from_root(uri) }
           end
 
-          if cached_asset[:metadata][:dependencies]
+          if cached_asset[:metadata][:links] && !cached_asset[:metadata][:links].empty?
+            cached_asset[:metadata][:links] = cached_asset[:metadata][:links].dup
+            cached_asset[:metadata][:links].map! { |uri| compress_from_root(uri) }
+          end
+
+          if cached_asset[:metadata][:stubbed] && !cached_asset[:metadata][:stubbed].empty?
+            cached_asset[:metadata][:stubbed] = cached_asset[:metadata][:stubbed].dup
+            cached_asset[:metadata][:stubbed].map! { |uri| compress_from_root(uri) }
+          end
+
+          if cached_asset[:metadata][:required] && !cached_asset[:metadata][:required].empty?
+            cached_asset[:metadata][:required] = cached_asset[:metadata][:required].dup
+            cached_asset[:metadata][:required].map! { |uri| compress_from_root(uri) }
+          end
+
+          if cached_asset[:metadata][:dependencies] && !cached_asset[:metadata][:dependencies].empty?
             cached_asset[:metadata][:dependencies] = cached_asset[:metadata][:dependencies].dup
             cached_asset[:metadata][:dependencies].map! do |uri|
               uri.start_with?("file-digest://".freeze) ? compress_from_root(uri) : uri
             end
+          end
+
+          # compress all _dependencies in metadata like `sass_dependencies`
+          cached_asset[:metadata].each do |key, value|
+            next unless key =~ /_dependencies\z/
+            cached_asset[:metadata][key] = value.dup
+            cached_asset[:metadata][key].map! {|uri| compress_from_root(uri) }
           end
         end
 
@@ -257,7 +287,7 @@ module Sprockets
       #
       #   [["environment-version", "environment-paths", "processors:type=text/css&file_type=text/css",
       #     "file-digest:///Full/path/app/assets/stylesheets/application.css",
-      #     "processors:type=text/css&file_type=text/css&pipeline=self",
+      #     "processors:type=text/css&file_digesttype=text/css&pipeline=self",
       #     "file-digest:///Full/path/app/assets/stylesheets"]]
       #
       # Where the first entry is a Set of dependencies for last generated version of that asset.
@@ -277,7 +307,7 @@ module Sprockets
 
         history = cache.get(key) || []
         history.each_with_index do |deps, index|
-          deps = deps.map { |path| path.start_with?("file-digest://") ? expand_from_root(path) : path }
+          deps.map! { |path| path.start_with?("file-digest://") ? expand_from_root(path) : path }
           if asset = yield(deps)
             cache.set(key, history.rotate!(index)) if index > 0
             return asset
@@ -285,7 +315,7 @@ module Sprockets
         end
 
         asset = yield
-        deps = asset[:metadata][:dependencies].map do |uri|
+        deps  = asset[:metadata][:dependencies].dup.map! do |uri|
           uri.start_with?("file-digest://") ? compress_from_root(uri) : uri
         end
         cache.set(key, history.unshift(deps).take(limit))

--- a/test/fixtures/default/schneems.js
+++ b/test/fixtures/default/schneems.js
@@ -1,0 +1,6 @@
+//= stub interpolation.js
+//= require ./noreturn.js
+//= require_self
+//= link logo.svg
+
+var dog = "cinco";


### PR DESCRIPTION
Previous pull requests (#92 & #101) did not properly "compress": `links`, `stubbed`, or `required` keys in the metadata. Also external processors can put arbitrary in the metadata hash, we now have a convention where anything that ends in `_dependencies` such as `sass_dependencies` will also be compressed. This change properly compresses and expand uris.

Targeted at 4.x

We also need to expand uris in the `fetch_asset_from_dependency_cache` before they are resolved to generate a digest. We must also make sure to compress them before they are stored back in the cache. There might be a better place to put this logic somewhere in the future, but for now it makes sense to put both expansion and compression in the same method, though this does mean we have to "compress" the dependencies twice.

Tests are written that will fail without this patch and pass with it. The "stubbed" and "required" sets in the metadata are not directly exposed, we must use private methods to observe them. I think it is better to do this for now, I believe this file has some refactor potential in the future, but don't want to mix bug fixes with refactoring.