### PR TITLE
Deprecation Branch for 3.X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ doc
 docs
 pkg
 tmp
+.DS_Store

--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -124,7 +124,7 @@ module Sprockets
   # Mmm, CoffeeScript
   require 'sprockets/coffee_script_processor'
   Deprecation.silence do
-    register_engine '.coffee', CoffeeScriptProcessor, mime_type: 'application/javascript'
+    register_engine '.coffee', CoffeeScriptProcessor, mime_type: 'application/javascript', silence_deprecation: true
   end
 
   # JST engines
@@ -132,24 +132,22 @@ module Sprockets
   require 'sprockets/ejs_processor'
   require 'sprockets/jst_processor'
   Deprecation.silence do
-    register_engine '.jst', JstProcessor, mime_type: 'application/javascript'
-    register_engine '.eco', EcoProcessor, mime_type: 'application/javascript'
-    register_engine '.ejs', EjsProcessor, mime_type: 'application/javascript'
+    register_engine '.jst', JstProcessor, mime_type: 'application/javascript', silence_deprecation: true
+    register_engine '.eco', EcoProcessor, mime_type: 'application/javascript', silence_deprecation: true
+    register_engine '.ejs', EjsProcessor, mime_type: 'application/javascript', silence_deprecation: true
   end
 
   # CSS engines
   require 'sprockets/sass_processor'
   Deprecation.silence do
-    register_engine '.sass', SassProcessor, mime_type: 'text/css'
-    register_engine '.scss', ScssProcessor, mime_type: 'text/css'
+    register_engine '.sass', SassProcessor, mime_type: 'text/css', silence_deprecation: true
+    register_engine '.scss', ScssProcessor, mime_type: 'text/css', silence_deprecation: true
   end
   register_bundle_metadata_reducer 'text/css', :sass_dependencies, Set.new, :+
 
   # Other
   require 'sprockets/erb_processor'
-  Deprecation.silence do
-    register_engine '.erb', ERBProcessor, mime_type: 'text/plain'
-  end
+  register_engine '.erb', ERBProcessor, mime_type: 'text/plain', silence_deprecation: true
 
   register_dependency_resolver 'environment-version' do |env|
     env.version

--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -123,25 +123,33 @@ module Sprockets
 
   # Mmm, CoffeeScript
   require 'sprockets/coffee_script_processor'
-  register_engine '.coffee', CoffeeScriptProcessor, mime_type: 'application/javascript'
+  Deprecation.silence do
+    register_engine '.coffee', CoffeeScriptProcessor, mime_type: 'application/javascript'
+  end
 
   # JST engines
   require 'sprockets/eco_processor'
   require 'sprockets/ejs_processor'
   require 'sprockets/jst_processor'
-  register_engine '.jst', JstProcessor, mime_type: 'application/javascript'
-  register_engine '.eco', EcoProcessor, mime_type: 'application/javascript'
-  register_engine '.ejs', EjsProcessor, mime_type: 'application/javascript'
+  Deprecation.silence do
+    register_engine '.jst', JstProcessor, mime_type: 'application/javascript'
+    register_engine '.eco', EcoProcessor, mime_type: 'application/javascript'
+    register_engine '.ejs', EjsProcessor, mime_type: 'application/javascript'
+  end
 
   # CSS engines
   require 'sprockets/sass_processor'
-  register_engine '.sass', SassProcessor, mime_type: 'text/css'
-  register_engine '.scss', ScssProcessor, mime_type: 'text/css'
+  Deprecation.silence do
+    register_engine '.sass', SassProcessor, mime_type: 'text/css'
+    register_engine '.scss', ScssProcessor, mime_type: 'text/css'
+  end
   register_bundle_metadata_reducer 'text/css', :sass_dependencies, Set.new, :+
 
   # Other
   require 'sprockets/erb_processor'
-  register_engine '.erb', ERBProcessor, mime_type: 'text/plain'
+  Deprecation.silence do
+    register_engine '.erb', ERBProcessor, mime_type: 'text/plain'
+  end
 
   register_dependency_resolver 'environment-version' do |env|
     env.version

