### PR TITLE
Fix a broken link in the documentation

### DIFF
--- a/guides/building_an_asset_processing_framework.md
+++ b/guides/building_an_asset_processing_framework.md
@@ -1,6 +1,6 @@
 # Building an Asset Processing Framework
 
-This guide is for using a Sprockets::Environment to process assets. You would use this class directly if you were building a feature similar to Rail's asset pipeline. If you aren't building an asset processing frameworks, you will want to refer to the [End User Asset Generation](end_user_asset_generation.md) guide instead. For a reference use of `Sprockets::Environemnt` see [sprockets-rails](github.com/rails/Sprockets-rails).
+This guide is for using a Sprockets::Environment to process assets. You would use this class directly if you were building a feature similar to Rail's asset pipeline. If you aren't building an asset processing frameworks, you will want to refer to the [End User Asset Generation](end_user_asset_generation.md) guide instead. For a reference use of `Sprockets::Environemnt` see [sprockets-rails](http://github.com/rails/Sprockets-rails).
 
 ## Gzip
 


### PR DESCRIPTION
I noticed a URL was broken in the "Building an Asset Processing Framework" documentation—this fixes it.