### PR TITLE
[ci skip] First draft of guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ gem 'sprockets', '~> 3.0'
 
 ## Behavior
 
+Sprockets is a Ruby library for compiling and serving web assets.
+It features declarative dependency management for JavaScript and CSS
+assets, as well as a preprocessor pipeline that allows you to
+write assets in languages like CoffeeScript, Sass and SCSS.
+
+## Using sprockets
+
+For most people interested in using sprockets you will want to see [End User Asset Generation](guides/end_user_asset_generation.md) guide. This contains information about sprocket's directive syntax, and default processing behavior.
+
+If you are a framework developer that is using sprockets, see [Building an Asset Processing Framework](guides/building_an_asset_processing_framework.md).
+
+If you are a library developer who is extending the functionality of sprockets, see [Extending Sprockets](guides/extending_sprockets.md).
+
+Below is a disjointed mix of documentation for all three of these roles. Eventually they will be moved to an appropriate guide, for now the recommended way to consume documentation is to view the appropriate guide first and then supplement with docs from the README.
+
 ### Index files are proxies for folders
 
 In sprockets index files such as `index.js` or `index.css` files inside of a folder will generate a file with the folder's name. So if you have a `foo/index.js` file it will compile down to `foo.js`. This is similar to NPM's behavior of using [folders as modules](https://nodejs.org/api/modules.html#modules_folders_as_modules). It is also somewhat similar to the way that a file in `public/my_folder/index.html` can be reached by a request to `/my_folder`. This means that you cannot directly use an index file. For example this would not work:

--- a/README.md
+++ b/README.md
@@ -20,13 +20,6 @@ Or include it in your project's `Gemfile` with Bundler:
 gem 'sprockets', '~> 3.0'
 ```
 
-## Behavior
-
-Sprockets is a Ruby library for compiling and serving web assets.
-It features declarative dependency management for JavaScript and CSS
-assets, as well as a preprocessor pipeline that allows you to
-write assets in languages like CoffeeScript, Sass and SCSS.
-
 ## Using sprockets
 
 For most people interested in using sprockets you will want to see [End User Asset Generation](guides/end_user_asset_generation.md) guide. This contains information about sprocket's directive syntax, and default processing behavior.
@@ -36,6 +29,8 @@ If you are a framework developer that is using sprockets, see [Building an Asset
 If you are a library developer who is extending the functionality of sprockets, see [Extending Sprockets](guides/extending_sprockets.md).
 
 Below is a disjointed mix of documentation for all three of these roles. Eventually they will be moved to an appropriate guide, for now the recommended way to consume documentation is to view the appropriate guide first and then supplement with docs from the README.
+
+## Behavior
 
 ### Index files are proxies for folders
 

--- a/guides/building_an_asset_processing_framework.md
+++ b/guides/building_an_asset_processing_framework.md
@@ -1,0 +1,9 @@
+# Building an Asset Processing Framework
+
+This guide is for using a Sprockets::Environment to process assets. You would use this class directly if you were building a feature similar to Rail's asset pipeline. If you aren't building an asset processing frameworks, you will want to refer to the [End User Asset Generation](end_user_asset_generation.md) guide instead. For a reference use of `Sprockets::Environemnt` see [sprockets-rails](github.com/rails/sprockets-rails).
+
+## WIP
+
+This guide is a work in progress. There are many different groups of people who interact with sprockets. Some only need to know directive syntax to put in their asset files, some are building features like the Rails asset pipeline, and some are plugging into sprockets and writing things like preprocessors. The goal of these guides are to provide task specific guidance to make the expected behavior explicit. If you are using sprockets and you find missing information in these guides, please consider submitting a pull request with updated information.
+
+These guides live in [guides](/guides).

--- a/guides/end_user_asset_generation.md
+++ b/guides/end_user_asset_generation.md
@@ -1,0 +1,184 @@
+# End User Asset Generation
+
+This guide is for those using sprockets through an interface similar to the Rails asset pipeline. It will talk about end user interfaces. If you are not the end user, but intstead a tools developer who is building an asset processing framework, see [building an asset processing framework](building_an_asset_processing_framework.md).
+
+## What is Sprockets?
+
+Sprockets is a Ruby library for compiling and serving web assets.
+It features declarative dependency management for JavaScript and CSS
+assets, as well as a preprocessor pipeline that allows you to
+write assets in languages like CoffeeScript, Sass and SCSS.
+
+## Behavior Overview
+
+You can interact through sprockets primarially through directives and file extensions. This section covers how to use each of these things, and the defaults that ship with sprockets.
+
+Since you are likely using sprockets through another framework (like the Rails asset pipeline), there will configuration options you can toggle that will change behavior such as what directories or files get compiled. For that documentation you should see your framework's documentation.
+
+### Directives
+
+Directives are special comments in your asset file and the main way of interacting with processors. What kind of interactions? You can use these directives to tell sprockets to load other files, or specify dependencies on other assets.
+
+For example, let's say you have custom javascript that you've written. You put this javascript in a file called `beta.js`. The javascript makes heavy use of jQuery, so you need to load that before your code executes. You could add this directive to the top of `beta.js`:
+
+```js
+//= require jquery
+
+$().ready({
+  // my custom code here
+})
+```
+
+The directive processor understands comment blocks in three formats:
+
+``` css
+/* Multi-line comment blocks (CSS, SCSS, JavaScript)
+ *= require foo
+ */
+```
+
+``` js
+// Single-line comment blocks (SCSS, JavaScript)
+//= require foo
+```
+
+``` coffee
+# Single-line comment blocks (CoffeeScript)
+#= require foo
+```
+
+Here is a list of the available directives
+
+- require
+- require_self
+- require_tree
+- require_directory
+- depend
+- depend_on_asset
+- stub
+- link
+- link_directory
+- link_tree
+
+You can see what each of these does below
+
+### Specifying Processors through File Extensions
+
+Sprockets uses the filename extensions to determine what processors to run on your file and in what order. For example if you have a file:
+
+```
+application.scss
+```
+
+Then sprockets will by default run the sass processor (which implements scss). The output file will be converted to css.
+
+You can specify multiple processors by specifying multiple file extensions. For example you can use Ruby's [ERB template language](http://ruby-doc.org/stdlib-2.2.3/libdoc/erb/rdoc/ERB.html) to embed content in your doc before running the sass processor. To accomplish this you would need to name your file
+
+```
+application.scss.erb
+```
+
+Processors are run from right to left, so in the above example the processor associated with `erb` will be run before the processor associated with `scss` extension.
+
+For a description of the processors that sprockets has by default see the "default processors" section below. Other libraries may register additional processors.
+
+## File Order Processing
+
+By default files are processed in alphabetical order. This behavior can impact your asset compilation when one asset needs to be loaded before another.
+
+For example if you have an `application.js` and it loads another directory
+
+```js
+//= require_directory my_javascript
+```
+
+The files in that directory will be loaded in alphabetical order. If the directory looks like this:
+
+```sh
+$ ls -1 my_javascript/
+
+alpha.js
+beta.js
+jquery.js
+```
+
+Then `alpha.js` will be loaded before either of the other two. This can be a problem if `alpha.js` uses jquery. For this reason it is not recommend to use `require_directory` with files that are ordering dependent. You can either require individual files manually:
+
+```
+//= require jquery
+//= require alpha
+//= require beta
+```
+
+Or you can use index files to proxy your folders
+
+### Index files are proxies for folders
+
+In sprockets index files such as `index.js` or `index.css` files inside of a folder will generate a file with the folder's name. So if you have a `foo/index.js` file it will compile down to `foo.js`. This is similar to NPM's behavior of using [folders as modules](https://nodejs.org/api/modules.html#modules_folders_as_modules). It is also somewhat similar to the way that a file in `public/my_folder/index.html` can be reached by a request to `/my_folder`. This means that you cannot directly use an index file. For example this would not work:
+
+```
+<%= asset_path("foo/index.js") %>
+```
+
+Instead you would need to use:
+
+```
+<%= asset_path("foo.js") %>
+```
+
+Why would you want to use this behavior?  It is common behavior where you might want to include an entire directory of files in a top level javascript. You can do this in sprockets using `require_tree .`
+
+```
+//= require_tree .
+```
+
+This has the problem that files are required alphabetically. If your directory has `jquery-ui.js` and `jquery.min.js` then sprockets will require `jquery-ui.js` before `jquery` is required which won't work (because jquery-ui depends on jquery). Previously the only way to get the correct ordering would be to rename your files, something like `0-jquery-ui.js`. Instead of doing that you can use an index file.
+
+For example, if you have an `application.js` and want all the files in the `foo/` folder you could do this:
+
+```
+//= require foo.js
+```
+
+Then create a file `foo/index.js` that requires all the files in that folder in any order you want:
+
+```
+//= require foo.min.js
+//= require foo-ui.js
+```
+
+Now in your `application.js` will correctly load the `foo.min.js` before `foo-ui.js`. If you used `require_tree` it would not work correctly.
+
+
+## Default Directives
+
+TODO: add description of each of the directives
+
+## Default Processors
+
+
+TODO: add description of each of the processors
+
+## Default Compressors
+
+TODO:
+
+## Output
+
+This section details the default output of sprockets. This may have been modified by the frameworks you're using, so you will want to verify behavior with their docs.
+
+Processors and compressors will affect individual file output contents. Refer to the default processors and compressor ection how processors for your asset may have modifed your file.
+
+### Manifest File
+
+TODO: Explain contents, location, and name of a manifest file.
+
+### Fingerprinting
+
+TODO: Explain default fingerprinting/digest behavior
+
+## WIP
+
+This guide is a work in progress. There are many different groups of people who interact with sprockets. Some only need to know directive syntax to put in their asset files, some are building features like the Rails asset pipeline, and some are plugging into sprockets and writing things like preprocessors. The goal of these guides are to provide task specific guidance to make the expected behavior explicit. If you are using sprockets and you find missing information in these guides, please consider submitting a pull request with updated information.
+
+These guides live in [guides](/guides).

--- a/guides/extending_sprockets.md
+++ b/guides/extending_sprockets.md
@@ -1,0 +1,9 @@
+# Extending Sprockets
+
+Sprockets can use custom processors, compressors, and directives. This document is intended for library authors who want to extend sprockets functionality.
+
+## WIP
+
+This guide is a work in progress. There are many different groups of people who interact with sprockets. Some only need to know directive syntax to put in their asset files, some are building features like the Rails asset pipeline, and some are plugging into sprockets and writing things like preprocessors. The goal of these guides are to provide task specific guidance to make the expected behavior explicit. If you are using sprockets and you find missing information in these guides, please consider submitting a pull request with updated information.
+
+These guides live in [guides](/guides).


### PR DESCRIPTION
There are 3 types of people who will want to interact with sprockets, asset processing framework developers, library developers who want to extend sprockets, and end users who will create and modify assets that get compiled using sprockets. The current documentation is all in the README or at the method level. The README does not make a distinction between these roles, so it makes determining what docs are applicable to your specific task. For that purpose I plan on splitting up documentation into different roles, and publishing these in the `guides/` directory.