--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -4,6 +4,7 @@ require 'sprockets/cache'
 require 'sprockets/environment'
 require 'sprockets/errors'
 require 'sprockets/manifest'
+require 'sprockets/deprecation'
 
 module Sprockets
   require 'sprockets/processor_utils'

--- a/lib/sprockets/coffee_script_template.rb
+++ b/lib/sprockets/coffee_script_template.rb
@@ -2,5 +2,16 @@ require 'sprockets/coffee_script_processor'
 
 module Sprockets
   # Deprecated
-  CoffeeScriptTemplate = CoffeeScriptProcessor
+  module CoffeeScriptTemplate
+    VERSION = CoffeeScriptProcessor::VERSION
+
+    def self.cache_key
+      CoffeeScriptProcessor.cache_key
+    end
+
+    def self.call(*args)
+      Sprockets::Deprecation.new.warn "CoffeeScriptTemplate is deprecated please use CoffeeScriptProcessor instead"
+      CoffeeScriptProcessor.call(*args)
+    end
+  end
 end

--- a/lib/sprockets/coffee_script_template.rb
+++ b/lib/sprockets/coffee_script_template.rb
@@ -10,7 +10,7 @@ module Sprockets
     end
 
     def self.call(*args)
-      Sprockets::Deprecation.new.warn "CoffeeScriptTemplate is deprecated please use CoffeeScriptProcessor instead"
+      Deprecation.new.warn "CoffeeScriptTemplate is deprecated please use CoffeeScriptProcessor instead"
       CoffeeScriptProcessor.call(*args)
     end
   end

