### PR TITLE
Ughhhhhhhhhhhhhhhhhhhhhh source maps

### DIFF
--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -156,7 +156,7 @@ module Sprockets
             metadata: {
               dependencies: dependencies,
               map: [
-                {source: source_path, generated: [0, 0], original: [0, 0]}
+                {source: source_path, generated: [1, 0], original: [1, 0]}
               ]
             }
           })

--- a/lib/sprockets/source_map_utils.rb
+++ b/lib/sprockets/source_map_utils.rb
@@ -56,9 +56,13 @@ module Sprockets
     def combine_source_maps(original_map, second_map)
       original_map ||= []
       return second_map.dup if original_map.empty?
+      if original_map.size == 1
+        map    = original_map.first
+        source = map[:source]
+        return second_map if map[:generated] == DEFAULT_MAP_VALUE &&  map[:original] == DEFAULT_MAP_VALUE && second_map.all? {|m| m[:source] == source }
+      end
 
       new_map = []
-
       second_map.each do |m|
         original_line = bsearch_mappings(original_map, m[:original])
         next unless original_line
@@ -67,6 +71,7 @@ module Sprockets
 
       new_map
     end
+    DEFAULT_MAP_VALUE = [1, 0]
 
     # Public: Compare two source map offsets.
     #

--- a/test/fixtures/source-maps/bar.js
+++ b/test/fixtures/source-maps/bar.js
@@ -1,0 +1,1 @@
+var bar = "bar";

--- a/test/fixtures/source-maps/foo-bar.js
+++ b/test/fixtures/source-maps/foo-bar.js
@@ -1,0 +1,2 @@
+//= require foo
+//= require bar

--- a/test/fixtures/source-maps/foo.js
+++ b/test/fixtures/source-maps/foo.js
@@ -1,0 +1,1 @@
+var foo = "foo";

--- a/test/test_source_map_utils.rb
+++ b/test/test_source_map_utils.rb
@@ -223,6 +223,21 @@ class TestSourceMapUtils < MiniTest::Test
       Sprockets::SourceMapUtils.encode_vlq_mappings(combined_mappings)
   end
 
+  def test_combine_source_maps_skips_default
+    first_mapping = [
+      { :source => "index.coffee", :generated => [1,  0], :original => [1,  0]},
+    ]
+    second_mapping = [
+      { :source => "index.coffee", :generated => [1,  1], :original => [1,  0]},
+      { :source => "index.coffee", :generated => [1, 12], :original => [1,  0]},
+      { :source => "index.coffee", :generated => [1, 15], :original => [1,  0]},
+      { :source => "index.coffee", :generated => [1, 20], :original => [1,  0]},
+    ]
+
+    combined_mappings = Sprockets::SourceMapUtils.combine_source_maps(first_mapping, second_mapping)
+    assert_equal second_mapping, combined_mappings
+  end
+
   def test_compare_offsets
     assert_equal( 0,  Sprockets::SourceMapUtils.compare_source_offsets([1, 5], [1, 5]))
     assert_equal(-1,  Sprockets::SourceMapUtils.compare_source_offsets([1, 5], [2, 0]))

--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -15,6 +15,108 @@ class TestSourceMaps < Sprockets::TestCase
     asset = @env['child.js']
     map = asset.metadata[:map]
     assert_equal ['child.source-1fa5b1a0f53ee03f5b38d4c5b2346d338916e58b0656d6c37f84bd4c742e49c1.js'], map.map { |m| m[:source] }.uniq.compact
