### PR TITLE
Use Future#wait! to ensure concurrent compile exceptions are re-raised

### DIFF
--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -208,7 +208,7 @@ module Sprockets
       end
       concurrent_writers.each(&:wait)
       concurrent_compressors.each(&:wait)
-      Concurrent::Future.execute { self.save }.wait
+      save
 
       filenames
     end

--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -202,12 +202,12 @@ module Sprockets
           logger.debug "Skipping #{target}.gz, already exists"
         else
           logger.info "Writing #{target}.gz"
-          concurrent_compressors << Concurrent::Future.execute { write_file.wait; gzip.compress(target) }
+          concurrent_compressors << Concurrent::Future.execute { write_file.wait!; gzip.compress(target) }
         end
 
       end
-      concurrent_writers.each(&:wait)
-      concurrent_compressors.each(&:wait)
+      concurrent_writers.each(&:wait!)
+      concurrent_compressors.each(&:wait!)
       save
 
       filenames

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -657,4 +657,11 @@ class TestManifest < Sprockets::TestCase
       refute File.exist?("#{@dir}/#{original_path}.gz"), "Expecting '#{original_path}' to not generate gzipped file: '#{original_path}.gz' but it did"
     end
   end
+
+  test 'raises exception when gzip fails' do
+    manifest = Sprockets::Manifest.new(@env, @dir)
+    Zlib::GzipWriter.stub(:new, -> { fail 'kaboom' }) do
+      assert_raises('kaboom') { manifest.compile('application.js') }
+    end
+  end
 end


### PR DESCRIPTION
Writing and gzipping assets may fail while being performed in the background using Concurrent::Future. Using `wait` on these futures will silently ignore any such failures. To ensure concurrent exceptions are properly raised, use `wait!` instead of `wait`.

Based on the discussion here: https://github.com/rails/sprockets/pull/193#issuecomment-161821436

/cc @schneems 