### PR TITLE
Improve the performance of FileStore cache in 20%

### DIFF
--- a/lib/sprockets/cache.rb
+++ b/lib/sprockets/cache.rb
@@ -153,7 +153,9 @@ module Sprockets
       #
       # Returns a String with a length less than 250 characters.
       def expand_key(key)
-        "sprockets/v#{VERSION}/#{DigestUtils.pack_urlsafe_base64digest(DigestUtils.digest(key))}"
+        digest_key = DigestUtils.pack_urlsafe_base64digest(DigestUtils.digest(key))
+        namespace = digest_key[0, 2]
+        "sprockets/v#{VERSION}/#{namespace}/#{digest_key}"
       end
 
       PEEK_SIZE = 100


### PR DESCRIPTION
The FileStore cache write the cache files in the same directory. Because of that the operation in the cache files becomes slower as the directory size grows.

To fix this we use the first 2 digits of the cache key to generate different folders.

This improved the time of compiling the assets in a large application from 3m8.592s to 2m34.529s.

A cold cache compiling on this application generates 18760 files.

cc @schneems @jeremy @matthewd @byroot 