### PR TITLE
prevent expanded paths from getting into the history cache

### DIFF
--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -308,8 +308,10 @@ module Sprockets
 
         history = cache.get(key) || []
         history.each_with_index do |deps, index|
-          deps.map! { |path| path.start_with?("file-digest://") ? expand_from_root(path) : path }
-          if asset = yield(deps)
+          expanded_deps = deps.map do |path|
+            path.start_with?("file-digest://") ? expand_from_root(path) : path
+          end
+          if asset = yield(expanded_deps)
             cache.set(key, history.rotate!(index)) if index > 0
             return asset
           end


### PR DESCRIPTION
This patch addresses #127 by avoiding expanding the history entries in-place.

I verified that this change fixed the problem with my deploys.