### PR TITLE
3.x

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+test/fixtures/**/*.png binary
+test/fixtures/**/* eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,13 @@ matrix:
 
 notifications:
   email: false
+  irc:
+    on_success: change
+    on_failure: always
+    channels:
+      - "irc.freenode.org#rails-contrib"
+  campfire:
+    on_success: change
+    on_failure: always
+    rooms:
+      - secure: "bJyiK4EXGfm0EhAId/QqIEdhPCx8BjxUKvx1h0+wgrsUm8BDoEN7tg2wqoGWU2KfzqLdx77wZVQXbmksOgmNcMGKJed5uNNMpAG4B+AQYTEX0odFRgOZKdkMtypga9CNIkKVgeSKhd6BY+g2AV6wvJ0Jq056uXpGkqK5OEFOpQc="

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 **Master**
 
+**3.5.0** (December 3, 2015)
+
 * Reintroduce Gzip file generation for non-binary assets.
 
 **3.4.1** (November 25, 2015)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**3.3.5** (September 25, 2015)
+
+* Fix bug related to absolute path being reintroduced into history cache #141.
+
 **3.3.4** (September 1, 2015)
 
 * Relative cache contents now work with windows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**3.3.6** (October 5, 2015)
+
+* Expose method to override the sass cache in the SassProcessor.
+
 **3.3.5** (September 25, 2015)
 
 * Fix bug related to absolute path being reintroduced into history cache #141.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed static asset mtimes
 * Fix manifest cleanup by age
 * Removed redundant minifier level cache
+* Updated SRI format according to spec changes
 
 **3.0.3** (April 27, 2015)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**3.3.1** (August 15, 2015)
+
+* Fix legacy Tilt integration when locals is required argument.
+
 **3.3.0** (August 12, 2015)
 
 * Change internal cache lookup to use relative asset paths instead of absolute paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**3.2.0** (June 2, 2015)
+
+* Updated SRI integrity to align with spec changes
+* Deprecated Manifest integrity attribute
+
 **3.1.0** (May 10, 2015)
 
 * Removed "index" logical path normalization. Asset#logical_path is always the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 **Master**
 
+**3.5.1** (December 5, 2015)
+
+* Fix gzip asset generation for assets already on disk.
+
 **3.5.0** (December 3, 2015)
 
 * Reintroduce Gzip file generation for non-binary assets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-**3.3.6** (October 5, 2015)
+**3.4.0** (October 5, 2015)
 
 * Expose method to override the sass cache in the SassProcessor.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 **Master**
 
+**3.5.2** (December 8, 2015)
+
+* Fix JRuby bug with concurrent-ruby.
+* Fix disabling gzip generation in cached environments.
+
 **3.5.1** (December 5, 2015)
 
 * Fix gzip asset generation for assets already on disk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**3.3.3** (August 21, 2015)
+
+* Remove more absolute paths from cache contents.
+
 **3.3.2** (August 19, 2015)
 
 * Fix cache contents to use relative paths instead of absolute paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-**3.1.0**
+**3.1.0** (March 10, 2015)
 
 * Removed "index" logical path normalization. Asset#logical_path is always the
   full logical path to the index file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Updated SRI integrity to align with spec changes
 * Deprecated Manifest integrity attribute
+* Cleanup concatenating JS sources with newlines
 
 **3.1.0** (May 10, 2015)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**3.4.1** (November 25, 2015)
+
+* PathUtils::Entries will no longer error on an empty directory.
+
 **3.4.0** (October 5, 2015)
 
 * Expose method to override the sass cache in the SassProcessor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**3.3.4** (September 1, 2015)
+
+* Relative cache contents now work with windows.
+
 **3.3.3** (August 21, 2015)
 
 * Remove more absolute paths from cache contents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
+**3.3.2** (August 19, 2015)
+
+* Fix cache contents to use relative paths instead of absolute paths.
+
 **3.3.1** (August 15, 2015)
 
 * Fix legacy Tilt integration when locals is required argument.
 
 **3.3.0** (August 12, 2015)
 
-* Change internal cache lookup to use relative asset paths instead of absolute paths.
+* Change internal cache key to use relative asset paths instead of absolute paths.
 
 **3.2.0** (June 2, 2015)
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,44 @@ Or include it in your project's `Gemfile` with Bundler:
 gem 'sprockets', '~> 3.0'
 ```
 
+## Behavior
+
+### Index files are proxies for folders
+
+In sprockets index files such as `index.js` or `index.css` files inside of a folder will generate a file with the folder's name. So if you have a `foo/index.js` file it will compile down to `foo.js`. This is similar to NPM's behavior of using [folders as modules](https://nodejs.org/api/modules.html#modules_folders_as_modules). It is also somewhat similar to the way that a file in `public/my_folder/index.html` can be reached by a request to `/my_folder`. This means that you cannot directly use an index file. For example this would not work:
+
+```
+<%= asset_path("foo/index.js") %>
+```
+
+Instead you would need to use:
+
+```
+<%= asset_path("foo.js") %>
+```
+
+Why would you want to use this behavior?  It is common behavior where you might want to include an entire directory of files in a top level javascript. You can do this in sprockets using `require_tree .`
+
+```
+//= require_tree .
+```
+
+This has the problem that files are required alphabetically. If your directory has `jquery-ui.js` and `jquery.min.js` then sprockets will require `jquery-ui.js` before `jquery` is required which won't work (because jquery-ui depends on jquery). Previously the only way to get the correct ordering would be to rename your files, something like `0-jquery-ui.js`. Instead of doing that you can use an index file.
+
+For example, if you have an `application.js` and want all the files in the `foo/` folder you could do this:
+
+```
+//= require foo.js
+```
+
+Then create a file `foo/index.js` that requires all the files in that folder in any order you want:
+
+```
+//= require foo.min.js
+//= require foo-ui.js
+```
+
+Now in your `application.js` will correctly load the `foo.min.js` before `foo-ui.js`. If you used `require_tree` it would not work correctly.
 
 ## Understanding the Sprockets Environment
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require "rake/testtask"
+require "bundler/gem_tasks"
 
 task :default => :test
 

--- a/guides/end_user_asset_generation.md
+++ b/guides/end_user_asset_generation.md
@@ -1,6 +1,6 @@
 # End User Asset Generation
 
-This guide is for those using sprockets through an interface similar to the Rails asset pipeline. It will talk about end user interfaces. If you are not the end user, but intstead a tools developer who is building an asset processing framework, see [building an asset processing framework](building_an_asset_processing_framework.md).
+This guide is for those using Sprockets through an interface similar to the Rails asset pipeline. It will talk about end user interfaces. If you are not the end user, but instead a tools developer who is building an asset processing framework, see [building an asset processing framework](building_an_asset_processing_framework.md).
 
 ## What is Sprockets?
 
@@ -11,7 +11,7 @@ write assets in languages like CoffeeScript, Sass and SCSS.
 
 ## Behavior Overview
 
-You can interact through sprockets primarially through directives and file extensions. This section covers how to use each of these things, and the defaults that ship with sprockets.
+You can interact through sprockets primarily through directives and file extensions. This section covers how to use each of these things, and the defaults that ship with sprockets.
 
 Since you are likely using sprockets through another framework (like the Rails asset pipeline), there will configuration options you can toggle that will change behavior such as what directories or files get compiled. For that documentation you should see your framework's documentation.
 
@@ -19,7 +19,7 @@ Since you are likely using sprockets through another framework (like the Rails a
 
 Directives are special comments in your asset file and the main way of interacting with processors. What kind of interactions? You can use these directives to tell sprockets to load other files, or specify dependencies on other assets.
 
-For example, let's say you have custom javascript that you've written. You put this javascript in a file called `beta.js`. The javascript makes heavy use of jQuery, so you need to load that before your code executes. You could add this directive to the top of `beta.js`:
+For example, let's say you have custom JavaScript that you've written. You put this javascript in a file called `beta.js`. The javascript makes heavy use of jQuery, so you need to load that before your code executes. You could add this directive to the top of `beta.js`:
 
 ```js
 //= require jquery
@@ -126,7 +126,7 @@ Instead you would need to use:
 <%= asset_path("foo.js") %>
 ```
 
-Why would you want to use this behavior?  It is common behavior where you might want to include an entire directory of files in a top level javascript. You can do this in sprockets using `require_tree .`
+Why would you want to use this behavior?  It is common behavior where you might want to include an entire directory of files in a top level JavaScript. You can do this in sprockets using `require_tree .`
 
 ```
 //= require_tree .
@@ -167,7 +167,7 @@ TODO:
 
 This section details the default output of sprockets. This may have been modified by the frameworks you're using, so you will want to verify behavior with their docs.
 
-Processors and compressors will affect individual file output contents. Refer to the default processors and compressor ection how processors for your asset may have modifed your file.
+Processors and compressors will affect individual file output contents. Refer to the default processors and compressor section how processors for your asset may have modified your file.
 
 ### Manifest File
 

