### PR TITLE
Make gzip option inheritable

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -32,7 +32,8 @@ module Sprockets
     registered_transformers: [].freeze,
     root: __dir__.dup.freeze,
     transformers: Hash.new { |h, k| {}.freeze }.freeze,
-    version: ""
+    version: "",
+    gzip_enabled: true
   }.freeze
 
   @context_class = Context

--- a/lib/sprockets/compressing.rb
+++ b/lib/sprockets/compressing.rb
@@ -51,21 +51,6 @@ module Sprockets
       end
     end
 
-    def gzip?
-      return @gzip if defined?(@gzip)
-      true
-    end
-
-    def skip_gzip?
-      !gzip?
-    end
-
-    # Enable or disable the creation of gzip files,
-    # on by default.
-    def gzip=(gzip)
-      @gzip = gzip
-    end
-
     # Assign a compressor to run on `application/javascript` assets.
     #
     # The compressor object must respond to `compress`.
@@ -84,6 +69,26 @@ module Sprockets
       end
 
       register_bundle_processor 'application/javascript', klass
+    end
+
+    # Public: Checks if Gzip is enabled.
+    def gzip?
+      config[:gzip_enabled]
+    end
+
+    # Public: Checks if Gzip is disabled.
+    def skip_gzip?
+      !gzip?
+    end
+
+    # Public: Enable or disable the creation of Gzip files.
+    #
+    # Defaults to true.
+    #
+    #     environment.gzip = false
+    #
+    def gzip=(gzip)
+      self.config = config.merge(gzip_enabled: gzip).freeze
     end
   end
 end

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -502,6 +502,10 @@ class TestEnvironment < Sprockets::TestCase
     @env.append_path(fixture_path('asset'))
   end
 
+  test "default gzip" do
+    assert_equal true, @env.gzip?
+  end
+
   test "change jst template namespace" do
     @env.register_transformer 'application/javascript+function', 'application/javascript', Sprockets::JstProcessor.new(namespace: 'this.JST2')
     assert asset = @env["hello.js"]
@@ -750,12 +754,23 @@ class TestCached < Sprockets::TestCase
     Sprockets::Environment.new(".") do |env|
       env.append_path(fixture_path('default'))
       env.cache = {}
+      env.gzip = false
       yield env if block_given?
     end.cached
   end
 
   def setup
     @env = new_environment
+  end
+
+  test "inherit the gzip option" do
+    assert_equal false, @env.gzip?
+  end
+
+  test "does not allow to change the gzip option" do
+    assert_raises RuntimeError do
+      @env.gzip = true
+    end
   end
 
   test "does not allow new mime types to be added" do


### PR DESCRIPTION
Right now gzip configuration is not inheritable what means that if we set it to `false` it doesn't work in the sprockets-rails workflow that is to use a `CachedEnvironment` based in the default environment. With this commit we use the already existent infrastructure to configurations what make it work as expected.

cc @schneems 