### PR TITLE
Use partition instead of split for URITar#initialize

### DIFF
--- a/lib/sprockets/uri_tar.rb
+++ b/lib/sprockets/uri_tar.rb
@@ -15,10 +15,8 @@ module Sprockets
       @env  = env
       uri   = uri.to_s
       if uri.include?("://".freeze)
-        uri_array = uri.split("://".freeze)
-        @scheme   = uri_array.shift
-        @scheme   << "://".freeze
-        @path     = uri_array.join("".freeze)
+        @scheme, _, @path = uri.partition("://".freeze)
+        @scheme << "://".freeze
       else
         @scheme = "".freeze
         @path   = uri


### PR DESCRIPTION
`Array#partition` is about 70% faster:

```ruby
require 'benchmark/ips'

STRING = "https://example.com/test/path/here"

def slice
  uri = STRING.dup
  uri_array = uri.split("://".freeze)
  scheme   = uri_array.shift
  scheme   << "://".freeze
  path     = uri_array.join("".freeze)
end

def partition_parallel
  uri = STRING.dup
  scheme, _, path = uri.partition("://".freeze)
  scheme = scheme + "://".freeze
end

Benchmark.ips do |x|
  x.report("slice") { slice }
  x.report("partition_parallel") { partition_parallel }

  x.compare!
end
```

```bash
$ ruby str_partition_vs_slice.rb 
Calculating -------------------------------------
               slice    53.200k i/100ms
  partition_parallel    79.267k i/100ms
-------------------------------------------------
               slice    828.945k (±16.2%) i/s -      4.043M
  partition_parallel      1.426M (± 9.0%) i/s -      7.134M

Comparison:
  partition_parallel:  1425874.2 i/s
               slice:   828944.9 i/s - 1.72x slower
```

@rafaelfranca 