### PR TITLE
Allow rack 1.0.0

### DIFF
--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.files = Dir["README.md", "CHANGELOG.md", "LICENSE", "lib/**/*.rb"]
   s.executables = ["sprockets"]
 
-  s.add_dependency "rack", "> 1", "< 3"
+  s.add_dependency "rack", ">= 1", "< 3"
 
   s.add_development_dependency "babel-transpiler", "~> 0.6"
   s.add_development_dependency "closure-compiler", "~> 1.1"


### PR DESCRIPTION
@rafaelfranca [recently updated the rack dependency to allow any version between 1 and 3](https://github.com/rails/sprockets/commit/6de1049bd2ff8562f0cc523fba3d48935e8e8ee8) but accidentally disallowed rack 1.0.0. If—for whatever reason—a project is locked to rack 1.0.0, they will now be able to use latest sprockets release.