--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -33,7 +33,8 @@ module Sprockets
     registered_transformers: Hash.new { |h, k| {}.freeze }.freeze,
     root: File.expand_path('..', __FILE__).freeze,
     transformers: Hash.new { |h, k| {}.freeze }.freeze,
-    version: ""
+    version: "",
+    gzip_enabled: true
   }.freeze
   self.computed_config = {}
 

--- a/lib/sprockets/asset.rb
+++ b/lib/sprockets/asset.rb
@@ -19,7 +19,6 @@ module Sprockets
       @content_type = attributes[:content_type]
       @filename     = attributes[:filename]
       @id           = attributes[:id]
-      @integrity    = attributes[:integrity]
       @load_path    = attributes[:load_path]
       @logical_path = attributes[:logical_path]
       @metadata     = attributes[:metadata]
@@ -140,7 +139,9 @@ module Sprockets
     end
 
     # Public: A "named information" URL for subresource integrity.
-    attr_reader :integrity
+    def integrity
+      DigestUtils.integrity_uri(metadata[:digest])
+    end
 
     # Public: Add enumerator to allow `Asset` instances to be used as Rack
     # compatible body objects.

--- a/lib/sprockets/cache.rb
+++ b/lib/sprockets/cache.rb
@@ -60,7 +60,7 @@ module Sprockets
     # cache - A compatible backend cache store instance.
     def initialize(cache = nil, logger = self.class.default_logger)
       @cache_wrapper = get_cache_wrapper(cache)
-      @fetch_cache   = Cache::MemoryStore.new(4096)
+      @fetch_cache   = Cache::MemoryStore.new(1024)
       @logger        = logger
     end
 

--- a/lib/sprockets/closure_compressor.rb
+++ b/lib/sprockets/closure_compressor.rb
@@ -1,4 +1,5 @@
 require 'sprockets/autoload'
+require 'sprockets/digest_utils'
 
 module Sprockets
   # Public: Closure Compiler minifier.
@@ -35,13 +36,7 @@ module Sprockets
 
     def initialize(options = {})
       @compiler = Autoload::Closure::Compiler.new(options)
-      @cache_key = [
-        self.class.name,
-        Autoload::Closure::VERSION,
-        Autoload::Closure::COMPILER_VERSION,
-        VERSION,
-        options
-      ].freeze
+      @cache_key = "#{self.class.name}:#{Autoload::Closure::VERSION}:#{Autoload::Closure::COMPILER_VERSION}:#{VERSION}:#{DigestUtils.digest(options)}".freeze
     end
 
     def call(input)

--- a/lib/sprockets/coffee_script_processor.rb
+++ b/lib/sprockets/coffee_script_processor.rb
@@ -12,12 +12,12 @@ module Sprockets
     VERSION = '1'
 
     def self.cache_key
-      @cache_key ||= [name, Autoload::CoffeeScript::Source.version, VERSION].freeze
+      @cache_key ||= "#{name}:#{Autoload::CoffeeScript::Source.version}:#{VERSION}".freeze
     end
 
     def self.call(input)
       data = input[:data]
-      input[:cache].fetch(self.cache_key + [data]) do
+      input[:cache].fetch([self.cache_key, data]) do
         Autoload::CoffeeScript.compile(data)
       end
     end

--- a/lib/sprockets/compressing.rb
+++ b/lib/sprockets/compressing.rb
@@ -51,21 +51,6 @@ module Sprockets
       end
     end
 
-    def gzip?
-      return @gzip if defined?(@gzip)
-      true
-    end
-
-    def skip_gzip?
-      !gzip?
-    end
-
-    # Enable or disable the creation of gzip files,
-    # on by default.
-    def gzip=(gzip)
-      @gzip = gzip
-    end
-
     # Assign a compressor to run on `application/javascript` assets.
     #
     # The compressor object must respond to `compress`.
@@ -84,6 +69,26 @@ module Sprockets
       end
 
       register_bundle_processor 'application/javascript', klass
+    end
+
+    # Public: Checks if Gzip is enabled.
+    def gzip?
+      config[:gzip_enabled]
+    end
+
+    # Public: Checks if Gzip is disabled.
+    def skip_gzip?
+      !gzip?
+    end
+
+    # Public: Enable or disable the creation of Gzip files.
+    #
+    # Defaults to true.
+    #
+    #     environment.gzip = false
+    #
+    def gzip=(gzip)
+      self.config = config.merge(gzip_enabled: gzip).freeze
     end
   end
 end

--- a/lib/sprockets/digest_utils.rb
+++ b/lib/sprockets/digest_utils.rb
@@ -96,6 +96,15 @@ module Sprockets
       bin.unpack('H*').first
     end
 
+    # Internal: Unpack a hex encoded digest string into binary bytes.
+    #
+    # hex - String hex
+    #
+    # Returns binary String.
+    def unpack_hexdigest(hex)
+      [hex].pack('H*')
+    end
+
     # Internal: Pack a binary digest to a base64 encoded string.
     #
     # bin - String bytes
@@ -124,8 +133,8 @@ module Sprockets
       Digest::SHA512 => 'sha512'.freeze
     }
 
-    # Internal: Generate a "named information" URI for use in the `integrity`
-    # attribute of an asset tag as per the subresource integrity specification.
+    # Public: Generate hash for use in the `integrity` attribute of an asset tag
+    # as per the subresource integrity specification.
     #
     # digest - The String byte digest of the asset content.
     #
@@ -144,6 +153,16 @@ module Sprockets
       if hash_name = HASH_ALGORITHMS[digest_class]
         "#{hash_name}-#{pack_base64digest(digest)}"
       end
+    end
+
+    # Public: Generate hash for use in the `integrity` attribute of an asset tag
+    # as per the subresource integrity specification.
+    #
+    # digest - The String hexbyte digest of the asset content.
+    #
+    # Returns a String or nil if hash algorithm is incompatible.
+    def hexdigest_integrity_uri(hexdigest)
+      integrity_uri(unpack_hexdigest(hexdigest))
     end
   end
 end

--- a/lib/sprockets/eco_processor.rb
+++ b/lib/sprockets/eco_processor.rb
@@ -12,7 +12,7 @@ module Sprockets
     VERSION = '1'
 
     def self.cache_key
-      @cache_key ||= [name, Autoload::Eco::Source::VERSION, VERSION].freeze
+      @cache_key ||= "#{name}:#{Autoload::Eco::Source::VERSION}:#{VERSION}".freeze
     end
 
     # Compile template data with Eco compiler.
@@ -24,7 +24,7 @@ module Sprockets
     #
     def self.call(input)
       data = input[:data]
-      input[:cache].fetch(cache_key + [data]) do
+      input[:cache].fetch([cache_key, data]) do
         Autoload::Eco.compile(data)
       end
     end

--- a/lib/sprockets/ejs_processor.rb
+++ b/lib/sprockets/ejs_processor.rb
@@ -11,7 +11,7 @@ module Sprockets
     VERSION = '1'
 
     def self.cache_key
-      @cache_key ||= [name, VERSION].freeze
+      @cache_key ||= "#{name}:#{VERSION}".freeze
     end
 
     # Compile template data with EJS compiler.
@@ -23,7 +23,7 @@ module Sprockets
     #
     def self.call(input)
       data = input[:data]
-      input[:cache].fetch(cache_key + [data]) do
+      input[:cache].fetch([cache_key, data]) do
         Autoload::EJS.compile(data)
       end
     end

--- a/lib/sprockets/legacy_tilt_processor.rb
+++ b/lib/sprockets/legacy_tilt_processor.rb
@@ -22,7 +22,7 @@ module Sprockets
       data     = input[:data]
       context  = input[:environment].context_class.new(input)
 
-      data = @klass.new(filename) { data }.render(context)
+      data = @klass.new(filename) { data }.render(context, {})
       context.metadata.merge(data: data.to_str)
     end
   end

--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -118,7 +118,6 @@ module Sprockets
           content_type: type,
           source: source,
           metadata: metadata,
-          integrity: integrity_uri(metadata[:digest]),
           dependencies_digest: digest(resolve_dependencies(metadata[:dependencies]))
         }
 

--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -1,7 +1,7 @@
 require 'json'
 require 'time'
 
-require 'concurrent/future'
+require 'concurrent'
 
 require 'sprockets/manifest_utils'
 require 'sprockets/utils/gzip'

--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -165,7 +165,11 @@ module Sprockets
           'mtime'        => asset.mtime.iso8601,
           'size'         => asset.bytesize,
           'digest'       => asset.hexdigest,
-          'integrity'    => asset.integrity
+
+          # Deprecated: Remove beta integrity attribute in next release.
+          # Callers should DigestUtils.hexdigest_integrity_uri to compute the
+          # digest themselves.
+          'integrity'    => DigestUtils.hexdigest_integrity_uri(asset.hexdigest)
         }
         assets[asset.logical_path] = asset.digest_path
 

--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -195,6 +195,7 @@ module Sprockets
         filenames << asset.filename
 
         next if environment.skip_gzip?
+        next if asset.metadata[:skip_gzip]
         gzip = Utils::Gzip.new(asset)
         next if gzip.cannot_compress?(environment.mime_types)
 

