### PR TITLE
Allow processor to be initialized with Sass config options that are passed to Sass engine initialization

### DIFF
--- a/lib/sprockets/sass_processor.rb
+++ b/lib/sprockets/sass_processor.rb
@@ -47,6 +47,7 @@ module Sprockets
       @cache_version = options[:cache_version]
       @cache_key = "#{self.class.name}:#{VERSION}:#{Autoload::Sass::VERSION}:#{@cache_version}".freeze
       @importer_class = options[:importer] || Sass::Importers::Filesystem
+      @sass_config = options[:sass_config] || {}
       @functions = Module.new do
         include Functions
         include options[:functions] if options[:functions]
@@ -57,7 +58,7 @@ module Sprockets
     def call(input)
       context = input[:environment].context_class.new(input)
 
-      options = {
+      engine_options = {
         filename: input[:filename],
         syntax: self.class.syntax,
         cache_store: build_cache_store(input, @cache_version),
@@ -68,9 +69,9 @@ module Sprockets
           environment: input[:environment],
           dependencies: context.metadata[:dependencies]
         }
-      }
+      }.merge!(@sass_config)
 
-      engine = Autoload::Sass::Engine.new(input[:data], options)
+      engine = Autoload::Sass::Engine.new(input[:data], engine_options)
 
       css, map = Utils.module_include(Autoload::Sass::Script::Functions, @functions) do
         engine.render_with_sourcemap('')

--- a/lib/sprockets/sassc_processor.rb
+++ b/lib/sprockets/sassc_processor.rb
@@ -7,6 +7,7 @@ module Sprockets
       @cache_version = options[:cache_version]
       @cache_key = "#{self.class.name}:#{VERSION}:#{Autoload::SassC::VERSION}:#{@cache_version}".freeze
       @importer_class = options[:importer]
+      @sass_config = options[:sass_config] || {}
       @functions = Module.new do
         include SassProcessor::Functions
         include options[:functions] if options[:functions]
@@ -50,7 +51,7 @@ module Sprockets
           environment: input[:environment],
           dependencies: context.metadata[:dependencies]
         }
-      }
+      }.merge!(@sass_config)
     end
   end
 


### PR DESCRIPTION
Required to fix rails/sass-rails#358.

I wasn't sure whether to add the same option to `SasscProcessor`, but can definitely to add it to this PR if you'd like!

/cc @rafaelfranca 