### PR TITLE
[close #233] Allow to register new archivers to make some compressions to asset file

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -36,8 +36,7 @@ module Sprockets
     root: __dir__.dup.freeze,
     transformers: Hash.new { |h, k| {}.freeze }.freeze,
     archivers: Hash.new { |h, k| {}.freeze }.freeze,
-    version: "",
-    gzip_enabled: true
+    version: ""
   }.freeze
 
   @context_class = Context

--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -6,6 +6,7 @@ require 'sprockets/cache'
 require 'sprockets/environment'
 require 'sprockets/errors'
 require 'sprockets/manifest'
+require 'sprockets/utils/zlib'
 
 module Sprockets
   require 'sprockets/processor_utils'
@@ -34,6 +35,7 @@ module Sprockets
     registered_transformers: [].freeze,
     root: __dir__.dup.freeze,
     transformers: Hash.new { |h, k| {}.freeze }.freeze,
+    archivers: Hash.new { |h, k| {}.freeze }.freeze,
     version: "",
     gzip_enabled: true
   }.freeze
@@ -217,4 +219,7 @@ module Sprockets
 
   depend_on 'environment-version'
   depend_on 'environment-paths'
+
+  #GZIP
+  register_archiver :gzip, Utils::Zlib
 end

--- a/lib/sprockets/archiving.rb
+++ b/lib/sprockets/archiving.rb
@@ -1,0 +1,72 @@
+require 'sprockets/http_utils'
+require 'sprockets/processor_utils'
+require 'sprockets/utils'
+
+module Sprockets
+  module Archiving
+    include Utils
+
+    def archivers
+      config[:archivers]
+    end
+
+    # Public: Register archiver, it has to respond to 3 methods
+    # type can be any symbol
+    #
+    # register_archiver :gzip, Utils::Zlib 
+    #
+    # will register Zlib compression for text file, 
+    # we dont use myme_types here, because different mime_type 
+    # can be compressed by one archiver (text/stylesheets, text/javascript, etc)
+    def register_archiver type, archiver
+      if archiver.is_a?( Class )
+        klass = archiver
+      else
+        raise(Error, "archiver is'n a class: #{archiver}")
+      end
+
+      self.config = hash_reassoc(config, :archivers) do |archivers|
+        archivers[type] = klass
+        archivers
+      end
+    end
+
+    def unregister_archiver type
+      self.config = hash_reassoc(config, :archivers) do |archivers|
+        archivers.delete(type)
+        archivers
+      end
+    end
+
+    # Public: Checks if Gzip is enabled.
+    def gzip?
+      config[:gzip_enabled]
+    end
+
+    # Public: Checks if Gzip is disabled.
+    def skip_gzip?
+      !gzip?
+    end
+
+    # Public: Enable or disable the creation of Gzip files.
+    #
+    # Defaults to true.
+    #
+    #     environment.gzip = false
+    #
+    def gzip=(gzip)
+      self.config = config.merge(gzip_enabled: gzip).freeze
+    end
+
+    # Public: Get list of archivers which is active
+    def active_archivers
+      archivers = []
+      config[:archivers].each do |sym, archiver|
+        is_active = !archiver.nil?
+        is_active = gzip? ? true : false if sym == :gzip
+        archivers << archiver if is_active
+      end
+      archivers
+    end
+  end
+end

--- a/lib/sprockets/archiving.rb
+++ b/lib/sprockets/archiving.rb
@@ -38,13 +38,34 @@ module Sprockets
       end
     end
 
+    # Public: Checks if archiver is enabled.
+    def archiver_enabled? type
+      archiver = archivers[type]
+      if archiver.nil?
+        false
+      else
+        if type == :gzip
+          config[:gzip_enabled] ? true : false
+        else
+          true
+        end
+      end
+    end
+
+    # Public: Checks if archiver is disabled.
+    def skip_archiver? type
+      !archiver_enabled?
+    end
+
     # Public: Checks if Gzip is enabled.
     def gzip?
+      warn "gzip? method is deprecated. Use archiver_enabled?(:gzip) to check if gzip is enabled"
       config[:gzip_enabled]
     end
 
     # Public: Checks if Gzip is disabled.
     def skip_gzip?
+      warn "skip_gzip? method is deprecated. Use skip_archiver?(:gzip) to check if gzip is disabled"
       !gzip?
     end
 