--- a/lib/sprockets/sass_compressor.rb
+++ b/lib/sprockets/sass_compressor.rb
@@ -1,4 +1,5 @@
 require 'sprockets/autoload'
+require 'sprockets/digest_utils'
 
 module Sprockets
   # Public: Sass CSS minifier.
@@ -35,17 +36,12 @@ module Sprockets
 
     def initialize(options = {})
       @options = options
-      @cache_key = [
-        self.class.name,
-        Autoload::Sass::VERSION,
-        VERSION,
-        options
-      ].freeze
+      @cache_key = "#{self.class.name}:#{Autoload::Sass::VERSION}:#{VERSION}:#{DigestUtils.digest(options)}".freeze
     end
 
     def call(input)
       data = input[:data]
-      input[:cache].fetch(@cache_key + [data]) do
+      input[:cache].fetch([@cache_key, data]) do
         options = {
           syntax: :scss,
           cache: false,

--- a/lib/sprockets/sass_compressor.rb
+++ b/lib/sprockets/sass_compressor.rb
@@ -35,18 +35,17 @@ module Sprockets
     attr_reader :cache_key
 
     def initialize(options = {})
-      @options = options
-      @cache_key = "#{self.class.name}:#{Autoload::Sass::VERSION}:#{VERSION}:#{DigestUtils.digest(options)}".freeze
-    end
-
-    def call(input)
-      options = {
+      @options = {
         syntax: :scss,
         cache: false,
         read_cache: false,
         style: :compressed
-      }.merge(@options)
-      Autoload::Sass::Engine.new(input[:data], options).render
+      }.merge(options).freeze
+      @cache_key = "#{self.class.name}:#{Autoload::Sass::VERSION}:#{VERSION}:#{DigestUtils.digest(options)}".freeze
+    end
+
+    def call(input)
+      Autoload::Sass::Engine.new(input[:data], @options).render
     end
   end
 end

--- a/lib/sprockets/sass_compressor.rb
+++ b/lib/sprockets/sass_compressor.rb
@@ -40,16 +40,13 @@ module Sprockets
     end
 
     def call(input)
-      data = input[:data]
-      input[:cache].fetch([@cache_key, data]) do
-        options = {
-          syntax: :scss,
-          cache: false,
-          read_cache: false,
-          style: :compressed
-        }.merge(@options)
-        Autoload::Sass::Engine.new(data, options).render
-      end
+      options = {
+        syntax: :scss,
+        cache: false,
+        read_cache: false,
+        style: :compressed
+      }.merge(@options)
+      Autoload::Sass::Engine.new(input[:data], options).render
     end
   end
 end

--- a/lib/sprockets/sass_processor.rb
+++ b/lib/sprockets/sass_processor.rb
@@ -44,12 +44,7 @@ module Sprockets
     #
     def initialize(options = {}, &block)
       @cache_version = options[:cache_version]
-      @cache_key = [
-        self.class.name,
-        VERSION,
-        Autoload::Sass::VERSION,
-        @cache_version
-      ].freeze
+      @cache_key = "#{self.class.name}:#{VERSION}:#{Autoload::Sass::VERSION}:#{@cache_version}".freeze
 
       @functions = Module.new do
         include Functions

--- a/lib/sprockets/uglifier_compressor.rb
+++ b/lib/sprockets/uglifier_compressor.rb
@@ -1,4 +1,5 @@
 require 'sprockets/autoload'
+require 'sprockets/digest_utils'
 
 module Sprockets
   # Public: Uglifier/Uglify compressor.
@@ -44,13 +45,7 @@ module Sprockets
       end
 
       @uglifier = Autoload::Uglifier.new(options)
-
-      @cache_key = [
-        self.class.name,
-        Autoload::Uglifier::VERSION,
-        VERSION,
-        options
-      ].freeze
+      @cache_key = "#{self.class.name}:#{Autoload::Uglifier::VERSION}:#{VERSION}:#{DigestUtils.digest(options)}".freeze
     end
 
     def call(input)

--- a/lib/sprockets/utils.rb
+++ b/lib/sprockets/utils.rb
@@ -95,11 +95,11 @@ module Sprockets
     #
     # Returns buf String.
     def concat_javascript_sources(buf, source)
-      if string_end_with_semicolon?(buf)
-        buf << source
-      else
-        buf << ";\n" << source
+      if buf.bytesize > 0
+        buf << ";" unless string_end_with_semicolon?(buf)
+        buf << "\n" unless buf.end_with?("\n")
       end
+      buf << source
     end
 
     # Internal: Prepends a leading "." to an extension if its missing.

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,3 +1,3 @@
 module Sprockets
-  VERSION = "3.3.4"
+  VERSION = "3.3.5"
 end

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,3 +1,3 @@
 module Sprockets
-  VERSION = "3.3.1"
+  VERSION = "3.3.2"
 end

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,3 +1,3 @@
 module Sprockets
-  VERSION = "3.4.0"
+  VERSION = "3.4.1"
 end

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,3 +1,3 @@
 module Sprockets
-  VERSION = "3.3.6"
+  VERSION = "3.4.0"
 end

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,3 +1,3 @@
 module Sprockets
-  VERSION = "3.3.0"
+  VERSION = "3.3.1"
 end

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,3 +1,3 @@
 module Sprockets
-  VERSION = "3.0.3"
+  VERSION = "3.1.0"
 end

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,3 +1,3 @@
 module Sprockets
-  VERSION = "3.1.0"
+  VERSION = "3.2.0"
 end

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,3 +1,3 @@
 module Sprockets
-  VERSION = "3.3.2"
+  VERSION = "3.3.3"
 end

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,3 +1,3 @@
 module Sprockets
-  VERSION = "3.3.3"
+  VERSION = "3.3.4"
 end

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,3 +1,3 @@
 module Sprockets
-  VERSION = "3.3.5"
+  VERSION = "3.3.6"
 end

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,3 +1,3 @@
 module Sprockets
-  VERSION = "3.4.1"
+  VERSION = "3.5.0"
 end

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,3 +1,3 @@
 module Sprockets
-  VERSION = "3.5.0"
+  VERSION = "3.5.1"
 end

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,3 +1,3 @@
 module Sprockets
-  VERSION = "3.5.1"
+  VERSION = "3.5.2"
 end

--- a/lib/sprockets/yui_compressor.rb
+++ b/lib/sprockets/yui_compressor.rb
@@ -1,4 +1,5 @@
 require 'sprockets/autoload'
+require 'sprockets/digest_utils'
 
 module Sprockets
   # Public: YUI compressor.
@@ -35,12 +36,7 @@ module Sprockets
 
     def initialize(options = {})
       @options = options
-      @cache_key = [
-        self.class.name,
-        Autoload::YUI::Compressor::VERSION,
-        VERSION,
-        options
-      ].freeze
+      @cache_key = "#{self.class.name}:#{Autoload::YUI::Compressor::VERSION}:#{VERSION}:#{DigestUtils.digest(options)}".freeze
     end
 
     def call(input)

--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.files = Dir["README.md", "CHANGELOG.md", "LICENSE", "lib/**/*.rb"]
   s.executables = ["sprockets"]
 
-  s.add_dependency "rack", "~> 1.0"
+  s.add_dependency "rack", "> 1", "< 3"
 
   s.add_development_dependency "closure-compiler", "~> 1.1"
   s.add_development_dependency "coffee-script-source", "~> 1.6"

--- a/test/fixtures/default/+plus.js
+++ b/test/fixtures/default/+plus.js
@@ -1,0 +1,1 @@
+function plus(a, b) { return a + b; }

--- a/test/sprockets_test.rb
+++ b/test/sprockets_test.rb
@@ -144,6 +144,15 @@ class Sprockets::TestCase < MiniTest::Test
     end
   end
 
+  def fixture_path_for_uri(path)
+    uri_path(fixture_path(path).to_s)
+  end
+
+  def uri_path(path)
+    path = '/' + path if path[1] == ':' # Windows path / drive letter
+    path
+  end
+
   def sandbox(*paths)
     backup_paths = paths.select { |path| File.exist?(path) }
     remove_paths = paths.select { |path| !File.exist?(path) }

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -175,7 +175,7 @@ class TextStaticAssetTest < Sprockets::TestCase
   include AssetTests
 
   test "uri" do
-    assert_equal "file://#{fixture_path('asset/log.txt')}?type=text/plain&id=xxx",
+    assert_equal "file://#{fixture_path_for_uri('asset/log.txt')}?type=text/plain&id=xxx",
       normalize_uri(@asset.uri)
   end
 
@@ -217,7 +217,7 @@ class BinaryStaticAssetTest < Sprockets::TestCase
   include AssetTests
 
   test "uri" do
-    assert_equal "file://#{fixture_path('asset/POW.png')}?type=image/png&id=xxx",
+    assert_equal "file://#{fixture_path_for_uri('asset/POW.png')}?type=image/png&id=xxx",
       normalize_uri(@asset.uri)
   end
 
@@ -337,7 +337,7 @@ class SourceAssetTest < Sprockets::TestCase
   include AssetTests
 
   test "uri" do
-    assert_equal "file://#{fixture_path('asset/application.js')}?type=application/javascript&pipeline=source&id=xxx",
+    assert_equal "file://#{fixture_path_for_uri('asset/application.js')}?type=application/javascript&pipeline=source&id=xxx",
       normalize_uri(@asset.uri)
   end
 
@@ -421,7 +421,7 @@ class ProcessedAssetTest < Sprockets::TestCase
   include AssetTests
 
   test "uri" do
-    assert_equal "file://#{fixture_path('asset/application.js')}?type=application/javascript&pipeline=self&id=xxx",
+    assert_equal "file://#{fixture_path_for_uri('asset/application.js')}?type=application/javascript&pipeline=self&id=xxx",
       normalize_uri(@asset.uri)
   end
 
@@ -509,7 +509,7 @@ class BundledAssetTest < Sprockets::TestCase
   include AssetTests
 
   test "uri" do
-    assert_equal "file://#{fixture_path('asset/application.js')}?type=application/javascript&id=xxx",
+    assert_equal "file://#{fixture_path_for_uri('asset/application.js')}?type=application/javascript&id=xxx",
       normalize_uri(@asset.uri)
   end
 
@@ -1019,9 +1019,9 @@ define("application.css", "application-46d50149c56fc370805f53c29f79b89a52d4cc479
 define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png")
     EOS
     assert_equal [
-      "file://#{fixture_path("asset/POW.png")}?type=image/png&id=xxx",
-      "file://#{fixture_path("asset/application.css")}?type=text/css&id=xxx",
-      "file://#{fixture_path("asset/application.js")}?type=application/javascript&id=xxx"
+      "file://#{fixture_path_for_uri("asset/POW.png")}?type=image/png&id=xxx",
+      "file://#{fixture_path_for_uri("asset/application.css")}?type=text/css&id=xxx",
+      "file://#{fixture_path_for_uri("asset/application.js")}?type=application/javascript&id=xxx"
     ], normalize_uris(asset.links)
   end
 
@@ -1038,16 +1038,16 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
     EOS
 
     assert_equal [
-      "file://#{fixture_path("asset/POW.png")}?type=image/png&id=xxx",
-      "file://#{fixture_path("asset/application.css")}?type=text/css&id=xxx",
-      "file://#{fixture_path("asset/application.js")}?type=application/javascript&id=xxx"
+      "file://#{fixture_path_for_uri("asset/POW.png")}?type=image/png&id=xxx",
+      "file://#{fixture_path_for_uri("asset/application.css")}?type=text/css&id=xxx",
+      "file://#{fixture_path_for_uri("asset/application.js")}?type=application/javascript&id=xxx"
     ], normalize_uris(asset.links)
   end
 
   test "link_directory current directory includes self last" do
     assert_equal [
-      "file://#{fixture_path("asset/link/directory/bar.js")}?type=application/javascript&id=xxx",
-      "file://#{fixture_path("asset/link/directory/foo.js")}?type=application/javascript&id=xxx"
+      "file://#{fixture_path_for_uri("asset/link/directory/bar.js")}?type=application/javascript&id=xxx",
+      "file://#{fixture_path_for_uri("asset/link/directory/foo.js")}?type=application/javascript&id=xxx"
     ], normalize_uris(asset("link/directory/application.js").links)
   end
 
@@ -1058,15 +1058,15 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
 
   test "link_tree without an argument defaults to the current directory" do
     assert_equal [
-      "file://#{fixture_path("asset/link/without_argument/a.js")}?type=application/javascript&id=xxx",
-      "file://#{fixture_path("asset/link/without_argument/b.js")}?type=application/javascript&id=xxx"
+      "file://#{fixture_path_for_uri("asset/link/without_argument/a.js")}?type=application/javascript&id=xxx",
+      "file://#{fixture_path_for_uri("asset/link/without_argument/b.js")}?type=application/javascript&id=xxx"
     ], normalize_uris(asset("link/without_argument/require_tree_without_argument.js").links)
   end
 
   test "link_tree with current directory includes self last" do
     assert_equal [
-      "file://#{fixture_path("asset/link/tree/bar.js")}?type=application/javascript&id=xxx",
-      "file://#{fixture_path("asset/link/tree/foo.js")}?type=application/javascript&id=xxx"
+      "file://#{fixture_path_for_uri("asset/link/tree/bar.js")}?type=application/javascript&id=xxx",
+      "file://#{fixture_path_for_uri("asset/link/tree/foo.js")}?type=application/javascript&id=xxx"
     ], normalize_uris(asset("link/tree/application.js").links)
   end
 
@@ -1084,31 +1084,31 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
 
   test "link_directory requires all child files in alphabetical order" do
     assert_equal [
-      "file://#{fixture_path("asset/link/all/README.md")}?id=xxx",
-      "file://#{fixture_path("asset/link/all/b.css")}?type=text/css&id=xxx",
-      "file://#{fixture_path("asset/link/all/b.js.erb")}?type=application/javascript&id=xxx"
+      "file://#{fixture_path_for_uri("asset/link/all/README.md")}?id=xxx",
+      "file://#{fixture_path_for_uri("asset/link/all/b.css")}?type=text/css&id=xxx",
+      "file://#{fixture_path_for_uri("asset/link/all/b.js.erb")}?type=application/javascript&id=xxx"
     ], normalize_uris(asset("link/all_with_require_directory.js").links)
   end
 
   test "link_directory as app/js requires all child files in alphabetical order" do
     assert_equal [
-      "file://#{fixture_path("asset/link/all/b.js.erb")}?type=application/javascript&id=xxx"
+      "file://#{fixture_path_for_uri("asset/link/all/b.js.erb")}?type=application/javascript&id=xxx"
     ], normalize_uris(asset("link/all_with_require_directory_as_js.js").links)
   end
 
   test "link_tree respects order of child dependencies" do
     assert_equal [
-      "file://#{fixture_path("asset/link/alpha/a.js")}?type=application/javascript&id=xxx",
-      "file://#{fixture_path("asset/link/alpha/b.js")}?type=application/javascript&id=xxx",
-      "file://#{fixture_path("asset/link/alpha/c.js")}?type=application/javascript&id=xxx"
+      "file://#{fixture_path_for_uri("asset/link/alpha/a.js")}?type=application/javascript&id=xxx",
+      "file://#{fixture_path_for_uri("asset/link/alpha/b.js")}?type=application/javascript&id=xxx",
+      "file://#{fixture_path_for_uri("asset/link/alpha/c.js")}?type=application/javascript&id=xxx"
     ], normalize_uris(asset("link/require_tree_alpha.js").links)
   end
 
   test "link_tree as app/js respects order of child dependencies" do
     assert_equal [
-      "file://#{fixture_path("asset/link/alpha/a.js")}?type=application/javascript&id=xxx",
-      "file://#{fixture_path("asset/link/alpha/b.js")}?type=application/javascript&id=xxx",
-      "file://#{fixture_path("asset/link/alpha/c.js")}?type=application/javascript&id=xxx"
+      "file://#{fixture_path_for_uri("asset/link/alpha/a.js")}?type=application/javascript&id=xxx",
+      "file://#{fixture_path_for_uri("asset/link/alpha/b.js")}?type=application/javascript&id=xxx",
+      "file://#{fixture_path_for_uri("asset/link/alpha/c.js")}?type=application/javascript&id=xxx"
     ], normalize_uris(asset("link/require_tree_alpha_as_js.js").links)
   end
 
@@ -1120,7 +1120,7 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
 }
     EOS
     assert_equal [
-      "file://#{fixture_path("asset/POW.png")}?type=image/png&id=xxx"
+      "file://#{fixture_path_for_uri("asset/POW.png")}?type=image/png&id=xxx"
       ], normalize_uris(asset.links)
   end
 

--- a/test/test_bundle.rb
+++ b/test/test_bundle.rb
@@ -19,7 +19,7 @@ class TestStylesheetBundle < Sprockets::TestCase
     data = ".project {}\n"
     result = Sprockets::Bundle.call(input)
     assert_equal data, result[:data]
-    assert_equal ["file-digest://#{filename}"],
+    assert_equal ["file-digest://#{uri_path(filename)}"],
       result[:dependencies].to_a.sort.select { |dep| dep.start_with?("file-digest:") }
   end
 
@@ -42,13 +42,13 @@ class TestStylesheetBundle < Sprockets::TestCase
     result = Sprockets::Bundle.call(input)
     assert_equal data, result[:data]
     assert_equal [
-      "file-digest://" + fixture_path('asset'),
-      "file-digest://" + fixture_path('asset/project'),
-      "file-digest://" + fixture_path('asset/project.css'),
-      "file-digest://" + fixture_path('asset/require_self.css'),
-      "file-digest://" + fixture_path('asset/tree/all'),
-      "file-digest://" + fixture_path('asset/tree/all/b'),
-      "file-digest://" + fixture_path('asset/tree/all/b.css')
+      "file-digest://" + fixture_path_for_uri('asset'),
+      "file-digest://" + fixture_path_for_uri('asset/project'),
+      "file-digest://" + fixture_path_for_uri('asset/project.css'),
+      "file-digest://" + fixture_path_for_uri('asset/require_self.css'),
+      "file-digest://" + fixture_path_for_uri('asset/tree/all'),
+      "file-digest://" + fixture_path_for_uri('asset/tree/all/b'),
+      "file-digest://" + fixture_path_for_uri('asset/tree/all/b.css')
     ], result[:dependencies].to_a.sort.select { |dep| dep.start_with?("file-digest:") }
   end
 
@@ -70,7 +70,7 @@ class TestStylesheetBundle < Sprockets::TestCase
     data = "var Project = {\n  find: function(id) {\n  }\n};\n"
     result = Sprockets::Bundle.call(input)
     assert_equal data, result[:data]
-    assert_equal ["file-digest://#{filename}"],
+    assert_equal ["file-digest://#{uri_path(filename)}"],
       result[:dependencies].to_a.sort.select { |dep| dep.start_with?("file-digest:") }
   end
 
@@ -93,12 +93,12 @@ class TestStylesheetBundle < Sprockets::TestCase
     result = Sprockets::Bundle.call(input)
     assert_equal data, result[:data]
     assert_equal [
-      "file-digest://" + fixture_path('asset'),
-      "file-digest://" + fixture_path('asset/application.js'),
-      "file-digest://" + fixture_path('asset/project'),
-      "file-digest://" + fixture_path('asset/project.js.erb'),
-      "file-digest://" + fixture_path('asset/users'),
-      "file-digest://" + fixture_path('asset/users.js.erb')
+      "file-digest://" + fixture_path_for_uri('asset'),
+      "file-digest://" + fixture_path_for_uri('asset/application.js'),
+      "file-digest://" + fixture_path_for_uri('asset/project'),
+      "file-digest://" + fixture_path_for_uri('asset/project.js.erb'),
+      "file-digest://" + fixture_path_for_uri('asset/users'),
+      "file-digest://" + fixture_path_for_uri('asset/users.js.erb')
     ], result[:dependencies].to_a.sort.select { |dep| dep.start_with?("file-digest:") }
   end
 end

--- a/test/test_cache_store.rb
+++ b/test/test_cache_store.rb
@@ -78,7 +78,7 @@ class TestNullStore < MiniTest::Test
   end
 
   def test_inspect
-    assert_equal "#<Sprockets::Cache local=#<Sprockets::Cache::MemoryStore size=0/4096> store=#<Sprockets::Cache::NullStore>>", @store.inspect
+    assert_equal "#<Sprockets::Cache local=#<Sprockets::Cache::MemoryStore size=0/1024> store=#<Sprockets::Cache::NullStore>>", @store.inspect
     assert_equal "#<Sprockets::Cache::NullStore>", @_store.inspect
   end
 

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -49,9 +49,9 @@ class TestContext < Sprockets::TestCase
   end
 
   test "resolve with content type" do
-    assert_equal [fixture_path("context/foo.js"),
-      fixture_path("context/foo.js"),
-      fixture_path("context/foo.js")
+    assert_equal [fixture_path_for_uri("context/foo.js"),
+      fixture_path_for_uri("context/foo.js"),
+      fixture_path_for_uri("context/foo.js")
     ].join(",\n"), @env["resolve_content_type.js"].to_s.strip
   end
 end

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -68,7 +68,7 @@ class TestCustomProcessor < Sprockets::TestCase
       @data = block.call
     end
 
-    def render(context)
+    def render(context, locals = {})
       manifest = YAML.load(@data)
       manifest['require'].each do |logical_path|
         context.require_asset(logical_path)
@@ -89,7 +89,7 @@ class TestCustomProcessor < Sprockets::TestCase
       @data = block.call
     end
 
-    def render(context)
+    def render(context, locals = {})
       data = @data
       data.gsub(/url\(\"(.+?)\"\)/) do
         path = context.resolve($1, compat: true)

--- a/test/test_digest_utils.rb
+++ b/test/test_digest_utils.rb
@@ -49,6 +49,11 @@ class TestDigestUtils < MiniTest::Test
     assert_equal "6e11c72f7cf6bc383152dd16ddd5903aba6bb1c99d6b6639a4bb0b838185fa92", pack_hexdigest(digest.digest)
   end
 
+  def test_unpack_hexdigest
+    digest = Digest::SHA256.new.update("alert(1)")
+    assert_equal digest.digest, unpack_hexdigest(digest.hexdigest)
+  end
+
   def test_pack_base64_digest
     digest = Digest::SHA256.new.update("alert(1)")
 
@@ -80,5 +85,16 @@ class TestDigestUtils < MiniTest::Test
     sha256 = Digest::SHA256.new.update("alert('Hello, world.');")
     assert_equal "sha256-qznLcsROx4GACP2dm0UCKCzCG+HiZ1guq6ZZDob/Tng=",
       integrity_uri(sha256)
+  end
+
+  def test_hexdigest_integrity_uri
+    sha256 = Digest::SHA256.new.update("alert(1)").hexdigest
+    sha512 = Digest::SHA512.new.update("alert(1)").hexdigest
+
+    assert_equal "sha256-bhHHL3z2vDgxUt0W3dWQOrprscmda2Y5pLsLg4GF+pI=",
+      hexdigest_integrity_uri(sha256)
+
+    assert_equal "sha512-+uuYUxxe7oWIShQrWEmMn/fixz/rxDP4qcAZddXLDM3nN8/tpk1ZC2jXQk6N+mXE65jwfzNVUJL/qjA3y9KbuQ==",
+      hexdigest_integrity_uri(sha512)
   end
 end

--- a/test/test_engines.rb
+++ b/test/test_engines.rb
@@ -10,7 +10,7 @@ class AlertProcessor
     @data = block.call
   end
 
-  def render(context)
+  def render(context, locals = {})
     "alert(#{@data.inspect});"
   end
 end
@@ -20,7 +20,7 @@ class StringProcessor
     @data = block.call
   end
 
-  def render(context)
+  def render(context, locals = {})
     @data.gsub(/#\{.*?\}/, "moo")
   end
 end

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -346,6 +346,12 @@ $app.run(function($templateCache) {
     assert_equal [137, 80, 78, 71, 13, 10, 26, 10, 60, 115], asset.to_s[0, 10].bytes.to_a
   end
 
+  test "asset with + character" do
+    assert asset = @env.find_asset("+plus.js")
+    assert_equal "+plus.js", asset.logical_path
+    assert_equal "application/javascript", asset.content_type
+  end
+
   test "missing static path returns nil" do
     assert_nil @env[fixture_path("default/missing.png")]
   end

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -522,6 +522,10 @@ class TestEnvironment < Sprockets::TestCase
     @env.append_path(fixture_path('asset'))
   end
 
+  test "default gzip" do
+    assert_equal true, @env.gzip?
+  end
+
   test "register bundle processor" do
     old_size = @env.bundle_processors['text/css'].size
     @env.register_bundle_processor 'text/css', WhitespaceProcessor
@@ -803,12 +807,23 @@ class TestCached < Sprockets::TestCase
     Sprockets::Environment.new(".") do |env|
       env.append_path(fixture_path('default'))
       env.cache = {}
+      env.gzip = false
       yield env if block_given?
     end.cached
   end
 
   def setup
     @env = new_environment
+  end
+
+  test "inherit the gzip option" do
+    assert_equal false, @env.gzip?
+  end
+
+  test "does not allow to change the gzip option" do
+    assert_raises RuntimeError do
+      @env.gzip = true
+    end
   end
 
   test "does not allow new mime types to be added" do

--- a/test/test_erb_processor.rb
+++ b/test/test_erb_processor.rb
@@ -4,6 +4,12 @@ require 'sprockets/cache'
 require 'sprockets/erb_processor'
 
 class TestERBProcessor < MiniTest::Test
+
+  def uri_path(path)
+    path = '/' + path if path[1] == ':' # Windows path / drive letter
+    path
+  end
+
   def tset_compile_js_erb_template
     environment = Sprockets::Environment.new
 
@@ -38,7 +44,7 @@ class TestERBProcessor < MiniTest::Test
     output = "var data = 'DATA';"
     result = Sprockets::ERBProcessor.call(input)
     assert_equal output, result[:data]
-    assert_equal "file-digest://#{path}", result[:dependencies].first
+    assert_equal "file-digest://#{uri_path(path)}", result[:dependencies].first
   end
 
   def test_compile_erb_template_with_depend_on_call_outside_load_paths
@@ -61,7 +67,7 @@ class TestERBProcessor < MiniTest::Test
     output = "var data = 'DATA';"
     result = Sprockets::ERBProcessor.call(input)
     assert_equal output, result[:data]
-    assert_equal "file-digest://#{path}", result[:dependencies].first
+    assert_equal "file-digest://#{uri_path(path)}", result[:dependencies].first
   end
 
   def test_pass_custom_erb_helpers_to_template

--- a/test/test_loader.rb
+++ b/test/test_loader.rb
@@ -7,7 +7,7 @@ class TestLoader < Sprockets::TestCase
   end
 
   test "load asset by uri" do
-    assert asset = @env.load("file://#{fixture_path('default/gallery.js')}?type=application/javascript")
+    assert asset = @env.load("file://#{fixture_path_for_uri('default/gallery.js')}?type=application/javascript")
     assert_equal fixture_path('default/gallery.js'), asset.filename
     assert_equal 'application/javascript', asset.content_type
     assert_equal '828e4be75f8bf69529b5d618dd12a6144d58d47cf4c3a9e3f64b0b8812008dab', asset.etag
@@ -17,25 +17,25 @@ class TestLoader < Sprockets::TestCase
     assert_equal 'application/javascript', asset.content_type
     assert_equal '828e4be75f8bf69529b5d618dd12a6144d58d47cf4c3a9e3f64b0b8812008dab', asset.etag
 
-    assert asset = @env.load("file://#{fixture_path('default/gallery.css.erb')}?type=text/css")
+    assert asset = @env.load("file://#{fixture_path_for_uri('default/gallery.css.erb')}?type=text/css")
     assert_equal fixture_path('default/gallery.css.erb'), asset.filename
     assert_equal 'text/css', asset.content_type
 
-    assert asset = @env.load(Pathname.new("file://#{fixture_path('default/gallery.css.erb')}?type=text/css"))
+    assert asset = @env.load(Pathname.new("file://#{fixture_path_for_uri('default/gallery.css.erb')}?type=text/css"))
     assert_equal fixture_path('default/gallery.css.erb'), asset.filename
     assert_equal 'text/css', asset.content_type
 
     bad_id = "0000000000000000000000000000000000000000"
-    assert asset = @env.load("file://#{fixture_path('default/gallery.js')}?type=application/javascript&id=#{bad_id}")
+    assert asset = @env.load("file://#{fixture_path_for_uri('default/gallery.js')}?type=application/javascript&id=#{bad_id}")
     assert_equal fixture_path('default/gallery.js'), asset.filename
     assert_equal 'application/javascript', asset.content_type
 
     assert_raises Sprockets::FileNotFound do
-      @env.load("file://#{fixture_path('default/missing.js')}?type=application/javascript")
+      @env.load("file://#{fixture_path_for_uri('default/missing.js')}?type=application/javascript")
     end
 
     assert_raises Sprockets::ConversionError do
-      @env.load("file://#{fixture_path('default/gallery.js')}?type=text/css")
+      @env.load("file://#{fixture_path_for_uri('default/gallery.js')}?type=text/css")
     end
   end
 end

--- a/test/test_path_digest_utils.rb
+++ b/test/test_path_digest_utils.rb
@@ -21,6 +21,8 @@ class TestPathDigestUtils < MiniTest::Test
   end
 
   def test_symlink_stat_digest
+    skip "no symlinks available" unless File.symlink?(File.expand_path("../fixtures/default/symlink", __FILE__))
+
     path = File.expand_path("../fixtures/default/mobile", __FILE__)
     assert_equal "e571f54b8982049817ee30d0bf0dcf5dd8c09252b50696f7ccb44019c9229ccd",
       stat_digest(path, File.stat(path)).unpack("h*")[0]
@@ -52,6 +54,8 @@ class TestPathDigestUtils < MiniTest::Test
   end
 
   def test_multiple_file_digests
+    skip "no symlinks available" unless File.symlink?(File.expand_path("../fixtures/default/symlink", __FILE__))
+
     paths = []
     paths << File.expand_path("../fixtures/default/hello.txt", __FILE__)
     paths << File.expand_path("../fixtures/default/app", __FILE__)

--- a/test/test_resolve.rb
+++ b/test/test_resolve.rb
@@ -6,27 +6,27 @@ class TestResolve < Sprockets::TestCase
   end
 
   test "resolve in default environment" do
-    @env.append_path(fixture_path('default'))
+    @env.append_path(fixture_path_for_uri('default'))
 
-    assert_equal "file://#{fixture_path('default/gallery.js')}?type=application/javascript",
+    assert_equal "file://#{fixture_path_for_uri('default/gallery.js')}?type=application/javascript",
       resolve("gallery.js")
-    assert_equal "file://#{fixture_path('default/coffee/foo.coffee')}?type=application/javascript",
+    assert_equal "file://#{fixture_path_for_uri('default/coffee/foo.coffee')}?type=application/javascript",
       resolve("coffee/foo.js")
-    assert_equal "file://#{fixture_path('default/jquery.tmpl.min.js')}?type=application/javascript",
+    assert_equal "file://#{fixture_path_for_uri('default/jquery.tmpl.min.js')}?type=application/javascript",
       resolve("jquery.tmpl.min")
-    assert_equal "file://#{fixture_path('default/jquery.tmpl.min.js')}?type=application/javascript",
+    assert_equal "file://#{fixture_path_for_uri('default/jquery.tmpl.min.js')}?type=application/javascript",
       resolve("jquery.tmpl.min.js")
-    assert_equal "file://#{fixture_path('default/manifest.js.yml')}?type=text/yaml",
+    assert_equal "file://#{fixture_path_for_uri('default/manifest.js.yml')}?type=text/yaml",
       resolve('manifest.js.yml')
     refute resolve("null")
   end
 
   test "resolve accept type list before paths" do
-    @env.append_path(fixture_path('resolve/javascripts'))
-    @env.append_path(fixture_path('resolve/stylesheets'))
+    @env.append_path(fixture_path_for_uri('resolve/javascripts'))
+    @env.append_path(fixture_path_for_uri('resolve/stylesheets'))
 
-    foo_js_uri  = "file://#{fixture_path('resolve/javascripts/foo.js')}?type=application/javascript"
-    foo_css_uri = "file://#{fixture_path('resolve/stylesheets/foo.css')}?type=text/css"
+    foo_js_uri  = "file://#{fixture_path_for_uri('resolve/javascripts/foo.js')}?type=application/javascript"
+    foo_css_uri = "file://#{fixture_path_for_uri('resolve/stylesheets/foo.css')}?type=text/css"
 
     assert_equal foo_js_uri, resolve('foo', accept: 'application/javascript')
     assert_equal foo_css_uri, resolve('foo', accept: 'text/css')
@@ -42,11 +42,11 @@ class TestResolve < Sprockets::TestCase
   end
 
   test "resolve under load path" do
-    @env.append_path(scripts = fixture_path('resolve/javascripts'))
-    @env.append_path(styles = fixture_path('resolve/stylesheets'))
+    @env.append_path(scripts = fixture_path_for_uri('resolve/javascripts'))
+    @env.append_path(styles = fixture_path_for_uri('resolve/stylesheets'))
 
-    foo_js_uri  = "file://#{fixture_path('resolve/javascripts/foo.js')}?type=application/javascript"
-    foo_css_uri = "file://#{fixture_path('resolve/stylesheets/foo.css')}?type=text/css"
+    foo_js_uri  = "file://#{fixture_path_for_uri('resolve/javascripts/foo.js')}?type=application/javascript"
+    foo_css_uri = "file://#{fixture_path_for_uri('resolve/stylesheets/foo.css')}?type=text/css"
 
     assert_equal foo_js_uri, resolve('foo.js', load_paths: [scripts])
     assert_equal foo_css_uri, resolve('foo.css', load_paths: [styles])
@@ -56,30 +56,30 @@ class TestResolve < Sprockets::TestCase
   end
 
   test "resolve absolute" do
-    @env.append_path(fixture_path('default'))
+    @env.append_path(fixture_path_for_uri('default'))
 
-    gallery_js_uri = "file://#{fixture_path('default/gallery.js')}?type=application/javascript"
+    gallery_js_uri = "file://#{fixture_path_for_uri('default/gallery.js')}?type=application/javascript"
 
-    assert_equal gallery_js_uri, resolve(fixture_path('default/gallery.js'))
-    assert_equal gallery_js_uri, resolve(fixture_path('default/app/../gallery.js'))
-    assert_equal gallery_js_uri, resolve(fixture_path('default/gallery.js'), accept: 'application/javascript')
+    assert_equal gallery_js_uri, resolve(fixture_path_for_uri('default/gallery.js'))
+    assert_equal gallery_js_uri, resolve(fixture_path_for_uri('default/app/../gallery.js'))
+    assert_equal gallery_js_uri, resolve(fixture_path_for_uri('default/gallery.js'), accept: 'application/javascript')
 
-    assert_equal "file://#{fixture_path('default/blank.gif')}?type=image/gif",
-      resolve(fixture_path('default/blank.gif'))
-    assert_equal "file://#{fixture_path('default/hello.txt')}?type=text/plain",
-      resolve(fixture_path('default/hello.txt'))
-    assert_equal "file://#{fixture_path('default/README.md')}",
-      resolve(fixture_path('default/README.md'))
+    assert_equal "file://#{fixture_path_for_uri('default/blank.gif')}?type=image/gif",
+      resolve(fixture_path_for_uri('default/blank.gif'))
+    assert_equal "file://#{fixture_path_for_uri('default/hello.txt')}?type=text/plain",
+      resolve(fixture_path_for_uri('default/hello.txt'))
+    assert_equal "file://#{fixture_path_for_uri('default/README.md')}",
+      resolve(fixture_path_for_uri('default/README.md'))
 
-    refute resolve(fixture_path('asset/POW.png'))
-    refute resolve(fixture_path('default/missing'))
-    refute resolve(fixture_path('default/gallery.js'), accept: 'text/css')
+    refute resolve(fixture_path_for_uri('asset/POW.png'))
+    refute resolve(fixture_path_for_uri('default/missing'))
+    refute resolve(fixture_path_for_uri('default/gallery.js'), accept: 'text/css')
   end
 
   test "resolve absolute identity" do
-    @env.append_path(fixture_path('default'))
+    @env.append_path(fixture_path_for_uri('default'))
 
-    @env.stat_tree(fixture_path('default')).each do |expected_path, stat|
+    @env.stat_tree(fixture_path_for_uri('default')).each do |expected_path, stat|
       next unless stat.file?
       actual_path, _ = @env.parse_asset_uri(resolve(expected_path))
       assert_equal expected_path, actual_path
@@ -87,26 +87,26 @@ class TestResolve < Sprockets::TestCase
   end
 
   test "resolve relative" do
-    @env.append_path(fixture_path('default'))
+    @env.append_path(fixture_path_for_uri('default'))
 
-    gallery_js_uri = "file://#{fixture_path('default/gallery.js')}?type=application/javascript"
+    gallery_js_uri = "file://#{fixture_path_for_uri('default/gallery.js')}?type=application/javascript"
 
-    assert_equal gallery_js_uri, resolve("./gallery.js", base_path: fixture_path('default'))
-    assert_equal gallery_js_uri, resolve("../gallery.js", base_path: fixture_path('default/app'))
-    assert_equal gallery_js_uri, resolve("./../gallery.js", base_path: fixture_path('default/app'))
-    assert_equal gallery_js_uri, resolve("../../gallery.js", base_path: fixture_path('default/vendor/gems'))
+    assert_equal gallery_js_uri, resolve("./gallery.js", base_path: fixture_path_for_uri('default'))
+    assert_equal gallery_js_uri, resolve("../gallery.js", base_path: fixture_path_for_uri('default/app'))
+    assert_equal gallery_js_uri, resolve("./../gallery.js", base_path: fixture_path_for_uri('default/app'))
+    assert_equal gallery_js_uri, resolve("../../gallery.js", base_path: fixture_path_for_uri('default/vendor/gems'))
 
-    refute resolve("./missing.js", base_path: fixture_path('default'))
-    refute resolve("../asset/application.js", base_path: fixture_path('default'))
-    refute resolve("../default/gallery.js", base_path: fixture_path('app'))
+    refute resolve("./missing.js", base_path: fixture_path_for_uri('default'))
+    refute resolve("../asset/application.js", base_path: fixture_path_for_uri('default'))
+    refute resolve("../default/gallery.js", base_path: fixture_path_for_uri('app'))
   end
 
   test "resolve extension before accept type" do
-    @env.append_path(fixture_path('resolve/javascripts'))
-    @env.append_path(fixture_path('resolve/stylesheets'))
+    @env.append_path(fixture_path_for_uri('resolve/javascripts'))
+    @env.append_path(fixture_path_for_uri('resolve/stylesheets'))
 
-    foo_js_uri  = "file://#{fixture_path('resolve/javascripts/foo.js')}?type=application/javascript"
-    foo_css_uri = "file://#{fixture_path('resolve/stylesheets/foo.css')}?type=text/css"
+    foo_js_uri  = "file://#{fixture_path_for_uri('resolve/javascripts/foo.js')}?type=application/javascript"
+    foo_css_uri = "file://#{fixture_path_for_uri('resolve/stylesheets/foo.css')}?type=text/css"
 
     assert_equal foo_js_uri, resolve('foo.js', accept: 'application/javascript')
     assert_equal foo_css_uri, resolve('foo.css', accept: 'text/css')
@@ -121,10 +121,10 @@ class TestResolve < Sprockets::TestCase
   end
 
   test "resolve accept type quality in paths" do
-    @env.append_path(fixture_path('resolve/javascripts'))
+    @env.append_path(fixture_path_for_uri('resolve/javascripts'))
 
-    bar_js_uri  = "file://#{fixture_path('resolve/javascripts/bar.js')}?type=application/javascript"
-    bar_css_uri = "file://#{fixture_path('resolve/javascripts/bar.css')}?type=text/css"
+    bar_js_uri  = "file://#{fixture_path_for_uri('resolve/javascripts/bar.js')}?type=application/javascript"
+    bar_css_uri = "file://#{fixture_path_for_uri('resolve/javascripts/bar.css')}?type=text/css"
 
     assert_equal bar_js_uri, resolve('bar', accept: 'application/javascript')
     assert_equal bar_css_uri, resolve('bar', accept: 'text/css')
@@ -140,100 +140,100 @@ class TestResolve < Sprockets::TestCase
   end
 
   test "resolve with dependencies" do
-    @env.append_path(fixture_path('default'))
+    @env.append_path(fixture_path_for_uri('default'))
 
     uri, deps = @env.resolve("gallery.js", compat: false)
-    assert_equal "file://#{fixture_path('default/gallery.js')}?type=application/javascript", uri
-    assert_includes deps, "file-digest://#{fixture_path('default/gallery.js')}"
-    assert_includes deps, "file-digest://#{fixture_path('default')}"
+    assert_equal "file://#{fixture_path_for_uri('default/gallery.js')}?type=application/javascript", uri
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('default/gallery.js')}"
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('default')}"
 
     uri, deps = @env.resolve("coffee/foo.js", compat: false)
-    assert_equal "file://#{fixture_path('default/coffee/foo.coffee')}?type=application/javascript", uri
-    assert_includes deps, "file-digest://#{fixture_path('default/coffee/foo.coffee')}"
-    assert_includes deps, "file-digest://#{fixture_path('default/coffee')}"
+    assert_equal "file://#{fixture_path_for_uri('default/coffee/foo.coffee')}?type=application/javascript", uri
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('default/coffee/foo.coffee')}"
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('default/coffee')}"
 
     uri, deps = @env.resolve("manifest.js.yml", compat: false)
-    assert_equal "file://#{fixture_path('default/manifest.js.yml')}?type=text/yaml", uri
-    assert_includes deps, "file-digest://#{fixture_path('default/manifest.js.yml')}"
-    assert_includes deps, "file-digest://#{fixture_path('default')}"
+    assert_equal "file://#{fixture_path_for_uri('default/manifest.js.yml')}?type=text/yaml", uri
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('default/manifest.js.yml')}"
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('default')}"
 
     uri, deps = @env.resolve("gallery", accept: 'application/javascript', compat: false)
-    assert_equal "file://#{fixture_path('default/gallery.js')}?type=application/javascript", uri
-    assert_includes deps, "file-digest://#{fixture_path('default/gallery.js')}"
-    assert_includes deps, "file-digest://#{fixture_path('default')}"
+    assert_equal "file://#{fixture_path_for_uri('default/gallery.js')}?type=application/javascript", uri
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('default/gallery.js')}"
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('default')}"
   end
 
   test "resolve under load path with dependencies" do
