### PR TITLE
Sprockets now correctly handles HEAD requests

### DIFF
--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -272,6 +272,11 @@ class TestServer < Sprockets::TestCase
   test "bad fingerprint digest returns a 404" do
     get "/assets/application-0000000000000000000000000000000000000000.js"
     assert_equal 404, last_response.status
+
+    head "/assets/application-0000000000000000000000000000000000000000.js"
+    assert_equal 404, last_response.status
+    assert_equal "0", last_response.headers['Content-Length']
+    assert_equal "", last_response.body
   end
 
   test "missing source" do
@@ -318,6 +323,11 @@ class TestServer < Sprockets::TestCase
 
     get "/assets/.-0000000./etc/passwd"
     assert_equal 403, last_response.status
+
+    head "/assets/.-0000000./etc/passwd"
+    assert_equal 403, last_response.status
+    assert_equal "0", last_response.headers['Content-Length']
+    assert_equal "", last_response.body
   end
 
   test "add new source to tree" do
@@ -351,6 +361,12 @@ class TestServer < Sprockets::TestCase
   test "disallow non-get methods" do
     get "/assets/foo.js"
     assert_equal 200, last_response.status
+
+    head "/assets/foo.js"
+    assert_equal 200, last_response.status
+    assert_equal "application/javascript", last_response.headers['Content-Type']
+    assert_equal "0", last_response.headers['Content-Length']
+    assert_equal "", last_response.body
 
     post "/assets/foo.js"
     assert_equal 405, last_response.status


### PR DESCRIPTION
This PR adds the ability for the Sprockets server to handle HEAD requests for assets. The use case for me, specifically, is local testing of SVG assets served to Internet Explorer >= 9 (including 11 and possibly Edge). Before displaying SVG natively, IE does a HEAD request of the asset to check the content type.

I also added tests which are passing. The code isn't as clean as I'd like it to be but as it's only used for development purposes I'm fine with it. For HEAD requests, the content length header is reset to "0" and the body is discarded.

This will fix #63.

I cherry-picked this commit from a branch that was created from the current master but as Rails 4.2.x only works with Sprockets < 4.0 I needed to back-port it to the 3.x branch. Just fyi, this commit also works with the current master, I can also open a PR against that if you want me to.