### PR TITLE
DOCUMENTATION: Attribute require behavior to Node.js, not npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Below is a disjointed mix of documentation for all three of these roles. Eventua
 
 ### Index files are proxies for folders
 
-In Sprockets index files such as `index.js` or `index.css` files inside of a folder will generate a file with the folder's name. So if you have a `foo/index.js` file it will compile down to `foo.js`. This is similar to NPM's behavior of using [folders as modules](https://nodejs.org/api/modules.html#modules_folders_as_modules). It is also somewhat similar to the way that a file in `public/my_folder/index.html` can be reached by a request to `/my_folder`. This means that you cannot directly use an index file. For example this would not work:
+In Sprockets index files such as `index.js` or `index.css` files inside of a folder will generate a file with the folder's name. So if you have a `foo/index.js` file it will compile down to `foo.js`. This is similar to Node.js's behavior of using [folders as modules](https://nodejs.org/api/modules.html#modules_folders_as_modules). It is also somewhat similar to the way that a file in `public/my_folder/index.html` can be reached by a request to `/my_folder`. This means that you cannot directly use an index file. For example this would not work:
 
 ```
 <%= asset_path("foo/index.js") %>


### PR DESCRIPTION
The distinction between the two can be a little hairy (just like with Ruby & Rubygems), but this is behavior implemented in Node core, not npm per se.