### PR TITLE
[close #115] Support Windows filesystem

### DIFF
--- a/lib/sprockets/uri_tar.rb
+++ b/lib/sprockets/uri_tar.rb
@@ -35,6 +35,15 @@ module Sprockets
       scheme + compressed_path
     end
 
+    # Internal: Tells us if we are using an absolute path
+    #
+    # Nix* systems start with a `/` like /Users/schneems.
+    # Windows systems start with a drive letter than colon and slash
+    # like C:/Schneems.
+    def absolute_path?
+      path.start_with?("/".freeze) || path =~ /\A[a-zA-Z]:\// # windows
+    end
+
     # Internal: Convert a "compressed" uri to an absolute path
     #
     # If a uri is inside of the environment's root it will not
@@ -48,7 +57,7 @@ module Sprockets
     #
     # Returns String
     def expand
-      if path.start_with?("/".freeze)
+      if absolute_path?
         # Stored path was absolute, don't add root
         scheme + path
       else
@@ -67,7 +76,14 @@ module Sprockets
     #
     # Returns String
     def compressed_path
-      if compressed_path = @env.split_subpath(root, path)
+      # windows
+      if !@root.start_with?("/".freeze) && path.start_with?("/".freeze)
+        consistent_root = "/".freeze + @root
+      else
+        consistent_root = @root
+      end
+
+      if compressed_path = @env.split_subpath(consistent_root, path)
         compressed_path
       else
         path

--- a/test/test_uri_tar.rb
+++ b/test/test_uri_tar.rb
@@ -1,0 +1,34 @@
+require 'sprockets_test'
+
+class TestURITar < Sprockets::TestCase
+  test "works with windows" do
+    fake_env = Class.new do
+      include Sprockets::PathUtils
+      attr_accessor :root
+    end.new
+
+    uri = "C:/Sites/sprockets/test/fixtures/paths/application.css?type=text/css"
+    fake_env.root = "C:/Different/path"
+    tar = Sprockets::URITar.new(uri, fake_env)
+    assert_equal uri, tar.expand
+    assert_equal uri, tar.compress
+    assert_equal uri, tar.compressed_path
+
+    uri = "file:///C:/Sites/sprockets/test/fixtures/paths/application.css?type=text/css"
+    fake_env.root = "C:/Sites/sprockets"
+    tar = Sprockets::URITar.new(uri, fake_env)
+    assert_equal uri, tar.expand
+    assert_equal Sprockets::URITar.new(tar.expand, fake_env).expand, tar.expand
+    assert_equal "test/fixtures/paths/application.css?type=text/css", tar.compressed_path
+    assert_equal "file://test/fixtures/paths/application.css?type=text/css", tar.compress
+    assert_equal Sprockets::URITar.new(tar.compress, fake_env).compress, tar.compress
+    assert_equal Sprockets::URITar.new(tar.expand, fake_env).compress, tar.compress
+
+    uri = "C:/Sites/sprockets/test/fixtures/paths/application.css?type=text/css"
+    fake_env.root = "C:/Sites/sprockets"
+    tar = Sprockets::URITar.new(uri, fake_env)
+    assert_equal uri, tar.expand
+    assert_equal "test/fixtures/paths/application.css?type=text/css", tar.compressed_path
+    assert_equal "test/fixtures/paths/application.css?type=text/css", tar.compress
+  end
+end


### PR DESCRIPTION
Windows uses a filesystem that starts with a drive letter than a colon and a slash. This is different from *nix systems that only start with a slash. Previous releases 3.3.{1,2,3} didn't take this into consideration.

Targeted at 4.x

To support windows we have to make sure we can correctly expand both kinds of paths. Previously we were checking if a path started with a slash to indicate it was already an absolute path and that we don't need to prepend the root to it. Now we also check for a drive letter + colon + slash. I added tests for windows style paths and this works for compressing them. The downside is that someone could create a folder in their app root called `C:` and this code would incorrectly think that the path was absolute and not expand it. I would assume this would happen in an EXTREME minority of cases, but when it does happen it will be very frustrating to find and fix. We could explicitly check for when you're on a windows machine using `Gem.win_platform?` but I don't know how accurate this code is, and it would make running tests on *nix platforms difficult.

In addition to expanding uris, we also have to support compressing them. The root object we get from windows will not contain a beginning slash, it will be something like `C:/Path/to/root`. Unfortunately the path code we've written will produce paths with beginning slashes. If the path starts with a slash we must make sure the root starts with a slash. If we don't  then when we try to get a compressed path from `file:///C:/Projects/Rails/app/assets/javascripts/application.js` which has a path of `/C:/Projects/Rails/app/assets/javascripts/application.js` it will not correctly compare with it's root which is `C:/Projects/Rails/`.  I'm pretty sure this doesn't impact *nix systems as their root will always begin with a slash.

Added tests for the new behavior.