### PR TITLE
Zopfli gzip

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -6,6 +6,8 @@ require 'sprockets/cache'
 require 'sprockets/environment'
 require 'sprockets/errors'
 require 'sprockets/manifest'
+require 'sprockets/utils/zlib_archiver'
+require 'sprockets/utils/zopfli_archiver'
 
 module Sprockets
   require 'sprockets/processor_utils'
@@ -35,7 +37,8 @@ module Sprockets
     root: __dir__.dup.freeze,
     transformers: Hash.new { |h, k| {}.freeze }.freeze,
     version: "",
-    gzip_enabled: true
+    gzip_enabled: true,
+    gzip_compressor: Sprockets::Utils::ZlibArchiver
   }.freeze
 
   @context_class = Context

--- a/lib/sprockets/autoload.rb
+++ b/lib/sprockets/autoload.rb
@@ -11,5 +11,6 @@ module Sprockets
     autoload :SassC, 'sprockets/autoload/sassc'
     autoload :Uglifier, 'sprockets/autoload/uglifier'
     autoload :YUI, 'sprockets/autoload/yui'
+    autoload :Zopfli, 'sprockets/autoload/zopfli'
   end
 end

--- a/lib/sprockets/autoload/zopfli.rb
+++ b/lib/sprockets/autoload/zopfli.rb
@@ -1,0 +1,7 @@
+require 'zopfli'
+
+module Sprockets
+  module Autoload
+    Zopfli = ::Zopfli
+  end
+end

--- a/lib/sprockets/compressing.rb
+++ b/lib/sprockets/compressing.rb
@@ -109,5 +109,17 @@ module Sprockets
     def gzip=(gzip)
       self.config = config.merge(gzip_enabled: gzip).freeze
     end
+
+    def gzip_compressor
+      config[:gzip_compressor]
+    end
+
+    def gzip_compressor=(value)
+      if value.respond_to?(:call)
+        self.config = config.merge(gzip_compressor: value).freeze
+      else
+        raise(Error, "gzip compressor #{value} must respond to call method")
+      end
+    end
   end
 end

--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -190,7 +190,7 @@ module Sprockets
         filenames << asset.filename
 
         next if environment.skip_gzip?
-        gzip = Utils::Gzip.new(asset)
+        gzip = Utils::Gzip.new(asset, environment.gzip_compressor)
         next if gzip.cannot_compress?(environment.mime_types)
 
         if File.exist?("#{target}.gz")

--- a/lib/sprockets/utils/zlib_archiver.rb
+++ b/lib/sprockets/utils/zlib_archiver.rb
@@ -1,0 +1,19 @@
+module Sprockets
+  module Utils
+    class ZlibArchiver
+
+      # Private:
+      # Compress the target source to file
+      #
+      # Returns nothing.
+      def self.call(file, source, mtime)
+        gz = Zlib::GzipWriter.new(file, Zlib::BEST_COMPRESSION)
+        gz.mtime = mtime
+        gz.write(source)
+        gz.close
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/sprockets/utils/zopfli_archiver.rb
+++ b/lib/sprockets/utils/zopfli_archiver.rb
@@ -1,0 +1,20 @@
+require 'sprockets/autoload'
+
+module Sprockets
+  module Utils
+    class ZopfliArchiver
+
+      # Private:
+      # Compress the target source to file
+      #
+      # Returns nothing.
+      def self.call(file, source, mtime)
+        file.write Autoload::Zopfli.deflate source, format: :gzip, mtime: mtime
+        file.close
+
+        nil
+      end
+
+    end
+  end
+end

--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sassc", "~> 1.7"
   s.add_development_dependency "uglifier", "~> 2.3"
   s.add_development_dependency "yui-compressor", "~> 0.12"
+  s.add_development_dependency "zopfli", "~> 0.0.4"
 
   s.required_ruby_version = '>= 2.0.0'
 


### PR DESCRIPTION
Can you please have a look at this propose: 

After reading http://blog.codinghorror.com/zopfli-optimization-literally-free-bandwidth/ this article, I've started experimenting with zopfli gzip optimization. 

and I have this parameters: 

Zopfli gzip:
````
real	7m58.097s
user	7m48.060s
sys	0m7.475s


17 228 872 B, objects count: 1 383
3 883 929 B, objects count: 626 (only gz files)
````

Normal gzip
````
real	6m54.173s
user	6m47.092s
sys	0m5.910s

17 357 756 B, objects count: 1 383
4 012 813 B, objects count: 626 (only gz files)
````

So we have 3,31% size improvment, but this takes about 14% longer to compile
I don't add zopfli as default archiver but if you want, you'll be able to process gz, using zopfli archiver. 