### PR TITLE
Portable absolute path detection

### DIFF
--- a/lib/sprockets/uri_tar.rb
+++ b/lib/sprockets/uri_tar.rb
@@ -1,3 +1,5 @@
+require 'sprockets/path_utils'
+
 module Sprockets
  # Internal: used to "expand" and "compress" values for storage
   class URITar
@@ -41,7 +43,7 @@ module Sprockets
     # Windows systems start with a drive letter than colon and slash
     # like C:/Schneems.
     def absolute_path?
-      path.start_with?("/".freeze) || path =~ /\A[a-zA-Z]:\// # windows
+      PathUtils.absolute_path?(path)
     end
 
     # Internal: Convert a "compressed" uri to an absolute path
@@ -83,7 +85,7 @@ module Sprockets
         consistent_root = @root
       end
 
-      if compressed_path = @env.split_subpath(consistent_root, path)
+      if compressed_path = PathUtils.split_subpath(consistent_root, path)
         compressed_path
       else
         path

--- a/test/test_uri_tar.rb
+++ b/test/test_uri_tar.rb
@@ -1,32 +1,63 @@
 require 'sprockets_test'
 
 class TestURITar < Sprockets::TestCase
-  test "works with windows" do
-    fake_env = Class.new do
+
+  def setup
+    @fake_env = Class.new do
       include Sprockets::PathUtils
       attr_accessor :root
     end.new
+  end
+
+  test "works with nix" do
+    uri = "/Sites/sprockets/test/fixtures/paths/application.css?type=text/css"
+    @fake_env.root = "/Different/path"
+    tar = Sprockets::URITar.new(uri, @fake_env)
+    assert_equal uri, tar.expand
+    assert_equal uri, tar.compress
+    assert_equal uri, tar.compressed_path
+
+    uri = "file:///Sites/sprockets/test/fixtures/paths/application.css?type=text/css"
+    @fake_env.root = "/Sites/sprockets"
+    tar = Sprockets::URITar.new(uri, @fake_env)
+    assert_equal uri, tar.expand
+    assert_equal Sprockets::URITar.new(tar.expand, @fake_env).expand, tar.expand
+    assert_equal "test/fixtures/paths/application.css?type=text/css", tar.compressed_path
+    assert_equal "file://test/fixtures/paths/application.css?type=text/css", tar.compress
+    assert_equal Sprockets::URITar.new(tar.compress, @fake_env).compress, tar.compress
+    assert_equal Sprockets::URITar.new(tar.expand, @fake_env).compress, tar.compress
+
+    uri = "/Sites/sprockets/test/fixtures/paths/application.css?type=text/css"
+    @fake_env.root = "/Sites/sprockets"
+    tar = Sprockets::URITar.new(uri, @fake_env)
+    assert_equal uri, tar.expand
+    assert_equal "test/fixtures/paths/application.css?type=text/css", tar.compressed_path
+    assert_equal "test/fixtures/paths/application.css?type=text/css", tar.compress
+  end
+
+  test "works with windows" do
+    skip "Only runs on windows" unless File::ALT_SEPARATOR
 
     uri = "C:/Sites/sprockets/test/fixtures/paths/application.css?type=text/css"
-    fake_env.root = "C:/Different/path"
-    tar = Sprockets::URITar.new(uri, fake_env)
+    @fake_env.root = "C:/Different/path"
+    tar = Sprockets::URITar.new(uri, @fake_env)
     assert_equal uri, tar.expand
     assert_equal uri, tar.compress
     assert_equal uri, tar.compressed_path
 
     uri = "file:///C:/Sites/sprockets/test/fixtures/paths/application.css?type=text/css"
-    fake_env.root = "C:/Sites/sprockets"
-    tar = Sprockets::URITar.new(uri, fake_env)
+    @fake_env.root = "C:/Sites/sprockets"
+    tar = Sprockets::URITar.new(uri, @fake_env)
     assert_equal uri, tar.expand
-    assert_equal Sprockets::URITar.new(tar.expand, fake_env).expand, tar.expand
+    assert_equal Sprockets::URITar.new(tar.expand, @fake_env).expand, tar.expand
     assert_equal "test/fixtures/paths/application.css?type=text/css", tar.compressed_path
     assert_equal "file://test/fixtures/paths/application.css?type=text/css", tar.compress
-    assert_equal Sprockets::URITar.new(tar.compress, fake_env).compress, tar.compress
-    assert_equal Sprockets::URITar.new(tar.expand, fake_env).compress, tar.compress
+    assert_equal Sprockets::URITar.new(tar.compress, @fake_env).compress, tar.compress
+    assert_equal Sprockets::URITar.new(tar.expand, @fake_env).compress, tar.compress
 
     uri = "C:/Sites/sprockets/test/fixtures/paths/application.css?type=text/css"
-    fake_env.root = "C:/Sites/sprockets"
-    tar = Sprockets::URITar.new(uri, fake_env)
+    @fake_env.root = "C:/Sites/sprockets"
+    tar = Sprockets::URITar.new(uri, @fake_env)
     assert_equal uri, tar.expand
     assert_equal "test/fixtures/paths/application.css?type=text/css", tar.compressed_path
     assert_equal "test/fixtures/paths/application.css?type=text/css", tar.compress


### PR DESCRIPTION
Instead of hardcoding windows and *nix to work on the same system we can use `PathUtils#absolute_path?` which is portable and optimized. This means that the windows tests won't run on *nix.

This will eliminate the possibility that someone names a folder `c:` on a *nix system and the whole thing blows up. 

CC @fxn @pixeltrix @sikachu