### PR TITLE
Hash#store is faster than delete then []=

### DIFF
--- a/lib/sprockets/cache/memory_store.rb
+++ b/lib/sprockets/cache/memory_store.rb
@@ -50,8 +50,7 @@ module Sprockets
       #
       # Returns Object value.
       def set(key, value)
-        @cache.delete(key)
-        @cache[key] = value
+        @cache.store(key, value)
         @cache.shift if @cache.size > @max_size
         value
       end


### PR DESCRIPTION
`Hash#store` is 2-6% faster than `Hash#delete` followed by `Hash#[]=`:

``` ruby
require 'benchmark/ips'

HASH = {
  key: "some_value"
}

def delete_set(key = :key)
  hash = HASH.dup
  hash.delete(key)
  hash[key] = "some_new_value"
end

def store(key = :key)
  hash = HASH.dup
  hash.store(:key, "some_new_value")
end

Benchmark.ips do |x|
  i = 0

  x.report("delete_set") { delete_set }
  x.report("store") { store }

  x.report("delete_set_unique_key") do
    delete_set(key = i)
    i += 1
  end

  x.report("store_uniqe_key") do
    store(key = i)
    i += 1
  end

  x.compare!
end
```

```bash
$ ruby hash_delete_set_vs_set.rb 
Calculating -------------------------------------
          delete_set    48.887k i/100ms
               store    47.941k i/100ms
delete_set_unique_key
                        45.209k i/100ms
     store_uniqe_key    47.437k i/100ms
-------------------------------------------------
          delete_set    789.215k (±22.2%) i/s -      3.715M
               store    833.387k (±22.2%) i/s -      3.979M
delete_set_unique_key
                        820.249k (±21.8%) i/s -      3.888M
     store_uniqe_key    839.404k (±22.3%) i/s -      3.985M

Comparison:
     store_uniqe_key:   839403.8 i/s
               store:   833387.5 i/s - 1.01x slower
delete_set_unique_key:   820249.2 i/s - 1.02x slower
          delete_set:   789215.5 i/s - 1.06x slower
```

@rafaelfranca 