-    @env.append_path(scripts = fixture_path('resolve/javascripts'))
-    @env.append_path(styles = fixture_path('resolve/stylesheets'))
+    @env.append_path(scripts = fixture_path_for_uri('resolve/javascripts'))
+    @env.append_path(styles = fixture_path_for_uri('resolve/stylesheets'))
 
     uri, deps = @env.resolve('foo.js', load_paths: [scripts], compat: false)
-    assert_equal "file://#{fixture_path('resolve/javascripts/foo.js')}?type=application/javascript", uri
-    assert_includes deps, "file-digest://#{fixture_path('resolve/javascripts/foo.js')}"
-    assert_includes deps, "file-digest://#{fixture_path('resolve/javascripts')}"
+    assert_equal "file://#{fixture_path_for_uri('resolve/javascripts/foo.js')}?type=application/javascript", uri
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('resolve/javascripts/foo.js')}"
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('resolve/javascripts')}"
 
     uri, deps = @env.resolve('foo.css', load_paths: [styles], compat: false)
-    assert_equal "file://#{fixture_path('resolve/stylesheets/foo.css')}?type=text/css", uri
-    assert_includes deps, "file-digest://#{fixture_path('resolve/stylesheets/foo.css')}"
-    assert_includes deps, "file-digest://#{fixture_path('resolve/stylesheets')}"
+    assert_equal "file://#{fixture_path_for_uri('resolve/stylesheets/foo.css')}?type=text/css", uri
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('resolve/stylesheets/foo.css')}"
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('resolve/stylesheets')}"
 
     uri, deps = @env.resolve('foo.js', load_paths: [styles], compat: false)
     refute uri
