### PR TITLE
Always return absolute path from expanded urls

### DIFF
--- a/lib/sprockets/uri_tar.rb
+++ b/lib/sprockets/uri_tar.rb
@@ -63,8 +63,13 @@ module Sprockets
         # Stored path was absolute, don't add root
         scheme + path
       else
-        # Stored path was relative, add root
-        scheme + File.join(root, path)
+        if scheme.empty?
+          File.join(root, path)
+        else
+          # We always want to return an absolute uri,
+          # make sure the path starts with a slash.
+          scheme + File.join("/".freeze, root, path)
+        end
       end
     end
 


### PR DESCRIPTION
Previously uris expanded on unix relied on the root to always begin with a slash `/` since the root on windows does not begin with a slash i.e. `C:/File/path` when we built the "expanded" uri it would only have two slashes like `file://C:/File/path` instead of `file:///C:File/path`. We can fix this by always ensuring that the root is joined with a beginning slash while building URIs that contain schemes. By using `File.join` we ensure that we don't get too many slashes when using non-windows i.e. unix like systems.

Previously failing test for this behavior was added to the target branch in: https://github.com/rails/sprockets/commit/7e5beaa38e00232baab77bcab352badedd0d1246

cc @daniel-rikowski