### PR TITLE
Assorted Source Maps patches

### DIFF
--- a/lib/sprockets/babel_processor.rb
+++ b/lib/sprockets/babel_processor.rb
@@ -38,7 +38,8 @@ module Sprockets
           'sourceRoot' => input[:load_path],
           'moduleRoot' => nil,
           'filename' => input[:filename],
-          'filenameRelative' => PathUtils.split_subpath(input[:load_path], input[:filename])
+          'filenameRelative' => PathUtils.split_subpath(input[:load_path], input[:filename]),
+          'sourceFileName' => input[:source_path]
         }.merge(@options)
 
         if opts['moduleIds'] && opts['moduleRoot']

--- a/lib/sprockets/source_map_processor.rb
+++ b/lib/sprockets/source_map_processor.rb
@@ -29,7 +29,7 @@ module Sprockets
           path = source
         end
         uri, _ = env.resolve!(path)
-        links << env.load(uri).uri
+        links << uri
       end
 
       json = env.encode_json_source_map(map, filename: asset.logical_path)

--- a/test/fixtures/source-maps/sass/_imported.scss
+++ b/test/fixtures/source-maps/sass/_imported.scss
@@ -1,0 +1,1 @@
+body { color: red; }

--- a/test/fixtures/source-maps/sass/with-import.scss
+++ b/test/fixtures/source-maps/sass/with-import.scss
@@ -1,0 +1,3 @@
+@import 'imported';
+
+nav { color: blue; }

--- a/test/test_babel_processor.rb
+++ b/test/test_babel_processor.rb
@@ -10,7 +10,8 @@ class TestBabelProcessor < MiniTest::Test
       metadata: {},
       load_path: File.expand_path("../fixtures", __FILE__),
       filename: File.expand_path("../fixtures/mod.es6", __FILE__),
-      cache: Sprockets::Cache.new
+      cache: Sprockets::Cache.new,
+      source_path: "mod.source-XYZ.es6"
     }
 
     assert js = Sprockets::BabelProcessor.call(input)[:data]
@@ -25,7 +26,8 @@ class TestBabelProcessor < MiniTest::Test
       metadata: {},
       load_path: File.expand_path("../fixtures", __FILE__),
       filename: File.expand_path("../fixtures/mod.es6", __FILE__),
-      cache: Sprockets::Cache.new
+      cache: Sprockets::Cache.new,
+      source_path: "mod.source-XYZ.es6"
     }
 
     assert js = Sprockets::BabelProcessor.call(input)[:data]
@@ -43,7 +45,8 @@ var square = function square(n) {
       metadata: {},
       load_path: File.expand_path("../fixtures", __FILE__),
       filename: File.expand_path("../fixtures/mod.es6", __FILE__),
-      cache: Sprockets::Cache.new
+      cache: Sprockets::Cache.new,
+      source_path: "mod.source-XYZ.es6"
     }
 
     assert js = Sprockets::BabelProcessor.new('modules' => 'common').call(input)[:data]
@@ -59,7 +62,8 @@ require("foo");
       metadata: {},
       load_path: File.expand_path("../fixtures", __FILE__),
       filename: File.expand_path("../fixtures/mod.es6", __FILE__),
-      cache: Sprockets::Cache.new
+      cache: Sprockets::Cache.new,
+      source_path: "mod.source-XYZ.es6"
     }
 
     assert js = Sprockets::BabelProcessor.new('modules' => 'amd').call(input)[:data]
@@ -75,7 +79,8 @@ define(["exports", "foo"], function (exports, _foo) {});
       metadata: {},
       load_path: File.expand_path("../fixtures", __FILE__),
       filename: File.expand_path("../fixtures/mod.es6", __FILE__),
-      cache: Sprockets::Cache.new
+      cache: Sprockets::Cache.new,
+      source_path: "mod.source-XYZ.es6"
     }
 
     assert js = Sprockets::BabelProcessor.new('modules' => 'amd', 'moduleIds' => true).call(input)[:data]
@@ -91,7 +96,8 @@ define("mod", ["exports", "foo"], function (exports, _foo) {});
       metadata: {},
       load_path: File.expand_path("../fixtures", __FILE__),
       filename: File.expand_path("../fixtures/mod.es6", __FILE__),
-      cache: Sprockets::Cache.new
+      cache: Sprockets::Cache.new,
+      source_path: "mod.source-XYZ.es6"
     }
 
     assert js = Sprockets::BabelProcessor.new('modules' => 'system').call(input)[:data]
