### PR TITLE
Skip GZip generation depend on specific file parameters

### DIFF
--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -195,6 +195,7 @@ module Sprockets
         filenames << asset.filename
 
         next if environment.skip_gzip?
+        next if asset.metadata[:skip_gzip]
         gzip = Utils::Gzip.new(asset)
         next if gzip.cannot_compress?(environment.mime_types)
 


### PR DESCRIPTION
Allow to skip generation gzip file for specific file

If you specific preprocessor for images

        app.config.assets.configure do |env|
          env.register_preprocessor 'image/png', :image_optim, ImageOptim::ImageOptimProcessor
        end

then sprocket generate gzip file for image which doesn't make sence because png file was already optimized

when we add skip_gzip: true in the processor return and sproket will skip gzip generation
