### PR TITLE
Convert regex to Ruby start_with? end_with? in PathUtils#entries

### DIFF
--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -56,7 +56,9 @@ module Sprockets
       if File.directory?(path)
         entries = Dir.entries(path, encoding: Encoding.default_internal)
         entries.reject! { |entry|
-          entry =~ /^\.|~$|^\#.*\#$/
+          entry.start_with?(".".freeze) ||
+            (entry.start_with?("#".freeze) && entry.end_with?("#".freeze)) ||
+            entry.end_with?("~".freeze)
         }
         entries.sort!
         entries


### PR DESCRIPTION
Uses Ruby instead of a Regex for PathUtils#entries for a 2x speedup. Benchmark code:

``` ruby
require 'benchmark/ips'

PATH="/Some/User/Path/To/Analyze"

def regex
  entry = PATH

  entry =~ /^\.|~$|^\#.*\#$/
end

def start_with_end_with
  entry = PATH

  entry.start_with?(".".freeze) ||
    (entry.start_with?("#".freeze) && entry.end_with?("#".freeze)) ||
    entry.end_with?("~".freeze)
end

Benchmark.ips do |x|
  x.report("regex") { regex }
  x.report("start_with_end_with") { start_with_end_with }

  x.compare!
end
```

``` bash
Just-Another-MacBook:benchmarks blakemesdag$ ruby regex_vs_start_with_end_with.rb 
Calculating -------------------------------------
               regex    82.555k i/100ms
 start_with_end_with   113.826k i/100ms
-------------------------------------------------
               regex      1.794M (± 6.7%) i/s -      8.998M
 start_with_end_with      3.544M (± 5.2%) i/s -     17.757M

Comparison:
 start_with_end_with:  3543901.8 i/s
               regex:  1793735.9 i/s - 1.98x slower
```

@rafaelfranca 