### PR TITLE
Fix bug in PathUtils::entries when dir is empty

### DIFF
--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -55,9 +55,12 @@ module Sprockets
     # Returns an empty `Array` if the directory does not exist.
     def entries(path)
       if File.directory?(path)
-        Dir.entries(path, encoding: Encoding.default_internal).reject! { |entry|
+        entries = Dir.entries(path, encoding: Encoding.default_internal)
+        entries.reject! { |entry|
           entry =~ /^\.|~$|^\#.*\#$/
-        }.sort!
+        }
+        entries.sort!
+        entries
       else
         []
       end

--- a/test/test_path_utils.rb
+++ b/test/test_path_utils.rb
@@ -43,6 +43,12 @@ class TestPathUtils < MiniTest::Test
       "source-maps",
       "symlink"
     ], entries(File.expand_path("../fixtures", __FILE__))
+    
+    [ ['a', 'b'], ['a', 'b', '.', '..'] ].each do |dir_contents|
+      Dir.stub :entries, dir_contents do
+        assert_equal ['a', 'b'], entries(Dir.tmpdir)
+      end
+    end
 
     assert_equal [], entries("/tmp/sprockets/missingdir")
   end


### PR DESCRIPTION
When working on a Rails app I ran into the following exception from sprockets:

```
undefined method `sort!' for nil:NilClass | lib/gems.jar!/gems/sprockets-3.3.5/lib/sprockets/path_utils.rb:58:in `entries'|
```

On investigation it seems that the `PathUtils::entries` method is performing an `Array#reject!`, which returns `nil` for an empty array. This is a rare case because `Dir.entries` never (I think) returns an empty array on MRI . However, it apparently does on JRuby, and might on other platforms.

Apparently, the `reject!` was introduced as a small performance improvement in a6bf1f97236283e89769f6af59f3b48a297b738b. This PR fixes the bug by reverting to `reject` instead again.

EDIT

To clarify, `Array#reject!` returns `nil` whenever the regex has no matches, so an empty directory is technically just a specific version of this edge case.