-    assert_includes deps, "file-digest://#{fixture_path('resolve/stylesheets')}"
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('resolve/stylesheets')}"
 
     uri, deps = @env.resolve('foo.css', load_paths: [scripts], compat: false)
     refute uri
-    assert_includes deps, "file-digest://#{fixture_path('resolve/javascripts')}"
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('resolve/javascripts')}"
   end
 
   test "resolve absolute with dependencies" do
-    @env.append_path(fixture_path('default'))
+    @env.append_path(fixture_path_for_uri('default'))
 
-    uri, deps = @env.resolve(fixture_path('default/gallery.js'), compat: false)
-    assert_equal "file://#{fixture_path('default/gallery.js')}?type=application/javascript", uri
-    assert_includes deps, "file-digest://#{fixture_path('default/gallery.js')}"
+    uri, deps = @env.resolve(fixture_path_for_uri('default/gallery.js'), compat: false)
+    assert_equal "file://#{fixture_path_for_uri('default/gallery.js')}?type=application/javascript", uri
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('default/gallery.js')}"
   end
 
   test "resolve uri identity with dependencies" do
-    @env.append_path(fixture_path('default'))
+    @env.append_path(fixture_path_for_uri('default'))
 
-    uri1 = "file://#{fixture_path('default/gallery.js')}?type=application/javascript"
+    uri1 = "file://#{fixture_path_for_uri('default/gallery.js')}?type=application/javascript"
     uri2, deps = @env.resolve(uri1, compat: false)
     assert_equal uri1, uri2
