### PR TITLE
Fix source_map_concat

### DIFF
--- a/lib/sprockets/source_map_utils.rb
+++ b/lib/sprockets/source_map_utils.rb
@@ -22,7 +22,13 @@ module Sprockets
       a ||= []
       b ||= []
       mappings = a.dup
-      offset   = a.any? ? a.last[:generated][0]+1 : 0
+
+      if a.any?
+        offset = a.last[:generated][0]
+      else
+        offset = 0
+      end
+
       b.each do |m|
         mappings << m.merge(generated: [m[:generated][0] + offset, m[:generated][1]])
       end

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -1098,7 +1098,7 @@ class DebugAssetTest < Sprockets::TestCase
   end
 
   test "digest path" do
-    assert_equal "application.debug-818d2228e758fba767c9d621ff7911063206065db55f2df026d657899466b48e.js",
+    assert_equal "application.debug-46d615bec0c09c68732fbca4bdb9b80022dd40692c54e351612dadbfdc832182.js",
       @asset.digest_path
   end
 
@@ -1115,7 +1115,7 @@ class DebugAssetTest < Sprockets::TestCase
   end
 
   test "to_s" do
-    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\nvar Users = {\n  find: function(id) {\n  }\n};\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n\n//# sourceMappingURL=application.js-7e76cc32f67cc6307711e7a92e1c5ad9214a4b9ad1b0faf9eedeca95e962da28.map", @asset.to_s
+    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\nvar Users = {\n  find: function(id) {\n  }\n};\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n\n//# sourceMappingURL=application.js-7531f14ecc0a864b8746f377f1411f2e513543b870c9277679c28800dc2f3809.map", @asset.to_s
   end
 
   def asset(logical_path, options = {})

--- a/test/test_source_map_utils.rb
+++ b/test/test_source_map_utils.rb
@@ -98,36 +98,44 @@ class TestSourceMapUtils < MiniTest::Test
     assert_equal expected, actual
   end
 
+  def test_concat_empty_source_map_returns_original
+    abc_mappings = [
+      { source: 'a.js', generated: [rand(1..100), rand(0..100)], original: [rand(1..100), rand(0..100)] },
+      { source: 'b.js', generated: [rand(1..100), rand(0..100)], original: [rand(1..100), rand(0..100)] },
+      { source: 'c.js', generated: [rand(1..100), rand(0..100)], original: [rand(1..100), rand(0..100)] }
+    ].freeze
+
+    assert_equal abc_mappings, Sprockets::SourceMapUtils.concat_source_maps(nil, abc_mappings)
+    assert_equal abc_mappings, Sprockets::SourceMapUtils.concat_source_maps(abc_mappings, nil)
+
+    assert_equal abc_mappings, Sprockets::SourceMapUtils.concat_source_maps([], abc_mappings)
+    assert_equal abc_mappings, Sprockets::SourceMapUtils.concat_source_maps(abc_mappings, [])
+  end
+
   def test_concat_source_maps
-    mappings = [
-      { source: 'a.js', generated: [0, 0], original: [0,  0] },
-      { source: 'b.js', generated: [1, 0], original: [20, 0] },
-      { source: 'c.js', generated: [2, 0], original: [30, 0] }
-    ].freeze
-
-    assert_equal mappings, Sprockets::SourceMapUtils.concat_source_maps(nil, mappings)
-    assert_equal mappings, Sprockets::SourceMapUtils.concat_source_maps(mappings, nil)
-
-    assert_equal mappings, Sprockets::SourceMapUtils.concat_source_maps([], mappings)
-    assert_equal mappings, Sprockets::SourceMapUtils.concat_source_maps(mappings, [])
-
-    mappings2 = [
-      { source: 'd.js', generated: [0, 0], original: [0, 0] }
-    ].freeze
-
-    assert_equal [
-      { source: 'a.js', generated: [0, 0], original: [0,  0] },
-      { source: 'b.js', generated: [1, 0], original: [20, 0] },
-      { source: 'c.js', generated: [2, 0], original: [30, 0] },
-      { source: 'd.js', generated: [3, 0], original: [0,  0] }
-    ], Sprockets::SourceMapUtils.concat_source_maps(mappings, mappings2)
-
-    assert_equal [
-      { source: 'd.js', generated: [0, 0], original: [0,  0] },
-      { source: 'a.js', generated: [1, 0], original: [0,  0] },
+    abc_mappings = [
+      { source: 'a.js', generated: [1, 0], original: [1,  0] },
       { source: 'b.js', generated: [2, 0], original: [20, 0] },
       { source: 'c.js', generated: [3, 0], original: [30, 0] }
-    ], Sprockets::SourceMapUtils.concat_source_maps(mappings2, mappings)
+    ].freeze
+
+    d_mapping = [
+      { source: 'd.js', generated: [1, 0], original: [1, 0] }
+    ].freeze
+
+    assert_equal [
+      { source: 'a.js', generated: [1, 0], original: [1,  0] },
+      { source: 'b.js', generated: [2, 0], original: [20, 0] },
+      { source: 'c.js', generated: [3, 0], original: [30, 0] },
+      { source: 'd.js', generated: [4, 0], original: [1,  0] }
+    ], Sprockets::SourceMapUtils.concat_source_maps(abc_mappings, d_mapping)
+
+    assert_equal [
+      { source: 'd.js', generated: [1, 0], original: [1,  0] },
+      { source: 'a.js', generated: [2, 0], original: [1,  0] },
+      { source: 'b.js', generated: [3, 0], original: [20, 0] },
+      { source: 'c.js', generated: [4, 0], original: [30, 0] }
+    ], Sprockets::SourceMapUtils.concat_source_maps(d_mapping, abc_mappings)
   end
 
   def test_combine_source_maps


### PR DESCRIPTION
Line numbers and columns are stored in an array so it is `[<line number>, <column>]`.

Source map line numbers can never be 0, so we should always start with 1. When we concat this source map:

```
[
  { source: 'a.js', generated: [1, 0], original: [1,  0] },
  { source: 'b.js', generated: [2, 0], original: [20, 0] },
  { source: 'c.js', generated: [3, 0], original: [30, 0] }
]
```

With this one:

```
{ source: 'd.js', generated: [1, 0], original: [1, 0] }
```

We would expect that since `d.js` generates onto the first line when compiled by itself, it would go onto the next free line when concatenated with the first free line above. So the result should be:

```
[
  { source: 'a.js', generated: [1, 0], original: [1,  0] },
  { source: 'b.js', generated: [2, 0], original: [20, 0] },
  { source: 'c.js', generated: [3, 0], original: [30, 0] },
  { source: 'd.js', generated: [4, 0], original: [1,  0] }
]
```

The original test was invalid since it used 0 as a starting line number. To make this test pass we don't want to increment the offset by + 1 otherwise we would have `d.js` be on the 5th line instead of the 4th line since it already effectively has an offset line number of 1 (remember 0 is impossible).

The modified hashes in the `test_asset.rb` file is due to the different contents of source maps. I didn't verify these hashes or the results of their source maps were correct, not sure of a good way to do that ¯\_(ツ)_/¯

cc/ @rafaelfranca 
