### PR TITLE
Add small utility method for checking if a string is a file-digest uri

### DIFF
--- a/lib/sprockets/dependencies.rb
+++ b/lib/sprockets/dependencies.rb
@@ -58,7 +58,7 @@ module Sprockets
     def resolve_dependency(str)
       # Optimize for the most common scheme to
       # save 22k allocations on an average Spree app.
-      scheme = if str.start_with?('file-digest:'.freeze)
+      scheme = if file_digest_uri?(str)
         'file-digest'.freeze
       else
         str[/([^:]+)/, 1]

--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -81,7 +81,7 @@ module Sprockets
           asset[:metadata][:links].map!             { |uri| expand_from_root(uri) } if asset[:metadata][:links]
           asset[:metadata][:stubbed].map!           { |uri| expand_from_root(uri) } if asset[:metadata][:stubbed]
           asset[:metadata][:required].map!          { |uri| expand_from_root(uri) } if asset[:metadata][:required]
-          asset[:metadata][:dependencies].map!      { |uri| uri.start_with?("file-digest://") ? expand_from_root(uri) : uri } if asset[:metadata][:dependencies]
+          asset[:metadata][:dependencies].map!      { |uri| file_digest_uri?(uri) ? expand_from_root(uri) : uri } if asset[:metadata][:dependencies]
 
           asset[:metadata].each_key do |k|
             next unless k =~ /_dependencies\z/
@@ -233,7 +233,7 @@ module Sprockets
           if cached_asset[:metadata][:dependencies] && !cached_asset[:metadata][:dependencies].empty?
             cached_asset[:metadata][:dependencies] = cached_asset[:metadata][:dependencies].dup
             cached_asset[:metadata][:dependencies].map! do |uri|
-              uri.start_with?("file-digest://".freeze) ? compress_from_root(uri) : uri
+              file_digest_uri?(uri) ? compress_from_root(uri) : uri
             end
           end
 
@@ -313,7 +313,7 @@ module Sprockets
         history = cache.get(key) || []
         history.each_with_index do |deps, index|
           expanded_deps = deps.map do |path|
-            path.start_with?("file-digest://") ? expand_from_root(path) : path
+            file_digest_uri?(path) ? expand_from_root(path) : path
           end
           if asset = yield(expanded_deps)
             cache.set(key, history.rotate!(index)) if index > 0
@@ -323,7 +323,7 @@ module Sprockets
 
         asset = yield
         deps  = asset[:metadata][:dependencies].dup.map! do |uri|
-          uri.start_with?("file-digest://") ? compress_from_root(uri) : uri
+          file_digest_uri?(uri) ? compress_from_root(uri) : uri
         end
         cache.set(key, history.unshift(deps).take(limit))
         asset

--- a/lib/sprockets/uri_utils.rb
+++ b/lib/sprockets/uri_utils.rb
@@ -21,6 +21,15 @@ module Sprockets
   module URIUtils
     extend self
 
+    # Internal: Determine if a URI is a file digest
+    #
+    # uri - String uri
+    #
+    # Returns {true, false}
+    def file_digest_uri?(uri)
+      uri.start_with?('file-digest://'.freeze)
+    end
+
     # Internal: Parse URI into component parts.
     #
     # uri - String uri

--- a/lib/sprockets/uri_utils.rb
+++ b/lib/sprockets/uri_utils.rb
@@ -21,15 +21,6 @@ module Sprockets
   module URIUtils
     extend self
 
-    # Internal: Determine if a URI is a file digest
-    #
-    # uri - String uri
-    #
-    # Returns {true, false}
-    def file_digest_uri?(uri)
-      uri.start_with?('file-digest://'.freeze)
-    end
-
     # Internal: Parse URI into component parts.
     #
     # uri - String uri
@@ -120,6 +111,15 @@ module Sprockets
     # Returns String URI.
     def build_asset_uri(path, params = {})
       join_file_uri("file", nil, path, encode_uri_query_params(params))
+    end
+
+    # Internal: Determine if a URI is a file digest
+    #
+    # uri - String uri
+    #
+    # Returns true uri is a digest uri
+    def file_digest_uri?(uri)
+      uri.start_with?('file-digest://'.freeze)
     end
 
     # Internal: Parse file-digest dependency URI.

--- a/test/test_uri_utils.rb
+++ b/test/test_uri_utils.rb
@@ -148,6 +148,14 @@ class TestURIUtils < MiniTest::Test
     end
   end
 
+  def test_file_digest_uri
+    assert file_digest_uri?('file-digest:///usr/local/var/github/app/assets/javascripts/application.js')
+    assert file_digest_uri?('file-digest:///C:/Users/IEUser/Documents/github/app/assets/javascripts/application.js')
+    refute file_digest_uri?('file:///usr/local/var/file-digest/app/assets/javascripts/application.js')
+    refute file_digest_uri?('file:///usr/local/var/github/app/assets/stylesheets/users.css?type=text/css')
+    refute file_digest_uri?('http://file-digest.com:8080')
+  end
+
   def test_parse_file_digest_uri
     assert_equal "/usr/local/var/github/app/assets/javascripts/application.js",
       parse_file_digest_uri("file-digest:///usr/local/var/github/app/assets/javascripts/application.js")


### PR DESCRIPTION
I was just diving into some of the Sprockets code for the first time and found this piece of logic in a few different places. So I thought this helper method was more semantically named and reduced some duplication. Not sure if it's in the right file though! I could use some feedback on the method's location and documentation.

Thanks!