### PR TITLE
Remove unnecessary `matrix` definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ rvm:
 
 matrix:
   include:
-    test_isolated
-
-matrix:
-  include:
     - rvm: 2.2
       script: bundle exec rake test_isolated
 


### PR DESCRIPTION
`matrix` is defined twice and the previous one is ignored.