--- a/lib/sprockets/deprecation.rb
+++ b/lib/sprockets/deprecation.rb
@@ -1,0 +1,57 @@
+module Sprockets
+  class Deprecation
+
+    attr_reader :callstack
+
+    def initialize(callstack = nil)
+      @callstack = callstack || caller_locations(2)
+    end
+
+    def warn(message)
+      deprecation_message(message).tap do |m|
+        behavior.each { |b| b.call(m, callstack) }
+      end
+    end
+
+    private
+      def deprecation_message(message = nil)
+        message ||= "You are using deprecated behavior which will be removed from the next major or minor release."
+        "DEPRECATION WARNING: #{message} #{ deprecation_caller_message }"
+      end
+
+      def deprecation_caller_message
+        file, line, method = extract_callstack(callstack)
+        if file
+          if line && method
+            "(called from #{method} at #{file}:#{line})"
+          else
+            "(called from #{file}:#{line})"
+          end
+        end
+      end
+
+      def extract_callstack
+        return _extract_callstack if callstack.first.is_a? String
+
+        offending_line = callstack.find { |frame|
+          frame.absolute_path && !ignored_callstack(frame.absolute_path)
+        } || callstack.first
+
+        [offending_line.path, offending_line.lineno, offending_line.label]
+      end
+
+      def _extract_callstack
+        warn "Please pass `caller_locations` to the deprecation API" if $VERBOSE
+        offending_line = callstack.find { |line| !ignored_callstack(line) } || callstack.first
+
+        if offending_line
+          if md = offending_line.match(/^(.+?):(\d+)(?::in `(.*?)')?/)
+            md.captures
+          else
+            offending_line
+          end
+        end
+      end
+  end
+  private_constant :Deprecation
+end

--- a/lib/sprockets/deprecation.rb
+++ b/lib/sprockets/deprecation.rb
@@ -15,7 +15,7 @@ module Sprockets
     attr_reader :callstack
 
     def initialize(callstack = nil)
-      @callstack = callstack || caller_locations(2)
+      @callstack = callstack || caller(2)
     end
 
     def warn(message)
@@ -66,7 +66,6 @@ module Sprockets
       end
 
       def _extract_callstack
-        warn "Please pass `caller_locations` to the deprecation API" if $VERBOSE
         offending_line = callstack.find { |line| !ignored_callstack(line) } || callstack.first
 
         if offending_line

--- a/lib/sprockets/eco_template.rb
+++ b/lib/sprockets/eco_template.rb
@@ -10,7 +10,7 @@ module Sprockets
     end
 
     def self.call(*args)
-      Sprockets::Deprecation.new.warn "EcoTemplate is deprecated please use EcoProcessor instead"
+      Deprecation.new.warn "EcoTemplate is deprecated please use EcoProcessor instead"
       EcoProcessor.call(*args)
     end
   end

--- a/lib/sprockets/eco_template.rb
+++ b/lib/sprockets/eco_template.rb
@@ -2,5 +2,16 @@ require 'sprockets/eco_processor'
 
 module Sprockets
   # Deprecated
-  EcoTemplate = EcoProcessor
+  module EcoTemplate
+    VERSION = EcoProcessor::VERSION
+
+    def self.cache_key
+      EcoProcessor.cache_key
+    end
+
+    def self.call(*args)
+      Sprockets::Deprecation.new.warn "EcoTemplate is deprecated please use EcoProcessor instead"
+      EcoProcessor.call(*args)
+    end
+  end
 end

--- a/lib/sprockets/ejs_template.rb
+++ b/lib/sprockets/ejs_template.rb
@@ -10,7 +10,7 @@ module Sprockets
     end
 
     def self.call(*args)
-      Sprockets::Deprecation.new.warn "EjsTemplate is deprecated please use EjsProcessor instead"
+      Deprecation.new.warn "EjsTemplate is deprecated please use EjsProcessor instead"
       EjsProcessor.call(*args)
     end
   end

--- a/lib/sprockets/ejs_template.rb
+++ b/lib/sprockets/ejs_template.rb
@@ -2,5 +2,16 @@ require 'sprockets/ejs_processor'
 
 module Sprockets
   # Deprecated
-  EjsTemplate = EjsProcessor
+  module EjsTemplate
+    VERSION = EjsProcessor::VERSION
+
+    def self.cache_key
+      EjsProcessor.cache_key
+    end
+
+    def self.call(*args)
+      Sprockets::Deprecation.new.warn "EjsTemplate is deprecated please use EjsProcessor instead"
+      EjsProcessor.call(*args)
+    end
+  end
 end

--- a/lib/sprockets/engines.rb
+++ b/lib/sprockets/engines.rb
@@ -51,6 +51,8 @@ module Sprockets
     #     environment.register_engine '.coffee', CoffeeScriptProcessor
     #
     def register_engine(ext, klass, options = {})
+      Deprecation.new([caller.first]).warn("`register_engine` is deprecated please register a mime type and use `register_compressor` or `register_transformer`")
+
       ext = Sprockets::Utils.normalize_extension(ext)
 
       self.computed_config = {}

--- a/lib/sprockets/engines.rb
+++ b/lib/sprockets/engines.rb
@@ -51,7 +51,16 @@ module Sprockets
     #     environment.register_engine '.coffee', CoffeeScriptProcessor
     #
     def register_engine(ext, klass, options = {})
-      Deprecation.new([caller.first]).warn("`register_engine` is deprecated please register a mime type and use `register_compressor` or `register_transformer`")
+      unless options[:silence_deprecation]
+        msg = <<-MSG
+Sprockets method `register_engine` is deprecated.
+Please register a mime type using `register_mime_type` then
+use `register_compressor` or `register_transformer`.
+https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
+        MSG
+
+        Deprecation.new([caller.first]).warn(msg)
+      end
 
       ext = Sprockets::Utils.normalize_extension(ext)
 

--- a/lib/sprockets/erb_template.rb
+++ b/lib/sprockets/erb_template.rb
@@ -2,5 +2,10 @@ require 'sprockets/erb_processor'
 
 module Sprockets
   # Deprecated
-  ERBTemplate = ERBProcessor
+  class ERBTemplate < ERBProcessor
+    def call(*args)
+      Sprockets::Deprecation.new.warn "ERBTemplate is deprecated please use ERBProcessor instead"
+      super
+    end
+  end
 end

--- a/lib/sprockets/erb_template.rb
+++ b/lib/sprockets/erb_template.rb
@@ -4,7 +4,7 @@ module Sprockets
   # Deprecated
   class ERBTemplate < ERBProcessor
     def call(*args)
-      Sprockets::Deprecation.new.warn "ERBTemplate is deprecated please use ERBProcessor instead"
+      Deprecation.new.warn "ERBTemplate is deprecated please use ERBProcessor instead"
       super
     end
   end

--- a/lib/sprockets/processing.rb
+++ b/lib/sprockets/processing.rb
@@ -231,14 +231,24 @@ module Sprockets
         compute_transformers!
       end
 
+      def deprecate_legacy_processor_interface(interface)
+        msg = "DEPRECATION WARNING: You are using the a deprecated processor interface #{ interface.inspect }.\n" +
+        "Please update your processor interface:\n" +
+        "https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors\n\n" +
+        caller.join("\n")
+        warn msg
+      end
+
       def wrap_processor(klass, proc)
         if !proc
           if klass.respond_to?(:call)
             klass
           else
+            deprecate_legacy_processor_interface(klass)
             LegacyTiltProcessor.new(klass)
           end
         elsif proc.respond_to?(:arity) && proc.arity == 2
+          deprecate_legacy_processor_interface(proc)
           LegacyProcProcessor.new(klass.to_s, proc)
         else
           proc

--- a/lib/sprockets/processing.rb
+++ b/lib/sprockets/processing.rb
@@ -232,11 +232,11 @@ module Sprockets
       end
 
       def deprecate_legacy_processor_interface(interface)
-        msg = "DEPRECATION WARNING: You are using the a deprecated processor interface #{ interface.inspect }.\n" +
+        msg = "You are using the a deprecated processor interface #{ interface.inspect }.\n" +
         "Please update your processor interface:\n" +
-        "https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors\n\n" +
-        caller.join("\n")
-        warn msg
+        "https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors\n"
+
+        Deprecation.new([caller_locations[3]]).warn msg
       end
 
       def wrap_processor(klass, proc)

--- a/lib/sprockets/processing.rb
+++ b/lib/sprockets/processing.rb
@@ -236,7 +236,7 @@ module Sprockets
         "Please update your processor interface:\n" +
         "https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors\n"
 
-        Deprecation.new([caller_locations[3]]).warn msg
+        Deprecation.new([caller[3]]).warn msg
       end
 
       def wrap_processor(klass, proc)

--- a/lib/sprockets/sass_cache_store.rb
+++ b/lib/sprockets/sass_cache_store.rb
@@ -27,7 +27,7 @@ module Sprockets
   # Deprecated: Use Sprockets::SassProcessor::CacheStore instead.
   class SassCacheStore < SassProcessor::CacheStore
     def initialize(*args)
-      Sprockets::Deprecation.new.warn "SassCacheStore is deprecated please use SassProcessor::CacheStore instead"
+      Deprecation.new.warn "SassCacheStore is deprecated please use SassProcessor::CacheStore instead"
       super
     end
   end

--- a/lib/sprockets/sass_cache_store.rb
+++ b/lib/sprockets/sass_cache_store.rb
@@ -25,5 +25,10 @@ module Sprockets
   end
 
   # Deprecated: Use Sprockets::SassProcessor::CacheStore instead.
-  SassCacheStore = SassProcessor::CacheStore
+  class SassCacheStore < SassProcessor::CacheStore
+    def initialize(*args)
+      Sprockets::Deprecation.new.warn "SassCacheStore is deprecated please use SassProcessor::CacheStore instead"
+      super
+    end
+  end
 end

--- a/lib/sprockets/sass_template.rb
+++ b/lib/sprockets/sass_template.rb
@@ -4,7 +4,7 @@ module Sprockets
   # Deprecated
   class SassTemplate < SassProcessor
     def self.call(*args)
-      Sprockets::Deprecation.new.warn "SassTemplate is deprecated please use SassProcessor instead"
+      Deprecation.new.warn "SassTemplate is deprecated please use SassProcessor instead"
       super
     end
   end
@@ -12,7 +12,7 @@ module Sprockets
   # Deprecated
   class ScssTemplate < ScssProcessor
     def self.call(*args)
-      Sprockets::Deprecation.new.warn "ScssTemplate is deprecated please use ScssProcessor instead"
+      Deprecation.new.warn "ScssTemplate is deprecated please use ScssProcessor instead"
       super
     end
   end

--- a/lib/sprockets/sass_template.rb
+++ b/lib/sprockets/sass_template.rb
@@ -2,6 +2,18 @@ require 'sprockets/sass_processor'
 
 module Sprockets
   # Deprecated
-  SassTemplate = SassProcessor
-  ScssTemplate = ScssProcessor
+  class SassTemplate < SassProcessor
+    def self.call(*args)
+      Sprockets::Deprecation.new.warn "SassTemplate is deprecated please use SassProcessor instead"
+      super
+    end
+  end
+
+  # Deprecated
+  class ScssTemplate < ScssProcessor
+    def self.call(*args)
+      Sprockets::Deprecation.new.warn "ScssTemplate is deprecated please use ScssProcessor instead"
+      super
+    end
+  end
 end

--- a/test/sprockets_test.rb
+++ b/test/sprockets_test.rb
@@ -197,3 +197,12 @@ class Sprockets::TestCase < MiniTest::Test
     end
   end
 end
+
+module Sprockets
+  module SilenceDeprecation
+    def self.silence(&block)
+      Deprecation.silence(&block)
+    end
+  end
+end
+

--- a/test/sprockets_test.rb
+++ b/test/sprockets_test.rb
@@ -23,7 +23,7 @@ end
 
 NoopProcessor = proc { |input| input[:data] }
 # Sprockets.register_mime_type 'text/haml', extensions: ['.haml']
-Sprockets.register_engine '.haml', NoopProcessor, mime_type: 'text/html'
+Sprockets.register_engine '.haml', NoopProcessor, mime_type: 'text/html', silence_deprecation: true
 
 # Sprockets.register_mime_type 'text/ng-template', extensions: ['.ngt']
 AngularProcessor = proc { |input|
@@ -33,19 +33,19 @@ $app.run(function($templateCache) {
 });
   EOS
 }
-Sprockets.register_engine '.ngt', AngularProcessor, mime_type: 'application/javascript'
+Sprockets.register_engine '.ngt', AngularProcessor, mime_type: 'application/javascript', silence_deprecation: true
 
 # Sprockets.register_mime_type 'text/mustache', extensions: ['.mustache']
-Sprockets.register_engine '.mustache', NoopProcessor, mime_type: 'application/javascript'
+Sprockets.register_engine '.mustache', NoopProcessor, mime_type: 'application/javascript', silence_deprecation: true
 
 # Sprockets.register_mime_type 'text/x-handlebars-template', extensions: ['.handlebars']
-Sprockets.register_engine '.handlebars', NoopProcessor, mime_type: 'application/javascript'
+Sprockets.register_engine '.handlebars', NoopProcessor, mime_type: 'application/javascript', silence_deprecation: true
 
 # Sprockets.register_mime_type 'application/javascript-module', extensions: ['.es6']
-Sprockets.register_engine '.es6', NoopProcessor, mime_type: 'application/javascript'
+Sprockets.register_engine '.es6', NoopProcessor, mime_type: 'application/javascript', silence_deprecation: true
 
 # Sprockets.register_mime_type 'application/dart', extensions: ['.dart']
-Sprockets.register_engine '.dart', NoopProcessor, mime_type: 'application/javascript'
+Sprockets.register_engine '.dart', NoopProcessor, mime_type: 'application/javascript', silence_deprecation: true
 
 require 'nokogiri'
 
@@ -72,7 +72,7 @@ Sprockets.register_mime_type 'application/xml+builder', extensions: ['.xml.build
 Sprockets.register_transformer 'application/xml+builder', 'application/xml', XmlBuilderProcessor
 
 require 'sprockets/jst_processor'
-Sprockets.register_engine '.jst2', Sprockets::JstProcessor.new(namespace: 'this.JST2'), mime_type: 'application/javascript'
+Sprockets.register_engine '.jst2', Sprockets::JstProcessor.new(namespace: 'this.JST2'), mime_type: 'application/javascript', silence_deprecation: true
 
 SVG2PNG = proc { |input|
   "\x89\x50\x4e\x47\xd\xa\x1a\xa#{input[:data]}"

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -90,6 +90,12 @@ class TestCustomProcessor < Sprockets::TestCase
       @data = block.call
     end
 
+    def self.call(input)
+      context = input[:environment].context_class.new(input)
+      result  = self.new(nil, &Proc.new { input[:data]} ).render(context)
+      { data: result }
+    end
+
     def render(context, locals = {})
       data = @data
       data.gsub(/url\(\"(.+?)\"\)/) do
@@ -102,7 +108,8 @@ class TestCustomProcessor < Sprockets::TestCase
   end
 
   test "custom processor using Context#resolve and Context#depend_on" do
-    @env.register_engine '.embed', DataUriProcessor
+    @env.register_mime_type 'text/css+embed', extensions: ['.css.embed']
+    @env.register_transformer 'text/css+embed', 'text/css', DataUriProcessor
 
     assert_equal ".pow {\n  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAZoAAAEsCAMAAADNS4U5AAAAGXRFWHRTb2Z0\n",
       @env["sprite.css"].to_s.lines.to_a[0..1].join

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -46,7 +46,12 @@ class AssetEncodingTest < Sprockets::TestCase
   end
 
   test "read processed BINARY asset" do
-    @env.register_postprocessor('image/png', :noop_processor) { |context, data| data }
+    klass = Class.new do
+      def self.call(input)
+        input[:data]
+      end
+    end
+    @env.register_postprocessor('image/png', klass)
     data = @env['binary.png'].to_s
     assert_equal "\x89PNG\r\n\x1A\n\x00\x00\x00".force_encoding("BINARY"),
       data[0..10]

--- a/test/test_engines.rb
+++ b/test/test_engines.rb
@@ -30,7 +30,7 @@ class TestEngines < Sprockets::TestCase
     env = new_environment
 
     Sprockets::SilenceDeprecation.silence do
-      env.register_engine ".alert", AlertProcessor
+      env.register_engine ".alert", AlertProcessor, silence_deprecation: true
     end
 
     asset = env["hello.alert"]

--- a/test/test_engines.rb
+++ b/test/test_engines.rb
@@ -28,7 +28,11 @@ end
 class TestEngines < Sprockets::TestCase
   test "registering engine" do
     env = new_environment
-    env.register_engine ".alert", AlertProcessor
+
+    Sprockets::SilenceDeprecation.silence do
+      env.register_engine ".alert", AlertProcessor
+    end
+
     asset = env["hello.alert"]
     assert_equal "alert(\"Hello world!\\n\");\n", asset.to_s
     assert_equal 'application/javascript', asset.content_type

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -539,43 +539,53 @@ class TestEnvironment < Sprockets::TestCase
   end
 
   test "register global block preprocessor" do
-    old_size = new_environment.preprocessors['text/css'].size
-    Sprockets.register_preprocessor('text/css', :foo) { |context, data| data }
-    assert_equal old_size+1, new_environment.preprocessors['text/css'].size
-    Sprockets.unregister_preprocessor('text/css', :foo)
-    assert_equal old_size, new_environment.preprocessors['text/css'].size
+    Sprockets::SilenceDeprecation.silence do
+      old_size = new_environment.preprocessors['text/css'].size
+      Sprockets.register_preprocessor('text/css', :foo) { |context, data| data }
+      assert_equal old_size+1, new_environment.preprocessors['text/css'].size
+      Sprockets.unregister_preprocessor('text/css', :foo)
+      assert_equal old_size, new_environment.preprocessors['text/css'].size
+    end
   end
 
   test "unregister custom block preprocessor" do
-    old_size = @env.preprocessors['text/css'].size
-    @env.register_preprocessor('text/css', :foo) { |context, data| data }
-    assert_equal old_size+1, @env.preprocessors['text/css'].size
-    @env.unregister_preprocessor('text/css', :foo)
-    assert_equal old_size, @env.preprocessors['text/css'].size
+    Sprockets::SilenceDeprecation.silence do
+      old_size = @env.preprocessors['text/css'].size
+      @env.register_preprocessor('text/css', :foo) { |context, data| data }
+      assert_equal old_size+1, @env.preprocessors['text/css'].size
+      @env.unregister_preprocessor('text/css', :foo)
+      assert_equal old_size, @env.preprocessors['text/css'].size
+    end
   end
 
   test "unregister custom block postprocessor" do
-    old_size = @env.postprocessors['text/css'].size
-    @env.register_postprocessor('text/css', :foo) { |context, data| data }
-    assert_equal old_size+1, @env.postprocessors['text/css'].size
-    @env.unregister_postprocessor('text/css', :foo)
-    assert_equal old_size, @env.postprocessors['text/css'].size
+    Sprockets::SilenceDeprecation.silence do
+      old_size = @env.postprocessors['text/css'].size
+      @env.register_postprocessor('text/css', :foo) { |context, data| data }
+      assert_equal old_size+1, @env.postprocessors['text/css'].size
+      @env.unregister_postprocessor('text/css', :foo)
+      assert_equal old_size, @env.postprocessors['text/css'].size
+    end
   end
 
   test "register global block postprocessor" do
-    old_size = new_environment.postprocessors['text/css'].size
-    Sprockets.register_postprocessor('text/css', :foo) { |context, data| data }
-    assert_equal old_size+1, new_environment.postprocessors['text/css'].size
-    Sprockets.unregister_postprocessor('text/css', :foo)
-    assert_equal old_size, new_environment.postprocessors['text/css'].size
+    Sprockets::SilenceDeprecation.silence do
+      old_size = new_environment.postprocessors['text/css'].size
+      Sprockets.register_postprocessor('text/css', :foo) { |context, data| data }
+      assert_equal old_size+1, new_environment.postprocessors['text/css'].size
+      Sprockets.unregister_postprocessor('text/css', :foo)
+      assert_equal old_size, new_environment.postprocessors['text/css'].size
+    end
   end
 
   test "unregister custom block bundle processor" do
-    old_size = @env.bundle_processors['text/css'].size
-    @env.register_bundle_processor('text/css', :foo) { |context, data| data }
-    assert_equal old_size+1, @env.bundle_processors['text/css'].size
-    @env.unregister_bundle_processor('text/css', :foo)
-    assert_equal old_size, @env.bundle_processors['text/css'].size
+    Sprockets::SilenceDeprecation.silence do
+      old_size = @env.bundle_processors['text/css'].size
+      @env.register_bundle_processor('text/css', :foo) { |context, data| data }
+      assert_equal old_size+1, @env.bundle_processors['text/css'].size
+      @env.unregister_bundle_processor('text/css', :foo)
+      assert_equal old_size, @env.bundle_processors['text/css'].size
+    end
   end
 
   test "register global bundle processor" do


### PR DESCRIPTION
The goal of this branch is to house all deprecations for 3.x.

I would like to add deprecation warnings where possible, the goal is that immediately after 4.x reaches a 4.0.0 release we can cut a deprecation release of Sprockets 3. Until then we can make pull requests to this deprecation branch so they are ready to go whenever we want to start issuing deprecation warnings.