@@ -112,7 +118,8 @@ System.register(["foo"], function (_export) {
       metadata: {},
       load_path: File.expand_path("../fixtures", __FILE__),
       filename: File.expand_path("../fixtures/mod.es6", __FILE__),
-      cache: Sprockets::Cache.new
+      cache: Sprockets::Cache.new,
+      source_path: "mod.source-XYZ.es6"
     }
 
     assert js = Sprockets::BabelProcessor.new('modules' => 'system', 'moduleIds' => true).call(input)[:data]
@@ -133,7 +140,8 @@ System.register("mod", ["foo"], function (_export) {
       metadata: {},
       load_path: File.expand_path("../fixtures", __FILE__),
       filename: File.expand_path("../fixtures/mod1.es6", __FILE__),
-      cache: Sprockets::Cache.new
+      cache: Sprockets::Cache.new,
+      source_path: "mod1.source-XYZ.es6"
     }
 
     mod2 = mod1.dup

--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -158,7 +158,7 @@ class TestSourceMaps < Sprockets::TestCase
     assert_equal "sass/main.css.map", asset.logical_path
     assert_equal "application/css-sourcemap+json", asset.content_type
     assert_equal [
-      "file://#{fixture_path_for_uri('source-maps/sass/main.scss')}?type=text/scss"
+      "file://#{fixture_path_for_uri('source-maps/sass/main.scss')}?type=text/scss&pipeline=source"
     ], normalize_uris(asset.links)
 
     assert map = JSON.parse(asset.source)
@@ -166,7 +166,42 @@ class TestSourceMaps < Sprockets::TestCase
       "version" => 3,
       "file" => "sass/main.css",
       "mappings" => "AACE,MAAG;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI;AAGlB,MAAG;EAAE,OAAO,EAAE,YAAY;AAE1B,KAAE;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI",
-      "sources" => [fixture_path_for_uri('source-maps/sass/main.scss')],
+      "sources" => ["sass/main.source-86fe07ad89fecbab307d376bcadfa23d65ad108e3735b564510246b705f6ced1.scss"],
+      "names" => []
+    }, map)
+  end
+
+  test "compile scss source map with imported dependencies" do
+    asset = silence_warnings do
+      @env.find_asset("sass/with-import.css")
+    end
+    assert asset
+    assert_equal fixture_path('source-maps/sass/with-import.scss'), asset.filename
+    assert_equal "text/css", asset.content_type
+
+    assert_match "body {\n  color: red; }", asset.source
+
+    asset = silence_warnings do
+      @env.find_asset("sass/with-import.css.map")
+    end
+    assert asset
+    assert_equal fixture_path('source-maps/sass/with-import.scss'), asset.filename
+    assert_equal "sass/with-import.css.map", asset.logical_path
+    assert_equal "application/css-sourcemap+json", asset.content_type
+    assert_equal [
+      "file://#{fixture_path_for_uri('source-maps/sass/_imported.scss')}?type=text/scss&pipeline=source",
+      "file://#{fixture_path_for_uri('source-maps/sass/with-import.scss')}?type=text/scss&pipeline=source"
+    ], normalize_uris(asset.links)
+
+    assert map = JSON.parse(asset.source)
+    assert_equal({
+      "version" => 3,
+      "file" => "sass/with-import.css",
+      "mappings" => "AAAA,IAAK;EAAE,KAAK,EAAE,GAAG;;ACEjB,GAAI;EAAE,KAAK,EAAE,IAAI",
+      "sources" => [
+        "sass/_imported.source-9767e91e9d4b0334e59a1d389e9801bc6a2c5c4a5500a3c2c7915687965b2c16.scss",
+        "sass/with-import.source-5d53742ba113ac26396986bf14ab5c7e19ef193e494d5d868a9362e3e057cb26.scss"
+      ],
       "names" => []
     }, map)
   end

--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -63,7 +63,7 @@ class TestSourceMaps < Sprockets::TestCase
     assert_equal "coffee/main.js.map", asset.logical_path
     assert_equal "application/js-sourcemap+json", asset.content_type
     assert_equal [
-      "file://#{fixture_path_for_uri('source-maps/coffee/main.coffee')}?type=text/coffeescript&pipeline=source&id=xxx"
+      "file://#{fixture_path_for_uri('source-maps/coffee/main.coffee')}?type=text/coffeescript&pipeline=source"
     ], normalize_uris(asset.links)
 
     assert map = JSON.parse(asset.source)
@@ -108,7 +108,7 @@ class TestSourceMaps < Sprockets::TestCase
     assert_equal "babel/main.js.map", asset.logical_path
     assert_equal "application/js-sourcemap+json", asset.content_type
     assert_equal [
-      "file://#{fixture_path_for_uri('source-maps/babel/main.es6')}?type=application/ecmascript-6&pipeline=source&id=xxx"
+      "file://#{fixture_path_for_uri('source-maps/babel/main.es6')}?type=application/ecmascript-6&pipeline=source"
     ], normalize_uris(asset.links)
 
     assert map = JSON.parse(asset.source)
@@ -158,7 +158,7 @@ class TestSourceMaps < Sprockets::TestCase
     assert_equal "sass/main.css.map", asset.logical_path
     assert_equal "application/css-sourcemap+json", asset.content_type
     assert_equal [
-      "file://#{fixture_path_for_uri('source-maps/sass/main.scss')}?type=text/scss&id=xxx"
+      "file://#{fixture_path_for_uri('source-maps/sass/main.scss')}?type=text/scss"
     ], normalize_uris(asset.links)
 
     assert map = JSON.parse(asset.source)
