### PR TITLE
Remove duplicate "sprockets/loader" require

### DIFF
--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -11,7 +11,6 @@ require 'sprockets/path_utils'
 require 'sprockets/resolve'
 require 'sprockets/server'
 require 'sprockets/source_map_utils'
-require 'sprockets/loader'
 require 'sprockets/uri_tar'
 
 module Sprockets


### PR DESCRIPTION
Remove unnecessary `require 'sprockets/loader'`