-    assert_includes deps, "file-digest://#{fixture_path('default/gallery.js')}"
+    assert_includes deps, "file-digest://#{fixture_path_for_uri('default/gallery.js')}"
   end
 
   test "resolve with pipeline" do
-    @env.append_path(fixture_path('default'))
+    @env.append_path(fixture_path_for_uri('default'))
 
-    assert_equal "file://#{fixture_path('default/gallery.js')}?type=application/javascript&pipeline=source",
+    assert_equal "file://#{fixture_path_for_uri('default/gallery.js')}?type=application/javascript&pipeline=source",
       resolve("gallery.js", pipeline: :source)
-    assert_equal "file://#{fixture_path('default/coffee/foo.coffee')}?type=application/javascript&pipeline=source",
+    assert_equal "file://#{fixture_path_for_uri('default/coffee/foo.coffee')}?type=application/javascript&pipeline=source",
       resolve("coffee/foo.js", pipeline: :source)
-    assert_equal "file://#{fixture_path('default/jquery.tmpl.min.js')}?type=application/javascript&pipeline=source",
+    assert_equal "file://#{fixture_path_for_uri('default/jquery.tmpl.min.js')}?type=application/javascript&pipeline=source",
       resolve("jquery.tmpl.min", pipeline: :source)
-    assert_equal "file://#{fixture_path('default/jquery.tmpl.min.js')}?type=application/javascript&pipeline=source",
+    assert_equal "file://#{fixture_path_for_uri('default/jquery.tmpl.min.js')}?type=application/javascript&pipeline=source",
       resolve("jquery.tmpl.min.js", pipeline: :source)
