### PR TITLE
Asset#mtime was deprecated and not the correct value

### DIFF
--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -202,7 +202,10 @@ module Sprockets
           logger.debug "Skipping #{target}.gz, already exists"
         else
           logger.info "Writing #{target}.gz"
-          concurrent_compressors << Concurrent::Future.execute { write_file.wait!; gzip.compress(target) }
+          concurrent_compressors << Concurrent::Future.execute do
+            write_file.wait!
+            gzip.compress(target)
+          end
         end
 
       end

--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -203,7 +203,7 @@ module Sprockets
         else
           logger.info "Writing #{target}.gz"
           concurrent_compressors << Concurrent::Future.execute do
-            write_file.wait!
+            write_file.wait! if write_file
             gzip.compress(target)
           end
         end

--- a/lib/sprockets/utils/gzip.rb
+++ b/lib/sprockets/utils/gzip.rb
@@ -4,7 +4,6 @@ module Sprockets
       # Private: Generates a gzipped file based off of reference file.
       def initialize(asset)
         @content_type  = asset.content_type
-        @mtime         = asset.mtime
         @source        = asset.source
         @charset       = asset.charset
       end
@@ -42,11 +41,14 @@ module Sprockets
       #
       # Returns nothing.
       def compress(target)
+        mtime = PathUtils.stat(target).mtime
         PathUtils.atomic_write("#{target}.gz") do |f|
           gz = Zlib::GzipWriter.new(f, Zlib::BEST_COMPRESSION)
-          gz.mtime = @mtime.to_i
+          gz.mtime = mtime
           gz.write(@source)
           gz.close
+
+          File.utime(mtime, mtime, f.path)
         end
 
         nil

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -636,6 +636,7 @@ class TestManifest < Sprockets::TestCase
       original_path = @env[file_name].digest_path
       manifest.compile(file_name)
       assert File.exist?("#{@dir}/#{original_path}.gz"), "Expecting '#{original_path}' to generate gzipped file: '#{original_path}.gz' but it did not"
+      assert_equal File.stat("#{@dir}/#{original_path}").mtime, Zlib::GzipReader.open("#{@dir}/#{original_path}.gz") {|gz| gz.mtime }
     end
   end
 

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -640,6 +640,26 @@ class TestManifest < Sprockets::TestCase
     end
   end
 
+
+  test "writes gzip files even if files were already on disk" do
+    @env.gzip = false
+    manifest = Sprockets::Manifest.new(@env, @dir)
+    files = %W{ gallery.css application.js logo.svg }
+    files.each do |file_name|
+      original_path = @env[file_name].digest_path
+      manifest.compile(file_name)
+      assert File.exist?("#{@dir}/#{original_path}"), "Expecting \"#{@dir}/#{original_path}\" to exist but did not"
+    end
+
+    @env.gzip = true
+    files.each do |file_name|
+      original_path = @env[file_name].digest_path
+      manifest.compile(file_name)
+      assert File.exist?("#{@dir}/#{original_path}.gz"), "Expecting '#{original_path}' to generate gzipped file: '#{original_path}.gz' but it did not"
+      assert_equal File.stat("#{@dir}/#{original_path}").mtime, Zlib::GzipReader.open("#{@dir}/#{original_path}.gz") {|gz| gz.mtime }
+    end
+  end
+
   test "disable file gzip" do
     @env.gzip = false
     manifest = Sprockets::Manifest.new(@env, @dir)


### PR DESCRIPTION
This change pulls mtime from the environment stat cache instead of relying on the asset object. Reference: https://github.com/rails/sprockets/commit/16ccffc72b619b2b211b7fcf9a749ea0a23405b3#commitcomment-14779288