### PR TITLE
Fix stubbing of Zlib::GzipWriter with expected args

### DIFF
--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -550,8 +550,9 @@ class TestManifest < Sprockets::TestCase
 
   test 'raises exception when gzip fails' do
     manifest = Sprockets::Manifest.new(@env, @dir)
-    Zlib::GzipWriter.stub(:new, -> { fail 'kaboom' }) do
-      assert_raises('kaboom') { manifest.compile('application.js') }
+    Zlib::GzipWriter.stub(:new, -> (io, level) { fail 'kaboom' }) do
+      ex = assert_raises(RuntimeError) { manifest.compile('application.js') }
+      assert_equal 'kaboom', ex.message
     end
   end
 end


### PR DESCRIPTION
The manifest test for raising exceptions from Zlib::GzipWriter was
catching an ArgumentException from Ruby when the stubbing lambda
(that accepted no arguments) was called with the normal two.  This fixes
the test to assert the correct exception and message was raised.

Observed on minitest 5.4.3 where assert_raises let the ArgumentError
bubble up and fail the test.