@@ -60,13 +81,11 @@ module Sprockets
 
     # Public: Get list of archivers which is active
     def active_archivers
-      archivers = []
-      config[:archivers].each do |sym, archiver|
-        is_active = !archiver.nil?
-        is_active = gzip? ? true : false if sym == :gzip
-        archivers << archiver if is_active
+      result = []
+      archivers.each do |sym, archiver|
+        result << archiver if archiver_enabled?( sym )
       end
-      archivers
+      result
     end
   end
 end

--- a/lib/sprockets/compressing.rb
+++ b/lib/sprockets/compressing.rb
@@ -90,24 +90,5 @@ module Sprockets
       register_bundle_processor 'application/javascript', klass
     end
 
-    # Public: Checks if Gzip is enabled.
-    def gzip?
-      config[:gzip_enabled]
-    end
-
-    # Public: Checks if Gzip is disabled.
-    def skip_gzip?
-      !gzip?
-    end
-
-    # Public: Enable or disable the creation of Gzip files.
-    #
-    # Defaults to true.
-    #
-    #     environment.gzip = false
-    #
-    def gzip=(gzip)
-      self.config = config.merge(gzip_enabled: gzip).freeze
-    end
   end
 end

--- a/lib/sprockets/configuration.rb
+++ b/lib/sprockets/configuration.rb
@@ -5,11 +5,13 @@ require 'sprockets/mime'
 require 'sprockets/paths'
 require 'sprockets/processing'
 require 'sprockets/transformers'
+require 'sprockets/archiving'
 require 'sprockets/utils'
 
 module Sprockets
   module Configuration
-    include Paths, Mime, Transformers, Processing, Compressing, Dependencies, Utils
+
+    include Paths, Mime, Transformers, Processing, Compressing, Archiving, Dependencies, Utils
 
     def initialize_configuration(parent)
       @config = parent.config

--- a/lib/sprockets/utils/zlib.rb
+++ b/lib/sprockets/utils/zlib.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 module Sprockets
   module Utils
-    class Gzip
+    class Zlib
       # Private: Generates a gzipped file based off of reference file.
-      def initialize(asset)
+      def initialize(asset, target)
         @content_type  = asset.content_type
         @source        = asset.source
         @charset       = asset.charset
+        @target        = target
+        @result_filename = "#{target}.gz"
       end
 
       # What non-text mime types should we compress? This list comes from:
@@ -50,10 +52,10 @@ module Sprockets
       # Does not modify the target asset.
       #
       # Returns nothing.
-      def compress(target)
-        mtime = PathUtils.stat(target).mtime
-        PathUtils.atomic_write("#{target}.gz") do |f|
-          gz = Zlib::GzipWriter.new(f, Zlib::BEST_COMPRESSION)
+      def compress
+        mtime = PathUtils.stat(@target).mtime
+        PathUtils.atomic_write( result_filename ) do |f|
+          gz = ::Zlib::GzipWriter.new(f, ::Zlib::BEST_COMPRESSION)
           gz.mtime = mtime
           gz.write(@source)
           gz.close
@@ -62,6 +64,10 @@ module Sprockets
         end
 
         nil
+      end
+
+      def result_filename
+        @result_filename
       end
     end
   end

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -516,7 +516,7 @@ class TestEnvironment < Sprockets::TestCase
   end
 
   test "default gzip" do
-    assert_equal true, @env.gzip?
+    assert_equal true, @env.archiver_enabled?(:gzip)
   end
 
   test "change jst template namespace" do
@@ -790,7 +790,7 @@ class TestCachedEnvironment < Sprockets::TestCase
   end
 
   test "inherit the gzip option" do
-    assert_equal false, @env.gzip?
+    assert_equal false, @env.archiver_enabled?(:gzip)
   end
 
   test "does not allow to change the gzip option" do


### PR DESCRIPTION
This commit allow to register new archiver. 

Can easily replace existing gzip implementation to zopfli (as it show in the #233 it can give about 3% space compressing) 

Allow to add new archivers such as generate .webp image format for chrome or JPEG-XR for IE, that will help to reduce image size for that browsers)

We can't use it as preprocessor/postprocessor because not all browsers support this format, but will help for precompiled assets, it will compile longer but will reduce overall site size. 