### PR TITLE
Improbe PathUtils.atomic_write

### DIFF
--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -1,5 +1,3 @@
-require 'fileutils'
-
 module Sprockets
   # Internal: File and path related utilities. Mixed into Environment.
   #
@@ -274,9 +272,9 @@ module Sprockets
         yield f
       end
 
-      FileUtils.mv(tmpname, filename)
+      File.rename(tmpname, filename)
     ensure
-      FileUtils.rm(tmpname) if File.exist?(tmpname)
+      File.delete(tmpname) if File.exist?(tmpname)
     end
   end
 end


### PR DESCRIPTION
- `FileUtils.mv` does way more than just renaming the file, mostly for handling cross device renaming, which in sprocket's case is useless because the temp file is in the same directory so AFAICT on the same device. See: https://github.com/ruby/ruby/blob/028f3801f806a6aebe7d8d1fb78d0ba3e38d6036/lib/fileutils.rb#L448-L475

- Even we had to do cross devices rename, it would mean the `atomic_write` wouldn't be atomic at all, see https://github.com/rails/rails/pull/16245 for more details.

- `FileUtils.rm` is doing way more than required as well: https://github.com/ruby/ruby/blob/028f3801f806a6aebe7d8d1fb78d0ba3e38d6036/lib/fileutils.rb#L494-L502


@rafaelfranca for review please.