### PR TITLE
Fix digest_class option

### DIFF
--- a/lib/sprockets/configuration.rb
+++ b/lib/sprockets/configuration.rb
@@ -63,7 +63,7 @@ module Sprockets
     #     environment.digest_class = Digest::MD5
     #
     def digest_class=(klass)
-      self.config = config.merge(digest_class: klass).freeze
+      self.config = hash_reassoc(config, :digest_class) { klass }
     end
 
     # This class maybe mutated and mixed in with custom helpers.


### PR DESCRIPTION
For some reason, I want to change the `digest_class` to reset digest for all my assets.
Then I found the option but it doesn't work.
Although it is deprecated, but why not to make it work well. 😄 