+
+    assert_equal [1, 0], map.first[:generated]
+    assert_equal [1, 0], map.first[:original]
+  end
+
+  test "simple source map" do
+    asset = @env['foo-bar.js']
+    map   = asset.metadata[:map]
+
+    expected = "var foo = \"foo\";\nvar bar = \"bar\";\n\n\n"
+    assert_equal expected, asset.source
+
+    foo_source_path     = "foo.source-98f4654ce1a9f7268ad1980896e0e20d1e6b95cca53c85e002feeb20eb3a8008.js"
+    bar_source_path     = "bar.source-fcb2768a2b823ae765d81566d477d6a5c20772b68c391a8a7f7456abcf9e6fc5.js"
+    foo_bar_source_path = "foo-bar.source-adf044b5009a8b37cda4ea2ebb72578512e0319aae337adca62f86c8861342b1.js"
+
+    expected = [foo_source_path, bar_source_path, foo_bar_source_path]
+    actual   = map.map { |m| m[:source] }.uniq.compact
+    assert_equal expected, actual
+
+    expected = [
+      {
+        :source    => foo_source_path,
+        :generated => [1, 0],
+        :original  => [1, 0]
+      },
+      {
+        :source => bar_source_path,
+        :generated => [2, 0],
+        :original  => [1, 0]
+      },
+      {
+        :source    => foo_bar_source_path,
+        :generated => [3, 0],
+        :original  => [1, 0]
+      }
+    ]
+    assert_equal expected, map
+  end
+
+  test "coffee" do
+    expected = [
+      {:source=>
+         "project.source-8c5bc45531c819bca8f1ff1667663276a6a95b02668d2483933f877bf8385e1c.coffee",
+       :generated => [1, 0],
+       :original  => [1, 0]},
+      {:source =>
+        "project.source-8c5bc45531c819bca8f1ff1667663276a6a95b02668d2483933f877bf8385e1c.coffee",
+       :generated => [2, 0],
+       :original  => [1, 0]},
+      {:source =>
+        "project.source-8c5bc45531c819bca8f1ff1667663276a6a95b02668d2483933f877bf8385e1c.coffee",
+       :generated => [2, 6],
+       :original  => [1, 0]},
+      {:source =>
+        "project.source-8c5bc45531c819bca8f1ff1667663276a6a95b02668d2483933f877bf8385e1c.coffee",
+       :generated => [4, 2],
+       :original  => [1, 0]},
+      {:source =>
+        "project.source-8c5bc45531c819bca8f1ff1667663276a6a95b02668d2483933f877bf8385e1c.coffee",
+       :generated => [4, 9],
+       :original  => [1, 0]},
+      {:source =>
+        "project.source-8c5bc45531c819bca8f1ff1667663276a6a95b02668d2483933f877bf8385e1c.coffee",
+       :generated => [4, 12],
+       :original  => [2,  2]},
+      {:source =>
+        "project.source-8c5bc45531c819bca8f1ff1667663276a6a95b02668d2483933f877bf8385e1c.coffee",
+       :generated => [5, 4],
+       :original  => [2, 2]},
+      {:source =>
+        "project.source-8c5bc45531c819bca8f1ff1667663276a6a95b02668d2483933f877bf8385e1c.coffee",
+       :generated => [5, 8],
+       :original  => [2, 2]},
+      {:source =>
+        "project.source-8c5bc45531c819bca8f1ff1667663276a6a95b02668d2483933f877bf8385e1c.coffee",
+       :generated => [5, 10],
+       :original  => [2,  8]},
+      {:source =>
+        "project.source-8c5bc45531c819bca8f1ff1667663276a6a95b02668d2483933f877bf8385e1c.coffee",
+       :generated => [5, 19],
+       :original  => [2,  9]},
+      {:source =>
+        "project.source-8c5bc45531c819bca8f1ff1667663276a6a95b02668d2483933f877bf8385e1c.coffee",
+       :generated => [5, 21],
+       :original  => [2,  8]},
+      {:source =>
+        "project.source-8c5bc45531c819bca8f1ff1667663276a6a95b02668d2483933f877bf8385e1c.coffee",
+       :generated => [5, 24],
+       :original  => [2,  8]},
+      {:source =>
+        "project.source-8c5bc45531c819bca8f1ff1667663276a6a95b02668d2483933f877bf8385e1c.coffee",
+       :generated => [5, 25],
+       :original  => [2,  2]},
+      {:source =>
+        "project.source-8c5bc45531c819bca8f1ff1667663276a6a95b02668d2483933f877bf8385e1c.coffee",
+       :generated => [7, 0],
+       :original  => [1, 0]}
+    ]
+    asset = @env['project.js']
+    map   = asset.metadata[:map]
+    assert_equal expected, map
   end
 
   test "builds a concatenated source map" do


### PR DESCRIPTION
Change the default value of source maps to `[1, 0]` since since `[0, 0]` is an invalid line number.

Unfortunately even with this value it will sort circuit `combine_source_maps` method which is used when building coffee script source maps and sass source maps. I fixed this issue by adding a default value check. I'm not 100% sure it's the right thing to fix things. 

Another potential fix is to not call this method inside of the `coffee_script_processor` here https://github.com/rails/sprockets/blob/030b7ccdea92b756aab1b8d3620cc7991d98090d/lib/sprockets/coffee_script_processor.rb#L27 and the sass processor as well. I need to investigate all of the use cases of these processors to see if that is a cleaner solution than special casing this inside of the source map utils.

Another possible solution would be as previously suggested in https://github.com/rails/sprockets/pull/203#issuecomment-166059314 to " replace [the default source map] with the actual source maps of the root file". This is kinda what the above solutions are doing for coffee and sass files, but falling short for non-compiled files like js and css. All in all, i'm not sure how to move forwards on that angle.

There's 4 failing tests that need to be updated, this is going to be a tough process since the values are not easily produced by another verifiable source. I'll see what I can do later.