### PR TITLE
Sprockets now correctly handles HEAD requests (II)

### DIFF
--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -23,7 +23,7 @@ module Sprockets
       start_time = Time.now.to_f
       time_elapsed = lambda { ((Time.now.to_f - start_time) * 1000).to_i }
 
-      if env['REQUEST_METHOD'] != 'GET'
+      if !['GET', 'HEAD'].include?(env['REQUEST_METHOD'])
         return method_not_allowed_response
       end
 
@@ -39,7 +39,7 @@ module Sprockets
 
       # URLs containing a `".."` are rejected for security reasons.
       if forbidden_request?(path)
-        return forbidden_response
+        return forbidden_response(env)
       end
 
       if fingerprint
@@ -67,7 +67,7 @@ module Sprockets
         status = :ok
       end
 
-      case status
+      rack_response = case status
       when :ok
         logger.info "#{msg} 200 OK (#{time_elapsed.call}ms)"
         ok_response(asset, env)
@@ -80,6 +80,14 @@ module Sprockets
       when :precondition_failed
         logger.info "#{msg} 412 Precondition Failed (#{time_elapsed.call}ms)"
         precondition_failed_response
+      end
+
+      if env['REQUEST_METHOD'] == 'HEAD'
+        response_status, response_headers, _ = rack_response
+        response_headers["Content-Length"] = "0" unless response_headers.nil?
+        [response_status, response_headers, []]
+      else
+        rack_response
       end
     rescue Exception => e
       logger.error "Error compiling asset #{path}:"
@@ -110,7 +118,11 @@ module Sprockets
 
       # Returns a 200 OK response tuple
       def ok_response(asset, env)
-        [ 200, headers(env, asset, asset.length), asset ]
+        if env['REQUEST_METHOD'] == 'HEAD'
+          [ 200, headers(env, asset, 0), [] ]
+        else
+          [ 200, headers(env, asset, asset.length), asset ]
+        end
       end
 
       # Returns a 304 Not Modified response tuple
@@ -119,8 +131,12 @@ module Sprockets
       end
 
       # Returns a 403 Forbidden response tuple
-      def forbidden_response
-        [ 403, { "Content-Type" => "text/plain", "Content-Length" => "9" }, [ "Forbidden" ] ]
+      def forbidden_response(env)
+        if env['REQUEST_METHOD'] == 'HEAD'
+          [ 403, { "Content-Type" => "text/plain", "Content-Length" => "0" }, [] ]
+        else
+          [ 403, { "Content-Type" => "text/plain", "Content-Length" => "9" }, [ "Forbidden" ] ]
+        end
       end
 
       # Returns a 404 Not Found response tuple

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -224,6 +224,11 @@ class TestServer < Sprockets::TestCase
   test "bad fingerprint digest returns a 404" do
     get "/assets/application-0000000000000000000000000000000000000000.js"
     assert_equal 404, last_response.status
+
+    head "/assets/application-0000000000000000000000000000000000000000.js"
+    assert_equal 404, last_response.status
+    assert_equal "0", last_response.headers['Content-Length']
+    assert_equal "", last_response.body
   end
 
   test "missing source" do
@@ -270,6 +275,11 @@ class TestServer < Sprockets::TestCase
 
     get "/assets/.-0000000./etc/passwd"
     assert_equal 403, last_response.status
+
+    head "/assets/.-0000000./etc/passwd"
+    assert_equal 403, last_response.status
+    assert_equal "0", last_response.headers['Content-Length']
+    assert_equal "", last_response.body
   end
 
   test "add new source to tree" do
@@ -303,6 +313,12 @@ class TestServer < Sprockets::TestCase
   test "disallow non-get methods" do
     get "/assets/foo.js"
     assert_equal 200, last_response.status
+
+    head "/assets/foo.js"
+    assert_equal 200, last_response.status
+    assert_equal "application/javascript", last_response.headers['Content-Type']
+    assert_equal "0", last_response.headers['Content-Length']
+    assert_equal "", last_response.body
 
     post "/assets/foo.js"
     assert_equal 405, last_response.status


### PR DESCRIPTION
_This was originally from #152 which had the wrong target branch_

This PR adds the ability for the Sprockets server to handle HEAD requests for assets. The use case for me, specifically, is local testing of SVG assets served to Internet Explorer >= 9 (including 11 and possibly Edge). Before displaying SVG natively, IE does a HEAD request of the asset to check the content type.

I also added tests which are passing. The code isn't as clean as I'd like it to be but as it's only used for development purposes I'm fine with it. For HEAD requests, the content length header is reset to "0" and the body is discarded.

This will fix #63.