-    assert_equal "file://#{fixture_path('default/manifest.js.yml')}?type=text/yaml&pipeline=source",
+    assert_equal "file://#{fixture_path_for_uri('default/manifest.js.yml')}?type=text/yaml&pipeline=source",
       resolve('manifest.js.yml', pipeline: :source)
     refute resolve("null", pipeline: :source)
 
-    assert_equal "file://#{fixture_path('default/gallery.js')}?type=application/javascript&pipeline=source",
+    assert_equal "file://#{fixture_path_for_uri('default/gallery.js')}?type=application/javascript&pipeline=source",
       resolve("gallery.source.js")
-    assert_equal "file://#{fixture_path('default/coffee/foo.coffee')}?type=application/javascript&pipeline=source",
+    assert_equal "file://#{fixture_path_for_uri('default/coffee/foo.coffee')}?type=application/javascript&pipeline=source",
       resolve("coffee/foo.source.js")
-    assert_equal "file://#{fixture_path('default/jquery.tmpl.min.js')}?type=application/javascript&pipeline=source",
+    assert_equal "file://#{fixture_path_for_uri('default/jquery.tmpl.min.js')}?type=application/javascript&pipeline=source",
       resolve("jquery.tmpl.min.source")
-    assert_equal "file://#{fixture_path('default/jquery.tmpl.min.js')}?type=application/javascript&pipeline=source",
+    assert_equal "file://#{fixture_path_for_uri('default/jquery.tmpl.min.js')}?type=application/javascript&pipeline=source",
       resolve("jquery.tmpl.min.source.js")
