### PR TITLE
add Sprockets::Cache#clear method, clear cache on Manifest#clobber

### DIFF
--- a/lib/sprockets/cache/file_store.rb
+++ b/lib/sprockets/cache/file_store.rb
@@ -20,7 +20,8 @@ module Sprockets
     class FileStore
       # Internal: Default key limit for store.
       DEFAULT_MAX_SIZE = 25 * 1024 * 1024
-
+      EXCLUDED_DIRS = ['.', '..'].freeze
+      GITKEEP_FILES = ['.gitkeep', '.keep'].freeze
       # Internal: Default standard error fatal logger.
       #
       # Returns a Logger.
@@ -121,6 +122,21 @@ module Sprockets
       # Returns String.
       def inspect
         "#<#{self.class} size=#{size}/#{@max_size}>"
+      end
+
+      # Public: Clear the cache
+      #
+      # adapted from ActiveSupport::Cache::FileStore#clear
+      #
+      # Deletes all items from the cache. In this case it deletes all the entries in the specified
+      # file store directory except for .keep or .gitkeep. Be careful which directory is specified
+      # as @root because everything in that directory will be deleted.
+      #
+      # Returns true
+      def clear(options=nil)
+        root_dirs = Dir.entries(@root).reject { |f| (EXCLUDED_DIRS + GITKEEP_FILES).include?(f) }
+        FileUtils.rm_r(root_dirs.collect{ |f| File.join(@root, f) })
+        true
       end
 
       private

--- a/lib/sprockets/cache/memory_store.rb
+++ b/lib/sprockets/cache/memory_store.rb
@@ -62,6 +62,14 @@ module Sprockets
       def inspect
         "#<#{self.class} size=#{@cache.size}/#{@max_size}>"
       end
+
+      # Public: Clear the cache
+      #
+      # Returns true
+      def clear(options=nil)
+        @cache.clear
+        true
+      end
     end
   end
 end

--- a/lib/sprockets/cache/null_store.rb
+++ b/lib/sprockets/cache/null_store.rb
@@ -42,6 +42,13 @@ module Sprockets
       def inspect
         "#<#{self.class}>"
       end
+
+      # Public: Simulate clearing the cache
+      #
+      # Returns true
+      def clear(options=nil)
+        true
+      end
     end
   end
 end

--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -265,6 +265,8 @@ module Sprockets
     def clobber
       FileUtils.rm_r(directory) if File.exist?(directory)
       logger.info "Removed #{directory}"
+      # if we have an environment clear the cache too
+      environment.cache.clear if environment
       nil
     end
 

--- a/test/test_cache_store.rb
+++ b/test/test_cache_store.rb
@@ -26,6 +26,11 @@ module CacheStoreNullTests
     result = @store.fetch("foo") { "bar" }
     assert_equal "bar", result
   end
+
+  def test_clear
+    result = @store.clear
+    assert result, "@store.clear returned #{result} instead of true"
+  end
 end
 
 module CacheStoreTests
@@ -69,6 +74,14 @@ module CacheStoreTests
   def test_fetch
     result = @store.fetch("user") { "josh" }
     assert_equal "josh", result
+  end
+
+  def test_clear
+    @store.set("foo", "bar")
+    assert_equal "bar", @store.get("foo")
+    result = @store.clear
+    assert result, "@store.clear returned #{result} instead of true"
+    assert_equal nil, @store.get("foo")
   end
 end
 

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -50,9 +50,15 @@ class TestRakeTask < Sprockets::TestCase
 
     @rake[:assets].invoke
     assert File.exist?("#{@dir}/#{digest_path}")
+    # set a cache key
+    result = @env.cache.set('foo', 'bar')
+    assert_equal result, @env.cache.get('foo')
 
     @rake[:clobber_assets].invoke
     assert !File.exist?("#{@dir}/#{digest_path}")
+    # verify the cache key was cleared
+    assert_equal @env.cache.get('foo'), nil
+
   end
 
   test "custom manifest directory" do


### PR DESCRIPTION
this adds `#clear` to `Sprockets::Cache` and all associated stores (see #248) and clears our our cache on `Manifiest#clobber` (see rails/sprockets-rails#326). 

currently if the underlying cache store's `#clear` call fails and raises an exception i catch it and just return false - should i let the exception propagate instead?
