### PR TITLE
Add documentation about compressors

### DIFF
--- a/guides/extending_sprockets.md
+++ b/guides/extending_sprockets.md
@@ -68,11 +68,24 @@ For example, say you wanted to have Sprockets process a `.html` file, and output
 
 ## Compressors
 
-A compressor takes in an asset, and returns a smaller version of that asset. For example the uglifier compressor takes in a javascript file, it then removes the whitespace and applies other space saving techniques and returns a smaller javascript source. It must respond to `call` and return a `:data` key in a hash similar to a preprocessor. You can register a compressor like this:
+A compressor takes in an asset, and returns a smaller version of that asset. For example the uglifier compressor takes in a javascript file, it then removes the whitespace and applies other space saving techniques and returns a smaller javascript source.
+
+Compressors must respond to `call` and return a `:data` key in a hash similar to a preprocessor.
+
+You can register a compressor like this:
 
 ```ruby
 Sprockets.register_compressor 'application/javascript', :uglify, UglifierCompressor
 ```
+
+Registering a compressor allows it to be used later. After registering a compressor you can activate it using the `js_compressor=` or `css_compressor=` method on the environment or Sprockets global.
+
+```ruby
+Sprockets.register_compressor 'text/css', :my_css, MyCssCompressor
+Sprockets.css_compressor = :my_css
+```
+
+Compressors only operate on JavaScript and CSS. If you want to compress a different type of asset, use a preprocessor (see "Preprocessors" above) to preprocess the asset.
 
 ## Adding directives to your extension
 

--- a/guides/extending_sprockets.md
+++ b/guides/extending_sprockets.md
@@ -68,9 +68,9 @@ For example, say you wanted to have Sprockets process a `.html` file, and output
 
 ## Compressors
 
-A compressor takes in an asset, and returns a smaller version of that asset. For example the uglifier compressor takes in a javascript file, it then removes the whitespace and applies other space saving techniques and returns a smaller javascript source.
+A compressor takes in an asset, and returns a smaller version of that asset. For example the uglifier compressor takes in a JavaScript file, it then removes the whitespace and applies other space saving techniques and returns a smaller JavaScript source.
 
-Compressors must respond to `call` and return a `:data` key in a hash similar to a preprocessor.
+Compressors must respond to `call` and return a `:data` key in a hash similar to a processor.
 
 You can register a compressor like this:
 
@@ -85,7 +85,7 @@ Sprockets.register_compressor 'text/css', :my_css, MyCssCompressor
 Sprockets.css_compressor = :my_css
 ```
 
-Compressors only operate on JavaScript and CSS. If you want to compress a different type of asset, use a preprocessor (see "Preprocessors" above) to preprocess the asset.
+Compressors only operate on JavaScript and CSS. If you want to compress a different type of asset, use a processor (see "Preprocessors" above) to process the asset.
 
 ## Adding directives to your extension
 

--- a/lib/sprockets/compressing.rb
+++ b/lib/sprockets/compressing.rb
@@ -11,6 +11,24 @@ module Sprockets
       config[:compressors]
     end
 
+    # Public: Register a new compressor `klass` at `sym` for `mime_type`.
+    #
+    # Registering a processor allows it to be looked up by `sym` later when
+    # assigning a JavaScript or CSS compressor.
+    #
+    # Compressors only operate on JavaScript and CSS. If you want to compress a
+    # different type of asset, use a preprocessor instead.
+    #
+    # Examples
+    #
+    #     register_compressor 'text/css', :my_sass, MySassCompressor
+    #     css_compressor = :my_sass
+    #
+    # mime_type - String MIME Type (one of: 'test/css' or 'application/javascript').
+    # sym       - Symbol registration address.
+    # klass     - The compressor class.
+    #
+    # Returns nothing.
     def register_compressor(mime_type, sym, klass)
       self.config = hash_reassoc(config, :compressors, mime_type) do |compressors|
         compressors[sym] = klass

--- a/lib/sprockets/compressing.rb
+++ b/lib/sprockets/compressing.rb
@@ -17,7 +17,7 @@ module Sprockets
     # assigning a JavaScript or CSS compressor.
     #
     # Compressors only operate on JavaScript and CSS. If you want to compress a
-    # different type of asset, use a preprocessor instead.
+    # different type of asset, use a processor instead.
     #
     # Examples
     #


### PR DESCRIPTION
It's not immediately apparent that compressors only operate on
JavaScript and CSS. This adds documentation about registering
compressors, notes that `register_compressor` only adds the compressor
to the list of available compressors, and shows how to then activate
that compressor as the one you want to use.

I updated both the inline documentation in the `Compressing` module and
the "Extending Sprockets" guide, per @mikong's suggestions in the open
issue.

Fixes #246
[ci skip]