-    assert_equal "file://#{fixture_path('default/manifest.js.yml')}?type=text/yaml&pipeline=source",
+    assert_equal "file://#{fixture_path_for_uri('default/manifest.js.yml')}?type=text/yaml&pipeline=source",
       resolve('manifest.js.source.yml')
   end
 
   test "verify all logical paths" do
     Dir.entries(Sprockets::TestCase::FIXTURE_ROOT).each do |dir|
       unless %w( . ..).include?(dir)
-        @env.append_path(fixture_path(dir))
+        @env.append_path(fixture_path_for_uri(dir))
       end
     end
 
@@ -245,7 +245,7 @@ class TestResolve < Sprockets::TestCase
   end
 
   test "legacy logical path iterator with matchers" do
-    @env.append_path(fixture_path('default'))
+    @env.append_path(fixture_path_for_uri('default'))
 
     assert_equal ["application.js", "gallery.css"],
       @env.each_logical_path("application.js", /gallery\.css/).to_a

--- a/test/test_uri_tar.rb
+++ b/test/test_uri_tar.rb
@@ -10,6 +10,8 @@ class TestURITar < Sprockets::TestCase
   end
 
   test "works with nix" do
+    skip "Only runs on nix" if File::ALT_SEPARATOR
+
     uri = "/Sites/sprockets/test/fixtures/paths/application.css?type=text/css"
     @fake_env.root = "/Different/path"
     tar = Sprockets::URITar.new(uri, @fake_env)

--- a/test/test_uri_tar.rb
+++ b/test/test_uri_tar.rb
@@ -23,7 +23,7 @@ class TestURITar < Sprockets::TestCase
     @fake_env.root = "/Sites/sprockets"
     tar = Sprockets::URITar.new(uri, @fake_env)
     assert_equal uri, tar.expand
-    assert_equal Sprockets::URITar.new(tar.expand, @fake_env).expand, tar.expand
+    assert_equal Sprockets::URITar.new(tar.compress, @fake_env).expand, uri
     assert_equal "test/fixtures/paths/application.css?type=text/css", tar.compressed_path
     assert_equal "file://test/fixtures/paths/application.css?type=text/css", tar.compress
     assert_equal Sprockets::URITar.new(tar.compress, @fake_env).compress, tar.compress
@@ -51,7 +51,7 @@ class TestURITar < Sprockets::TestCase
     @fake_env.root = "C:/Sites/sprockets"
     tar = Sprockets::URITar.new(uri, @fake_env)
     assert_equal uri, tar.expand
-    assert_equal Sprockets::URITar.new(tar.expand, @fake_env).expand, tar.expand
+    assert_equal Sprockets::URITar.new(tar.compress, @fake_env).expand, uri
     assert_equal "test/fixtures/paths/application.css?type=text/css", tar.compressed_path
     assert_equal "file://test/fixtures/paths/application.css?type=text/css", tar.compress
     assert_equal Sprockets::URITar.new(tar.compress, @fake_env).compress, tar.compress

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -102,10 +102,12 @@ class TestUtils < MiniTest::Test
   def test_concat_javascript_sources
     assert_equal "var foo;\n", concat_javascript_sources("", "var foo;\n".freeze)
     assert_equal "\nvar foo;\n", concat_javascript_sources("\n", "var foo;\n".freeze)
-    assert_equal " var foo;\n", concat_javascript_sources(" ", "var foo;\n".freeze)
+    assert_equal " \nvar foo;\n", concat_javascript_sources(" ", "var foo;\n".freeze)
 
     assert_equal "var foo;\nvar bar;\n", concat_javascript_sources("var foo;\n", "var bar;\n".freeze)
     assert_equal "var foo;\nvar bar", concat_javascript_sources("var foo", "var bar".freeze)
+    assert_equal "var foo;\nvar bar;", concat_javascript_sources("var foo;", "var bar;".freeze)
+    assert_equal "var foo;\nvar bar;", concat_javascript_sources("var foo", "var bar;".freeze)
   end
 
   def test_post_order_depth_first_search


### PR DESCRIPTION
Allow to skip generation gzip file for specific file

If you specific preprocessor for images
```
        app.config.assets.configure do |env|
          env.register_preprocessor 'image/png', :image_optim, ImageOptim::ImageOptimProcessor
        end
```
then sprocket generate gzip file for image which doesn't make sence because png file was already optimized

when we add skip_gzip: true in the processor return and sproket will skip gzip generation 