### PR TITLE
Remove checks for existing semicolons and newlines in concat_javascript_sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprockets/blob/master/UPGRADING.md
 
+- Remove expensive checking for existing semicolons and newlines in concat_javascript_sources [#310]
+
 ## 4.0.0.beta2
 
 - Fix load_paths on Sass processors [#223]

--- a/lib/sprockets/utils.rb
+++ b/lib/sprockets/utils.rb
@@ -68,29 +68,9 @@ module Sprockets
       end
     end
 
-    # Internal: Check if string has a trailing semicolon.
-    #
-    # str - String
-    #
-    # Returns true or false.
-    def string_end_with_semicolon?(str)
-      i = str.size - 1
-      while i >= 0
-        c = str[i]
-        i -= 1
-        if c == "\n" || c == " " || c == "\t"
-          next
-        elsif c != ";"
-          return false
-        else
-          return true
-        end
-      end
-      true
-    end
-
     # Internal: Accumulate asset source to buffer and append a trailing
-    # semicolon if necessary.
+    # semicolon and newline. This may result in duplicated semicolons and
+    # newlines, but we don't mind because they'll be removed by the minifier.
     #
     # buf    - String buffer to append to
     # source - String source to append
@@ -98,8 +78,7 @@ module Sprockets
     # Returns buf String.
     def concat_javascript_sources(buf, source)
       if buf.bytesize > 0
-        buf << ";" unless string_end_with_semicolon?(buf)
-        buf << "\n" unless buf.end_with?("\n")
+        buf << ";\n"
       end
       buf << source
     end

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -431,7 +431,7 @@ class BundledAssetTest < Sprockets::TestCase
   end
 
   test "digest path" do
-    assert_equal "application-955b2dddd0d1449b1c617124b83b46300edadec06d561104f7f6165241b31a94.js",
+    assert_equal "application-91236d87a8fed56003b8bf2e96e7feb7ffaae0d25b07bf6d33ee8fc509f7f1e3.js",
       @asset.digest_path
   end
 
@@ -440,23 +440,23 @@ class BundledAssetTest < Sprockets::TestCase
   end
 
   test "length" do
-    assert_equal 159, @asset.length
+    assert_equal 163, @asset.length
   end
 
   test "source digest" do
-    assert_equal [149, 91, 45, 221, 208, 209, 68, 155, 28, 97, 113, 36, 184, 59, 70, 48, 14, 218, 222, 192, 109, 86, 17, 4, 247, 246, 22, 82, 65, 179, 26, 148], @asset.digest.bytes.to_a
+    assert_equal [145, 35, 109, 135, 168, 254, 213, 96, 3, 184, 191, 46, 150, 231, 254, 183, 255, 170, 224, 210, 91, 7, 191, 109, 51, 238, 143, 197, 9, 247, 241, 227], @asset.digest.bytes.to_a
   end
 
   test "source hexdigest" do
-    assert_equal "955b2dddd0d1449b1c617124b83b46300edadec06d561104f7f6165241b31a94", @asset.hexdigest
+    assert_equal "91236d87a8fed56003b8bf2e96e7feb7ffaae0d25b07bf6d33ee8fc509f7f1e3", @asset.hexdigest
   end
 
   test "source base64digest" do
-    assert_equal "lVst3dDRRJscYXEkuDtGMA7a3sBtVhEE9/YWUkGzGpQ=", @asset.base64digest
+    assert_equal "kSNth6j+1WADuL8uluf+t/+q4NJbB79tM+6PxQn38eM=", @asset.base64digest
   end
 
   test "integrity" do
-    assert_equal "sha256-lVst3dDRRJscYXEkuDtGMA7a3sBtVhEE9/YWUkGzGpQ=", @asset.integrity
+    assert_equal "sha256-kSNth6j+1WADuL8uluf+t/+q4NJbB79tM+6PxQn38eM=", @asset.integrity
   end
 
   test "charset is UTF-8" do
@@ -464,13 +464,13 @@ class BundledAssetTest < Sprockets::TestCase
   end
 
   test "to_s" do
-    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\nvar Users = {\n  find: function(id) {\n  }\n};\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n", @asset.to_s
+    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\n;\nvar Users = {\n  find: function(id) {\n  }\n};\n;\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n", @asset.to_s
   end
 
   test "each" do
     body = String.new("")
     @asset.each { |part| body << part }
-    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\nvar Users = {\n  find: function(id) {\n  }\n};\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n", body
+    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\n;\nvar Users = {\n  find: function(id) {\n  }\n};\n;\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n", body
   end
 
   test "asset is stale when one of its source files is modified" do
@@ -739,7 +739,7 @@ class BundledAssetTest < Sprockets::TestCase
   end
 
   test "requiring the same file multiple times has no effect" do
-    assert_equal read("asset/project.js.erb")+"\n\n\n", asset("multiple.js").to_s
+    assert_equal read("asset/project.js.erb")+"\n;\n\n\n", asset("multiple.js").to_s
   end
 
   test "requiring a file of a different format raises an exception" do
@@ -749,7 +749,7 @@ class BundledAssetTest < Sprockets::TestCase
   end
 
   test "bundling joins files with blank line" do
-    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\nvar Users = {\n  find: function(id) {\n  }\n};\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n",
+    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\n;\nvar Users = {\n  find: function(id) {\n  }\n};\n;\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n",
       asset("application.js").to_s
   end
 
@@ -758,23 +758,23 @@ class BundledAssetTest < Sprockets::TestCase
   end
 
   test "processing a source file with no engine extensions" do
-    assert_equal read("asset/users.js.erb"), asset("noengine.js").to_s
+    assert_equal read("asset/users.js.erb") + ";\n", asset("noengine.js").to_s
   end
 
   test "processing a source file with different content type extensions" do
-    assert_equal read("asset/users.js.erb"), asset("es6_asset.js").to_s
+    assert_equal read("asset/users.js.erb") + ";\n", asset("es6_asset.js").to_s
   end
 
   test "processing a source file with different content type extensions 1" do
-    assert_equal read("asset/users.js.erb") + "(function() {\n\n\n}).call(this);\n", asset("coffee_asset.js").to_s
+    assert_equal read("asset/users.js.erb") + ";\n(function() {\n\n\n}).call(this);\n", asset("coffee_asset.js").to_s
   end
 
   test "processing a source file with unknown extensions" do
-    assert_equal read("asset/users.js.erb") + "var jQuery;\n\n\n", asset("unknownexts.min.js").to_s
+    assert_equal read("asset/users.js.erb") + ";\nvar jQuery;\n;\n\n\n", asset("unknownexts.min.js").to_s
   end
 
   test "requiring a file with a relative path" do
-    assert_equal read("asset/project.js.erb") + "\n",
+    assert_equal read("asset/project.js.erb") + "\n;\n",
       asset("relative/require.js").to_s
   end
 
@@ -803,14 +803,14 @@ class BundledAssetTest < Sprockets::TestCase
 
   test "require_directory requires all child files in alphabetical order" do
     assert_equal(
-      "ok(\"b.js.erb\");\n",
+      "ok(\"b.js.erb\");\n;\n",
       asset("tree/all_with_require_directory.js").to_s
     )
   end
 
   test "require_directory current directory includes self last" do
     assert_equal(
-      "var Bar;\nvar Foo;\nvar App;\n",
+      "var Bar;\n;\nvar Foo;\n;\nvar App;\n",
       asset("tree/directory/application.js").to_s
     )
   end
@@ -824,14 +824,14 @@ class BundledAssetTest < Sprockets::TestCase
 
   test "require_tree without an argument defaults to the current directory" do
     assert_equal(
-      "a();\nb();\n",
+      "a();\n;\nb();\n;\n",
       asset("tree/without_argument/require_tree_without_argument.js").to_s
     )
   end
 
   test "require_tree with current directory includes self last" do
     assert_equal(
-      "var Bar;\nvar Foo;\nvar App;\n",
+      "var Bar;\n;\nvar Foo;\n;\nvar App;\n",
       asset("tree/tree/application.js").to_s
     )
   end
@@ -856,7 +856,7 @@ class BundledAssetTest < Sprockets::TestCase
 
   test "require_tree respects order of child dependencies" do
     assert_equal(
-      "var c;\nvar b;\nvar a;\n\n",
+      "var c;\n;\nvar b;\n;\nvar a;\n\n;\n",
       asset("tree/require_tree_alpha.js").to_s
     )
   end
@@ -875,7 +875,7 @@ class BundledAssetTest < Sprockets::TestCase
     assert asset = asset("require_manifest.js")
     assert_equal <<-EOS, asset.to_s
 
-define("application.js", "application-955b2dddd0d1449b1c617124b83b46300edadec06d561104f7f6165241b31a94.js")
+define("application.js", "application-91236d87a8fed56003b8bf2e96e7feb7ffaae0d25b07bf6d33ee8fc509f7f1e3.js")
 define("application.css", "application-46d50149c56fc370805f53c29f79b89a52d4cc479eeebcdc8db84ab116d7ab1a.css")
 define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png")
     EOS
@@ -893,7 +893,7 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
 
 
 
-define("application.js", "application-955b2dddd0d1449b1c617124b83b46300edadec06d561104f7f6165241b31a94.js")
+define("application.js", "application-91236d87a8fed56003b8bf2e96e7feb7ffaae0d25b07bf6d33ee8fc509f7f1e3.js")
 define("application.css", "application-46d50149c56fc370805f53c29f79b89a52d4cc479eeebcdc8db84ab116d7ab1a.css")
 define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png")
     EOS
@@ -986,24 +986,24 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
   end
 
   test "stub single dependency" do
-    assert_equal "var jQuery.UI = {};\n\n\n", asset("stub/skip_jquery").to_s
+    assert_equal "var jQuery.UI = {};\n;\n\n\n", asset("stub/skip_jquery").to_s
   end
 
   test "stub dependency tree" do
-    assert_equal "var Foo = {};\n\n\n\n", asset("stub/application").to_s
+    assert_equal "var Foo = {};\n;\n\n\n\n", asset("stub/application").to_s
   end
 
   test "resolves circular requires" do
-    assert_equal "var A;\nvar C;\nvar B;\n",
+    assert_equal "var A;\n;\nvar C;\n;\nvar B;\n",
       asset("circle/a.js").to_s
-    assert_equal "var B;\nvar A;\nvar C;\n",
+    assert_equal "var B;\n;\nvar A;\n;\nvar C;\n",
       asset("circle/b.js").to_s
-    assert_equal "var C;\nvar B;\nvar A;\n",
+    assert_equal "var C;\n;\nvar B;\n;\nvar A;\n",
       asset("circle/c.js").to_s
   end
 
   test "unknown directives are ignored" do
-    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\n\n//\n// = Foo\n//\n// == Examples\n//\n// Foo.bar()\n// => \"baz\"\nvar Foo;\n",
+    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\n;\n\n//\n// = Foo\n//\n// == Examples\n//\n// Foo.bar()\n// => \"baz\"\nvar Foo;\n",
       asset("unknown_directives.js").to_s
   end
 
@@ -1104,7 +1104,7 @@ class DebugAssetTest < Sprockets::TestCase
   end
 
   test "digest path" do
-    assert_equal "application.debug-2f5fde4066077205c961164247ca6ae471977d347b4ef96d9d6e2e17d9d9906c.js",
+    assert_equal "application.debug-4e488239a4775658381340f2419a3acf74409271f0fb0b09cfb189e9355eca7f.js",
       @asset.digest_path
   end
 
@@ -1113,7 +1113,7 @@ class DebugAssetTest < Sprockets::TestCase
   end
 
   test "length" do
-    assert_equal 264, @asset.length
+    assert_equal 268, @asset.length
   end
 
   test "charset is UTF-8" do
@@ -1121,7 +1121,7 @@ class DebugAssetTest < Sprockets::TestCase
   end
 
   test "to_s" do
-    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\nvar Users = {\n  find: function(id) {\n  }\n};\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n\n//# sourceMappingURL=application.js-a1ddc843806213ded8eaf93eb6502617575c906ebb3c8826825abe53344c8806.map", @asset.to_s
+    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\n;\nvar Users = {\n  find: function(id) {\n  }\n};\n;\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n\n//# sourceMappingURL=application.js-a1ddc843806213ded8eaf93eb6502617575c906ebb3c8826825abe53344c8806.map", @asset.to_s
   end
 
   def asset(logical_path, options = {})

--- a/test/test_bundle.rb
+++ b/test/test_bundle.rb
@@ -90,7 +90,7 @@ class TestStylesheetBundle < Sprockets::TestCase
       metadata: {}
     }
 
-    data = "var Project = {\n  find: function(id) {\n  }\n};\nvar Users = {\n  find: function(id) {\n  }\n};\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n"
+    data = "var Project = {\n  find: function(id) {\n  }\n};\n;\nvar Users = {\n  find: function(id) {\n  }\n};\n;\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n"
     result = Sprockets::Bundle.call(input)
     assert_equal data, result[:data]
     assert_equal [

--- a/test/test_caching.rb
+++ b/test/test_caching.rb
@@ -200,7 +200,7 @@ class TestCaching < Sprockets::TestCase
     sandbox foo, bar do
       File.open(foo, 'w') { |f| f.write "//= require bar-tmp\nfoo;\n" }
       File.open(bar, 'w') { |f| f.write "bar;\n" }
-      assert_equal "bar;\nfoo;\n", @env1["foo-tmp.js"].to_s
+      assert_equal "bar;\n;\nfoo;\n", @env1["foo-tmp.js"].to_s
       assert_equal "bar;\n", @env1["bar-tmp.js"].to_s
 
       # File.open(foo, 'w') { |f| f.write "foo;\n" }
@@ -224,7 +224,7 @@ class TestCaching < Sprockets::TestCase
       env.cache = @cache
     end
 
-    assert_equal "jQuery;\n", env1["main.js"].to_s
+    assert_equal "jQuery;\n;\n", env1["main.js"].to_s
     assert_equal "jQuery;\n", env1["jquery.js"].to_s
 
     assert_raises Sprockets::FileNotFound do
@@ -250,13 +250,13 @@ class TestCaching < Sprockets::TestCase
 
       asset = @env["main.js"]
       assert_equal fixture_path('default/app/main.js'), asset.filename
-      assert_equal "jQuery;\n", asset.to_s
+      assert_equal "jQuery;\n;\n", asset.to_s
 
       write(patched_jquery, "jQueryFixed;\n", 1422000010)
 
       asset = @env["main.js"]
       assert_equal fixture_path('default/app/main.js'), asset.filename
-      assert_equal "jQueryFixed;\n", asset.to_s
+      assert_equal "jQueryFixed;\n;\n", asset.to_s
 
       asset = @env["jquery.js"]
       assert_equal fixture_path('default/app/jquery.js'), asset.filename
@@ -271,7 +271,7 @@ class TestCaching < Sprockets::TestCase
 
       asset = @env["main.js"]
       assert_equal fixture_path('default/app/main.js'), asset.filename
-      assert_equal "jQuery;\n", asset.to_s
+      assert_equal "jQuery;\n;\n", asset.to_s
     end
   end
 
@@ -293,14 +293,14 @@ class TestCaching < Sprockets::TestCase
 
       asset = @env["main.js"]
       assert_equal fixture_path('default/app/main.js'), asset.filename
-      assert_equal "jQuery;\n", asset.to_s
+      assert_equal "jQuery;\n;\n", asset.to_s
 
       FileUtils.mkdir(File.dirname(patched_jquery))
       write(patched_jquery, "jQueryFixed;\n", 1423000010)
 
       asset = @env["main.js"]
       assert_equal fixture_path('default/app/main.js'), asset.filename
-      assert_equal "jQueryFixed;\n", asset.to_s
+      assert_equal "jQueryFixed;\n;\n", asset.to_s
 
       asset = @env["jquery.js"]
       assert_equal fixture_path('default/app/jquery/index.js'), asset.filename
@@ -315,7 +315,7 @@ class TestCaching < Sprockets::TestCase
 
       asset = @env["main.js"]
       assert_equal fixture_path('default/app/main.js'), asset.filename
-      assert_equal "jQuery;\n", asset.to_s
+      assert_equal "jQuery;\n;\n", asset.to_s
     end
   end
 
@@ -333,13 +333,13 @@ class TestCaching < Sprockets::TestCase
     end
 
     assert main = env1.find_asset("main.js")
-    assert_equal "var jQuery;\n", main.to_s
+    assert_equal "var jQuery;\n;\n", main.to_s
     assert_equal fixture_path('default/app/main.js'), main.filename
     assert_equal main, env1.load(main.uri)
     assert_equal main, env1.find_asset("main.js")
 
     assert main = env2.find_asset("main.js")
-    assert_equal "var jQuery;\n", main.to_s
+    assert_equal "var jQuery;\n;\n", main.to_s
     assert_equal fixture_path('default/app/main.js'), main.filename
     assert_equal main, env2.load(main.uri)
     assert_equal main, env2.find_asset("main.js")

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -11,7 +11,7 @@ class TestContext < Sprockets::TestCase
   test "context environment is cached" do
     instances = @env["environment.js"].to_s.split("\n")
     assert_match "Sprockets::CachedEnvironment", instances[0]
-    assert_equal instances[0], instances[1]
+    assert_equal instances[0], instances[2]
   end
 
   test "source file properties are exposed in context" do
@@ -78,7 +78,7 @@ class TestCustomProcessor < Sprockets::TestCase
     @env.register_mime_type 'text/yaml+bundle', extensions: ['.bundle.yml']
     @env.register_transformer 'text/yaml+bundle', 'application/javascript', YamlBundleProcessor
 
-    assert_equal "var Foo = {};\n\nvar Bar = {};\n", @env['application.js'].to_s
+    assert_equal "var Foo = {};\n\n;\nvar Bar = {};\n;\n", @env['application.js'].to_s
   end
 
   require 'base64'

--- a/test/test_encoding.rb
+++ b/test/test_encoding.rb
@@ -33,7 +33,7 @@ class AssetEncodingTest < Sprockets::TestCase
 
   test "read ASCII + UTF-8 concatation asset" do
     data = @env['ascii_utf8.js'].to_s
-    assert_equal "var foo = \"bar\";\nvar snowman = \"\342\230\203\";\n\n\n",
+    assert_equal "var foo = \"bar\";\n;\nvar snowman = \"\342\230\203\";\n;\n\n\n",
       data
     assert_equal Encoding::UTF_8, data.encoding
   end

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -226,7 +226,7 @@ module EnvironmentTests
   end
 
   test "find index.js in directory" do
-    assert_equal "var A;\nvar B;\n", @env["mobile.js"].to_s
+    assert_equal "var A;\n;\nvar B;\n;\n", @env["mobile.js"].to_s
   end
 
   test "find index.css in directory" do

--- a/test/test_performance.rb
+++ b/test/test_performance.rb
@@ -328,7 +328,7 @@ class TestPerformance < Sprockets::TestCase
       reset_stats!
 
       assert asset = env["tmp-main.js"]
-      assert_equal "a;\n", asset.source
+      assert_equal "a;\n;\n", asset.source
       ida = asset.id
       assert_no_redundant_processor_calls
       assert_no_redundant_bundle_processor_calls
@@ -338,7 +338,7 @@ class TestPerformance < Sprockets::TestCase
       reset_stats!
 
       assert asset = env["tmp-main.js"]
-      assert_equal "b;\n", asset.source
+      assert_equal "b;\n;\n", asset.source
       idb = asset.id
       assert_no_redundant_processor_calls
       assert_no_redundant_bundle_processor_calls
@@ -348,7 +348,7 @@ class TestPerformance < Sprockets::TestCase
       reset_stats!
 
       assert asset = env["tmp-main.js"]
-      assert_equal "a;\n", asset.source
+      assert_equal "a;\n;\n", asset.source
       assert_equal ida, asset.id
       assert_no_redundant_stat_calls
       assert_no_processor_calls
@@ -360,7 +360,7 @@ class TestPerformance < Sprockets::TestCase
       reset_stats!
 
       assert asset = env["tmp-main.js"]
-      assert_equal "b;\n", asset.source
+      assert_equal "b;\n;\n", asset.source
       assert_equal idb, asset.id
       assert_no_redundant_stat_calls
       assert_no_processor_calls
@@ -387,7 +387,7 @@ class TestPerformance < Sprockets::TestCase
       reset_stats!
 
       assert asset = env["tmp.js"]
-      assert_equal "a;\n", asset.source
+      assert_equal "a;\n;\n", asset.source
       ida = asset.id
       assert_no_redundant_processor_calls
       assert_no_redundant_bundle_processor_calls
@@ -398,7 +398,7 @@ class TestPerformance < Sprockets::TestCase
       reset_stats!
 
       assert asset = env["tmp.js"]
-      assert_equal "a;\nb;\n", asset.source
+      assert_equal "a;\n;\nb;\n;\n", asset.source
       idab = asset.id
       assert_no_redundant_processor_calls
       assert_no_redundant_bundle_processor_calls
@@ -409,7 +409,7 @@ class TestPerformance < Sprockets::TestCase
       reset_stats!
 
       assert asset = env["tmp.js"]
-      assert_equal "a;\n", asset.source
+      assert_equal "a;\n;\n", asset.source
       assert_equal ida, asset.id
       assert_no_redundant_stat_calls
       assert_no_processor_calls
@@ -422,7 +422,7 @@ class TestPerformance < Sprockets::TestCase
       reset_stats!
 
       assert asset = env["tmp.js"]
-      assert_equal "a;\nb;\n", asset.source
+      assert_equal "a;\n;\nb;\n;\n", asset.source
       assert_equal idab, asset.id
       assert_no_redundant_stat_calls
       assert_no_processor_calls

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -55,7 +55,7 @@ class TestServer < Sprockets::TestCase
 
   test "serve source with dependencies" do
     get "/assets/application.js"
-    assert_equal "var foo;\n\n(function() {\n  application.boot();\n})();\n",
+    assert_equal "var foo;\n;\n\n(function() {\n  application.boot();\n})();\n",
       last_response.body
   end
 
@@ -112,8 +112,8 @@ class TestServer < Sprockets::TestCase
       'HTTP_IF_NONE_MATCH' => "nope"
 
     assert_equal 200, last_response.status
-    assert_equal '"b452c9ae1d5c8d9246653e0d93bc83abce0ee09ef725c0f0a29a41269c217b83"', last_response.headers['ETag']
-    assert_equal '52', last_response.headers['Content-Length']
+    assert_equal '"0daf0f86922e94e54db5d664a29121ca1f2ac5dfda71db9691e5c6477d42b28b"', last_response.headers['ETag']
+    assert_equal '54', last_response.headers['Content-Length']
   end
 
   test "not modified partial response with fingerprint and if-none-match etags match" do
@@ -172,8 +172,8 @@ class TestServer < Sprockets::TestCase
       'HTTP_IF_MATCH' => etag
 
     assert_equal 200, last_response.status
-    assert_equal '"b452c9ae1d5c8d9246653e0d93bc83abce0ee09ef725c0f0a29a41269c217b83"', last_response.headers['ETag']
-    assert_equal '52', last_response.headers['Content-Length']
+    assert_equal '"0daf0f86922e94e54db5d664a29121ca1f2ac5dfda71db9691e5c6477d42b28b"', last_response.headers['ETag']
+    assert_equal '54', last_response.headers['Content-Length']
   end
 
   test "precondition failed with if-match is a mismatch" do
@@ -288,7 +288,7 @@ class TestServer < Sprockets::TestCase
 
     sandbox filename do
       get "/assets/tree.js"
-      assert_equal "var foo;\n\n(function() {\n  application.boot();\n})();\nvar bar;\nvar japanese = \"日本語\";\n", last_response.body
+      assert_equal "var foo;\n;\n\n(function() {\n  application.boot();\n})();\n;\nvar bar;\n;\nvar japanese = \"日本語\";\n;\n", last_response.body
 
       File.open(filename, "w") do |f|
         f.write "var baz;\n"
@@ -299,7 +299,7 @@ class TestServer < Sprockets::TestCase
       File.utime(mtime, mtime, path)
 
       get "/assets/tree.js"
-      assert_equal "var foo;\n\n(function() {\n  application.boot();\n})();\nvar bar;\nvar baz;\nvar japanese = \"日本語\";\n", last_response.body
+      assert_equal "var foo;\n;\n\n(function() {\n  application.boot();\n})();\n;\nvar bar;\n;\nvar baz;\n;\nvar japanese = \"日本語\";\n;\n", last_response.body
     end
   end
 

--- a/test/test_sprocketize.rb
+++ b/test/test_sprocketize.rb
@@ -52,7 +52,7 @@ class TestSprockets < Sprockets::TestCase
 
   test "compile file with dependencies" do
     output = sprockets "-I", fixture_path("asset"), fixture_path("asset/application.js")
-    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\nvar Users = {\n  find: function(id) {\n  }\n};\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n", output
+    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\n;\nvar Users = {\n  find: function(id) {\n  }\n};\n;\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n", output
   end
 
   test "compile asset to output directory" do

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -69,34 +69,14 @@ class TestUtils < MiniTest::Test
     assert h[:foo][:bar].frozen?
   end
 
-  def test_string_ends_with_semicolon
-    assert string_end_with_semicolon?("var foo;")
-    refute string_end_with_semicolon?("var foo")
-
-    assert string_end_with_semicolon?("var foo;\n")
-    refute string_end_with_semicolon?("var foo\n")
-
-    assert string_end_with_semicolon?("var foo;\n\n")
-    refute string_end_with_semicolon?("var foo\n\n")
-
-    assert string_end_with_semicolon?("  var foo;\n  \n")
-    refute string_end_with_semicolon?("  var foo\n  \n")
-
-    assert string_end_with_semicolon?("\tvar foo;\n\t\n")
-    refute string_end_with_semicolon?("\tvar foo\n\t\n")
-
-    assert string_end_with_semicolon?("var foo\n;\n")
-    refute string_end_with_semicolon?("var foo\n\n")
-  end
-
   def test_concat_javascript_sources
     assert_equal "var foo;\n", concat_javascript_sources(String.new(""), "var foo;\n".freeze)
-    assert_equal "\nvar foo;\n", concat_javascript_sources(String.new("\n"), "var foo;\n".freeze)
-    assert_equal " \nvar foo;\n", concat_javascript_sources(String.new(" "), "var foo;\n".freeze)
+    assert_equal "\n;\nvar foo;\n", concat_javascript_sources(String.new("\n"), "var foo;\n".freeze)
+    assert_equal " ;\nvar foo;\n", concat_javascript_sources(String.new(" "), "var foo;\n".freeze)
 
-    assert_equal "var foo;\nvar bar;\n", concat_javascript_sources(String.new("var foo;\n"), "var bar;\n".freeze)
+    assert_equal "var foo;\n;\nvar bar;\n", concat_javascript_sources(String.new("var foo;\n"), "var bar;\n".freeze)
     assert_equal "var foo;\nvar bar", concat_javascript_sources(String.new("var foo"), "var bar".freeze)
-    assert_equal "var foo;\nvar bar;", concat_javascript_sources(String.new("var foo;"), "var bar;".freeze)
+    assert_equal "var foo;;\nvar bar;", concat_javascript_sources(String.new("var foo;"), "var bar;".freeze)
     assert_equal "var foo;\nvar bar;", concat_javascript_sources(String.new("var foo"), "var bar;".freeze)
   end
 


### PR DESCRIPTION
Closes #300

Unfortunately, given how widely used `concat_javascript_sources` is, this required changing a lot of tests. It would be nice if we could remove some of the duplication in these tests (so that similar changes would not require updating this many tests), but that can come in another PR.