### PR TITLE
[close #112] Allow pathname

### DIFF
--- a/lib/sprockets/unloaded_asset.rb
+++ b/lib/sprockets/unloaded_asset.rb
@@ -19,7 +19,7 @@ module Sprockets
     #
     # Returns UnloadedAsset.
     def initialize(uri, env)
-      @uri               = uri
+      @uri               = uri.to_s
       @env               = env
       @compressed_path   = URITar.new(uri, env).compressed_path
       @params            = nil # lazy loaded

--- a/lib/sprockets/uri_tar.rb
+++ b/lib/sprockets/uri_tar.rb
@@ -10,6 +10,7 @@ module Sprockets
     def initialize(uri, env)
       @root = env.root
       @env  = env
+      uri   = uri.to_s
       if uri.include?("://".freeze)
         uri_array = uri.split("://".freeze)
         @scheme   = uri_array.shift

--- a/test/test_loader.rb
+++ b/test/test_loader.rb
@@ -21,6 +21,10 @@ class TestLoader < Sprockets::TestCase
     assert_equal fixture_path('default/gallery.css.erb'), asset.filename
     assert_equal 'text/css', asset.content_type
 
+    assert asset = @env.load(Pathname.new("file://#{fixture_path('default/gallery.css.erb')}?type=text/css"))
+    assert_equal fixture_path('default/gallery.css.erb'), asset.filename
+    assert_equal 'text/css', asset.content_type
+
     bad_id = "0000000000000000000000000000000000000000"
     assert asset = @env.load("file://#{fixture_path('default/gallery.js')}?type=application/javascript&id=#{bad_id}")
     assert_equal fixture_path('default/gallery.js'), asset.filename


### PR DESCRIPTION
Previously pathname objects could be used with sprockets, this wasn't explicitly tested, but it should be supported. This patch calls `to_s` on all uri's passed into UnloadedAsset#new and URITar#new. This shouldn't be a performance penalty most of the time as `to_s` returns the original string.