### PR TITLE
Merge `load_paths` configuration option on sass processors.

### DIFF
--- a/lib/sprockets/sass_processor.rb
+++ b/lib/sprockets/sass_processor.rb
@@ -58,7 +58,7 @@ module Sprockets
     def call(input)
       context = input[:environment].context_class.new(input)
 
-      engine_options = {
+      engine_options = merge_options({
         filename: input[:filename],
         syntax: self.class.syntax,
         cache_store: build_cache_store(input, @cache_version),
@@ -69,7 +69,7 @@ module Sprockets
           environment: input[:environment],
           dependencies: context.metadata[:dependencies]
         }
-      }.merge!(@sass_config)
+      })
 
       engine = Autoload::Sass::Engine.new(input[:data], engine_options)
 
@@ -105,6 +105,18 @@ module Sprockets
       CacheStore.new(input[:cache], version)
     end
     private :build_cache_store
+
+    def merge_options(options)
+      defaults = @sass_config.dup
+
+      if load_paths = defaults.delete(:load_paths)
+        options[:load_paths] += load_paths
+      end
+
+      options.merge!(defaults)
+      options
+    end
+    private :merge_options
 
     # Public: Functions injected into Sass context during Sprockets evaluation.
     #

--- a/lib/sprockets/sassc_processor.rb
+++ b/lib/sprockets/sassc_processor.rb
@@ -43,7 +43,7 @@ module Sprockets
     end
 
     def engine_options(input, context)
-      {
+      merge_options({
         filename: input[:filename],
         syntax: self.class.syntax,
         load_paths: input[:environment].paths,
@@ -55,7 +55,7 @@ module Sprockets
           environment: input[:environment],
           dependencies: context.metadata[:dependencies]
         }
-      }.merge!(@sass_config)
+      })
     end
   end
 


### PR DESCRIPTION
`sass-rails` sets an empty `Array` on this option, which replaces the default option that references the environment paths.

Based on https://github.com/rails/sprockets/pull/208#discussion_r49736792

I couldn't figure out how to write a test for this on the sprockets test suite (as all sass related tests are integration tests that rely on a full env with the default settings), but it fixes the `@import` related failures on `sass-rails`.