### PR TITLE
Remove message not to disclose full path in the browser.

### DIFF
--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -89,11 +89,11 @@ module Sprockets
       when ".js"
         # Re-throw JavaScript asset exceptions to the browser
         logger.info "#{msg} 500 Internal Server Error\n\n"
-        return javascript_exception_response(e)
+        return javascript_exception_response
       when ".css"
         # Display CSS asset exceptions in the browser
         logger.info "#{msg} 500 Internal Server Error\n\n"
-        return css_exception_response(e)
+        return css_exception_response
       else
         raise
       end
@@ -136,65 +136,12 @@ module Sprockets
         [ 412, { "Content-Type" => "text/plain", "Content-Length" => "19", "X-Cascade" => "pass" }, [ "Precondition Failed" ] ]
       end
 
-      # Returns a JavaScript response that re-throws a Ruby exception
-      # in the browser
-      def javascript_exception_response(exception)
-        err  = "#{exception.class.name}"
-        body = "throw Error(#{err.inspect})"
-        [ 500, { "Content-Type" => "application/javascript", "Content-Length" => body.bytesize.to_s }, [ body ] ]
+      def javascript_exception_response
+        [ 500, { "Content-Type" => "application/javascript", "Content-Length" => "21" }, [ "Internal Server Error" ] ]
       end
 
-      # Returns a CSS response that hides all elements on the page and
-      # displays the exception
-      def css_exception_response(exception)
-        message   = "\n#{exception.class.name}: #{exception.message}"
-        backtrace = "\n  #{exception.backtrace.first}"
-
-        body = <<-CSS
-          html {
-            padding: 18px 36px;
-          }
-
-          head {
-            display: block;
-          }
-
-          body {
-            margin: 0;
-            padding: 0;
-          }
-
-          body > * {
-            display: none !important;
-          }
-
-          head:after, body:before, body:after {
-            display: block !important;
-          }
-
-          head:after {
-            font-family: sans-serif;
-            font-size: large;
-            font-weight: bold;
-            content: "Error compiling CSS asset";
-          }
-
-          body:before, body:after {
-            font-family: monospace;
-            white-space: pre-wrap;
-          }
-
-          body:before {
-            font-weight: bold;
-            content: "#{escape_css_content(message)}";
-          }
-
-          body:after {
-            content: "#{escape_css_content(backtrace)}";
-          }
-        CSS
-
-        [ 500, { "Content-Type" => "text/css;charset=utf-8", "Content-Length" => body.bytesize.to_s }, [ body ] ]
+      def css_exception_response
+        [ 500, { "Content-Type" => "text/css;charset=utf-8", "Content-Length" => "21" }, [ "Internal Server Error" ] ]
       end
 
       # Escape special characters for use inside a CSS content("...") string

--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -139,9 +139,9 @@ module Sprockets
       # Returns a JavaScript response that re-throws a Ruby exception
       # in the browser
       def javascript_exception_response(exception)
-        err  = "#{exception.class.name}: #{exception.message}\n  (in #{exception.backtrace[0]})"
+        err  = "#{exception.class.name}"
         body = "throw Error(#{err.inspect})"
-        [ 200, { "Content-Type" => "application/javascript", "Content-Length" => body.bytesize.to_s }, [ body ] ]
+        [ 500, { "Content-Type" => "application/javascript", "Content-Length" => body.bytesize.to_s }, [ body ] ]
       end
 
       # Returns a CSS response that hides all elements on the page and
@@ -194,7 +194,7 @@ module Sprockets
           }
         CSS
 
-        [ 200, { "Content-Type" => "text/css; charset=utf-8", "Content-Length" => body.bytesize.to_s }, [ body ] ]
+        [ 500, { "Content-Type" => "text/css;charset=utf-8", "Content-Length" => body.bytesize.to_s }, [ body ] ]
       end
 
       # Escape special characters for use inside a CSS content("...") string

--- a/test/test_coffee_script_processor.rb
+++ b/test/test_coffee_script_processor.rb
@@ -13,7 +13,7 @@ class TestCoffeeScriptProcessor < MiniTest::Test
     }
     result = Sprockets::CoffeeScriptProcessor.call(input)
     assert result[:data].match(/var square/)
-    assert_equal 19, result[:map].size
+    assert_equal 13, result[:map].size
     assert_equal [], result[:map].map { |m| m[:source] }.uniq.compact
   end
 

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -234,13 +234,13 @@ class TestServer < Sprockets::TestCase
 
   test "re-throw JS exceptions in the browser" do
     get "/assets/missing_require.js"
-    assert_equal 200, last_response.status
-    assert_equal "throw Error(\"Sprockets::FileNotFound: couldn't find file 'notfound' with type 'application/javascript'\\n  (in #{fixture_path("server/vendor/javascripts/missing_require.js")}:1)\")", last_response.body
+    assert_equal 500, last_response.status
+    assert_equal "throw Error(\"Sprockets::FileNotFound\")", last_response.body
   end
 
   test "display CSS exceptions in the browser" do
     get "/assets/missing_require.css"
-    assert_equal 200, last_response.status
+    assert_equal 500, last_response.status
     assert_match %r{content: ".*?Sprockets::FileNotFound}, last_response.body
   end
 

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -235,13 +235,13 @@ class TestServer < Sprockets::TestCase
   test "re-throw JS exceptions in the browser" do
     get "/assets/missing_require.js"
     assert_equal 500, last_response.status
-    assert_equal "throw Error(\"Sprockets::FileNotFound\")", last_response.body
+    assert_equal "Internal Server Error", last_response.body
   end
 
   test "display CSS exceptions in the browser" do
     get "/assets/missing_require.css"
     assert_equal 500, last_response.status
-    assert_match %r{content: ".*?Sprockets::FileNotFound}, last_response.body
+    assert_equal "Internal Server Error", last_response.body
   end
 
   test "serve encoded utf-8 filename" do


### PR DESCRIPTION
When displayed file path in the browser, it might be happened directly traversal. 
The concern I mentioned is disclosing server side path can be found the file path by hacker (ex. /usr/local/xxx/xxx/.) it provide the hint to access directory/file.
So I will send this pull request not to display file path. 

And the response code should not be 200 since actually it's not OK. Logger also put message as Internal Server Error. So I will request also to change from 200 to 500 when Ruby has exception by loading Javascript/CSS.
Please confirm my pull request. Best Regards,
