### PR TITLE
Fix bug in PathUtils::entries when dir is empty

### DIFF
--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -55,9 +55,11 @@ module Sprockets
     # Returns an empty `Array` if the directory does not exist.
     def entries(path)
       if File.directory?(path)
-        Dir.entries(path, :encoding => Encoding.default_internal).reject! { |entry|
+        entries = Dir.entries(path, :encoding => Encoding.default_internal)
+        entries.reject! { |entry|
           entry =~ /^\.|~$|^\#.*\#$/
-        }.sort!
+        }
+        entries.sort!
       else
         []
       end

--- a/test/test_path_utils.rb
+++ b/test/test_path_utils.rb
@@ -44,6 +44,12 @@ class TestPathUtils < MiniTest::Test
       "symlink"
     ], entries(File.expand_path("../fixtures", __FILE__))
 
+    [ ['a', 'b'], ['a', 'b', '.', '..'] ].each do |dir_contents|
+      Dir.stub :entries, dir_contents do
+        assert_equal ['a', 'b'], entries(Dir.tmpdir)
+      end
+    end
+
     assert_equal [], entries("/tmp/sprockets/missingdir")
   end
 


### PR DESCRIPTION
Fix for the same issue as in #153, but now for the 3.x branch. Summary of the bug: `PathUtils::entries` uses `Array#reject!` with a regex which may return nil in some cases (e.g. when the result of `Dir.entries` does not contain `.` or `..` as elements).