@@ -226,7 +226,7 @@ class TestSasscSourceMaps < Sprockets::TestCase
     assert_equal "sass/main.css.map", asset.logical_path
     assert_equal "application/css-sourcemap+json", asset.content_type
     assert_equal [
-      "file://#{fixture_path('source-maps/sass/main.scss')}?type=text/scss&pipeline=source&id=xxx"
+      "file://#{fixture_path('source-maps/sass/main.scss')}?type=text/scss&pipeline=source"
     ], normalize_uris(asset.links)
 
     assert map = JSON.parse(asset.source)

--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -108,7 +108,7 @@ class TestSourceMaps < Sprockets::TestCase
     assert_equal "babel/main.js.map", asset.logical_path
     assert_equal "application/js-sourcemap+json", asset.content_type
     assert_equal [
-      "file://#{fixture_path_for_uri('source-maps/babel/main.es6')}?type=application/ecmascript-6&id=xxx"
+      "file://#{fixture_path_for_uri('source-maps/babel/main.es6')}?type=application/ecmascript-6&pipeline=source&id=xxx"
     ], normalize_uris(asset.links)
 
     assert map = JSON.parse(asset.source)
@@ -116,7 +116,7 @@ class TestSourceMaps < Sprockets::TestCase
       "version" => 3,
       "file" => "babel/main.js",
       "mappings" => ";;;;;;;;;;AACA,IAAI,IAAI,GAAG,KAAK,CAAC,GAAG,CAAC,UAAA,CAAC;SAAI,CAAC,GAAG,CAAC;CAAA,CAAC,CAAC;AACjC,IAAI,IAAI,GAAG,KAAK,CAAC,GAAG,CAAC,UAAC,CAAC,EAAE,CAAC;SAAK,CAAC,GAAG,CAAC;CAAA,CAAC,CAAC;;IAEhC,WAAW;YAAX,WAAW;;AACJ,WADP,WAAW,CACH,QAAQ,EAAE,SAAS,EAAE;0BAD7B,WAAW;;AAEb,+BAFE,WAAW,6CAEP,QAAQ,EAAE,SAAS,EAAE;GAE5B;;eAJG,WAAW;;WAKT,gBAAC,MAAM,EAAE;AACb,iCANE,WAAW,wCAME;KAChB;;;WACmB,yBAAG;AACrB,aAAO,IAAI,KAAK,CAAC,OAAO,EAAE,CAAC;KAC5B;;;SAVG,WAAW;GAAS,KAAK,CAAC,IAAI;;AAapC,IAAI,SAAS,uBACV,MAAM,CAAC,QAAQ,0BAAG;MACb,GAAG,EAAM,GAAG,EAEV,IAAI;;;;AAFN,WAAG,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC;;;AAEd,YAAI,GAAG,GAAG;;AACd,WAAG,GAAG,GAAG,CAAC;AACV,WAAG,IAAI,IAAI,CAAC;;eACN,GAAG;;;;;;;;;;;CAEZ,EACF,CAAA",
-      "sources"  => ["babel/main.es6"],
+      "sources" => ["babel/main.source-1acb9cf16a3e1ce0fe0a38491472a14a6a97281ceace4b67ec16a904be5fa1b9.es6"],
       "names"=>[]
     }, map)
   end


### PR DESCRIPTION
This Pull Request contains 3 slightly related patches to the Source Maps support related to Babel/Sass assets.

* 4da21144bb9bed8e73c16ead2b2e0eb225f142be - Fixes the `source` path on source maps from the `BabelProcessor` so the browser can request the asset original source, replacing the relative path that was used before.
* 6ce8690eff945bd4a8a949193e79404ab267d7e7 - Skip processing each `source` when processing the source map. This was causing issues on my app where Sprockets was getting lost on trying to load `.css` files as `.scss` ones - considering that the `SourceMapProcessor` already has the `link` value for each source, we can use it instead of (re)loading the file.
* 34de4ea104ebdacc47b4a443e5cab82dce5af2c2 - Similar to the Babel related fix, but for Sass `@import`ed files (the `source` value ends up being the absolute path for each stylesheet that was imported). I'm not 100% happy with calling `resolve!` + `load` inside the processor, but was the only way to transform the absolute file path into the source path I could think of. This patch can be easily test on a public app like [Code Triage](http://github.com/codetriage/codetriage) by inspecting the loaded sources. I haven't tested if the same happens with the Sassc processor, but we can duplicate the test case and see how it goes. 

Let me know what makes sense/doesn't make sense of these patches, I can remove/rework any of those commits as we need. 

I still believe that the source maps support here isn't 100%, as some of my exploratory tests on Google Chrome has showed some mismatches between the source contents and the positions reported by the console, but I don't have enough experience on Source Maps to rule this as an issue with the generated map or with the browser support - but I think those patches are a step forward on this.

Thanks @rafaelfranca for walking through and explaining the current implementation when debugging the first two patches with me yesterday :heart:.