### PR TITLE
Fix that cached index aliases break when Sprockets root changes

### DIFF
--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -101,7 +101,13 @@ module Sprockets
           raise FileNotFound, "could not find file: #{unloaded.filename}"
         end
 
-        path_to_split = unloaded.params[:index_alias] || unloaded.filename
+        path_to_split =
+          if index_alias = unloaded.params[:index_alias]
+            expand_from_root index_alias
+          else
+            unloaded.filename
+          end
+
         load_path, logical_path = paths_split(config[:paths], path_to_split)
 
         unless load_path

--- a/lib/sprockets/resolve.rb
+++ b/lib/sprockets/resolve.rb
@@ -242,7 +242,9 @@ module Sprockets
         end
 
         candidates.map! do |c|
-          { filename: c[0], type: c[1], index_alias: c[0].gsub(/\/index(\.[^\/]+)$/, '\1') }
+          { filename: c[0],
+            type: c[1],
+            index_alias: compress_from_root(c[0].sub(/\/index(\.[^\/]+)$/, '\1')) }
         end
 
         return candidates, [ URIUtils.build_file_digest_uri(dirname) ]

--- a/test/test_resolve.rb
+++ b/test/test_resolve.rb
@@ -26,17 +26,17 @@ class TestResolve < Sprockets::TestCase
 
     assert_equal "file://#{fixture_path('index-assets/bar/index.js')}?type=application/javascript",
       resolve("bar/index.js")
-    assert_equal "file://#{fixture_path('index-assets/bar/index.js')}?type=application/javascript&index_alias=#{fixture_path('index-assets/bar.js')}",
+    assert_equal "file://#{fixture_path('index-assets/bar/index.js')}?type=application/javascript&index_alias=#{@env.compress_from_root(fixture_path('index-assets/bar.js'))}",
       resolve("bar.js")
 
     assert_equal "file://#{fixture_path('index-assets/index/foo/index.js')}?type=application/javascript",
       resolve("index/foo/index.js")
-    assert_equal "file://#{fixture_path('index-assets/index/foo/index.js')}?type=application/javascript&index_alias=#{fixture_path('index-assets/index/foo.js')}",
+    assert_equal "file://#{fixture_path('index-assets/index/foo/index.js')}?type=application/javascript&index_alias=#{@env.compress_from_root(fixture_path('index-assets/index/foo.js'))}",
       resolve("index/foo.js")
 
     assert_equal "file://#{fixture_path('index-assets/baz/index.js.erb')}?type=application/javascript",
       resolve("baz/index.js")
-    assert_equal "file://#{fixture_path('index-assets/baz/index.js.erb')}?type=application/javascript&index_alias=#{fixture_path('index-assets/baz.js.erb')}",
+    assert_equal "file://#{fixture_path('index-assets/baz/index.js.erb')}?type=application/javascript&index_alias=#{@env.compress_from_root(fixture_path('index-assets/baz.js.erb'))}",
       resolve("baz.js")
   end
 


### PR DESCRIPTION
Index aliases were stored as absolute paths in an asset's URI params, so they escaped the compress/uncompress dance in the loader.

Compress the alias path as soon as it's resolved instead. No need to stash it as an absolute path then parse it out and recompress it in the loader. Expand it when loading from the cache.

Fixes #139 