### PR TITLE
Backport fixes from TannerRogalsky/sprockets-es6 regarding modules integration

### DIFF
--- a/lib/sprockets/babel_processor.rb
+++ b/lib/sprockets/babel_processor.rb
@@ -34,11 +34,19 @@ module Sprockets
       data = input[:data]
 
       result = input[:cache].fetch(@cache_key + [data]) do
-        Autoload::Babel::Transpiler.transform(data, @options.merge(
+        opts = {
           'sourceRoot' => input[:load_path],
+          'moduleRoot' => nil,
           'filename' => input[:filename],
           'filenameRelative' => PathUtils.split_subpath(input[:load_path], input[:filename])
-        ))
+        }.merge(@options)
+
+        if opts['moduleIds'] && opts['moduleRoot']
+          opts['moduleId'] ||= File.join(opts['moduleRoot'], input[:name])
+        elsif opts['moduleIds']
+          opts['moduleId'] ||= input[:name]
+        end
+        Autoload::Babel::Transpiler.transform(data, opts)
       end
 
       map = SourceMapUtils.decode_json_source_map(JSON.generate(result['map']))

--- a/test/test_babel_processor.rb
+++ b/test/test_babel_processor.rb
@@ -80,7 +80,7 @@ define(["exports", "foo"], function (exports, _foo) {});
 
     assert js = Sprockets::BabelProcessor.new('modules' => 'amd', 'moduleIds' => true).call(input)[:data]
     assert_equal <<-JS.chomp, js.strip
-define("#{File.expand_path("../fixtures/mod", __FILE__)}", ["exports", "foo"], function (exports, _foo) {});
+define("mod", ["exports", "foo"], function (exports, _foo) {});
     JS
   end
 
@@ -117,7 +117,7 @@ System.register(["foo"], function (_export) {
 
     assert js = Sprockets::BabelProcessor.new('modules' => 'system', 'moduleIds' => true).call(input)[:data]
     assert_equal <<-JS.chomp, js.strip
-System.register("#{File.expand_path("../fixtures/mod", __FILE__)}", ["foo"], function (_export) {
+System.register("mod", ["foo"], function (_export) {
   return {
     setters: [function (_foo) {}],
     execute: function () {}


### PR DESCRIPTION
These fixes are necessary to emit the proper `moduleId` option for Babel to generate modules with application relative modules by default or with the `moduleRoot` option prepended when given - related with TannerRogalsky/sprockets-es6#10, TannerRogalsky/sprockets-es6#4 and other PRs on the sprockets-es6 repository.

/cc @rafaelfranca @fnando 