### PR TITLE
Freeze string matching to '*', allocating objects

### DIFF
--- a/lib/sprockets/http_utils.rb
+++ b/lib/sprockets/http_utils.rb
@@ -15,7 +15,7 @@ module Sprockets
     def match_mime_type?(value, matcher)
       v1, v2 = value.split('/'.freeze, 2)
       m1, m2 = matcher.split('/'.freeze, 2)
-      (m1 == '*' || v1 == m1) && (m2.nil? || m2 == '*' || m2 == v2)
+      (m1 == '*'.freeze || v1 == m1) && (m2.nil? || m2 == '*'.freeze || m2 == v2)
     end
 
     # Public: Return values from Hash where the key matches the mime type.

--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -110,7 +110,7 @@ module Sprockets
     # subpath is outside of path.
     def split_subpath(path, subpath)
       return "" if path == subpath
-      path = File.join(path, '')
+      path = File.join(path, ''.freeze)
       if subpath.start_with?(path)
         subpath[path.length..-1]
       else


### PR DESCRIPTION
Derailed output, before this-

```

$ TEST_COUNT=100 bundle exec derailed exec perf:objects
....
   7500  /path/to/sprockets/lib/sprockets/http_utils.rb:18
....
```

r? @schneems 