### PR TITLE
Fix quadratic performance in concat_javascript_sources

### DIFF
--- a/lib/sprockets/utils.rb
+++ b/lib/sprockets/utils.rb
@@ -76,16 +76,19 @@ module Sprockets
     def string_end_with_semicolon?(str)
       i = str.size - 1
       while i >= 0
-        c = str[i]
+        c = str[i].ord
         i -= 1
-        if c == "\n" || c == " " || c == "\t"
-          next
-        elsif c != ";"
-          return false
-        else
-          return true
+
+        # Need to compare against the ordinals because the string can be UTF_8 or UTF_32LE encoded
+        # 0x0A == "\n"
+        # 0x20 == " "
+        # 0x09 == "\t"
+        # 0x3B == ";"
+        unless c == 0x0A || c == 0x20 || c == 0x09
+          return c === 0x3B
         end
       end
+
       true
     end
 
@@ -97,11 +100,21 @@ module Sprockets
     #
     # Returns buf String.
     def concat_javascript_sources(buf, source)
-      if buf.bytesize > 0
-        buf << ";" unless string_end_with_semicolon?(buf)
-        buf << "\n" unless buf.end_with?("\n")
+      if source.bytesize > 0
+        buf << source
+
+        # If the source contains non-ASCII characters, indexing on it becomes O(N).
+        # This will lead to O(N^2) performance in string_end_with_semicolon?, so we should use 32 bit encoding to make sure indexing stays O(1)
+        source = source.encode(Encoding::UTF_32LE) unless source.ascii_only?
+
+        if !string_end_with_semicolon?(source)
+          buf << ";\n"
+        elsif source[source.size - 1].ord != 0x0A
+          buf << "\n"
+        end
       end
-      buf << source
+
+      buf
     end
 
     # Internal: Inject into target module for the duration of the block.

--- a/test/fixtures/context/resolve_content_type.js.erb
+++ b/test/fixtures/context/resolve_content_type.js.erb
@@ -1,2 +1,2 @@
-<%= resolve("foo.js") %>,
-<%= resolve("foo", accept: "application/javascript") %>
+<%= resolve("foo.js") %>;
+<%= resolve("foo", accept: "application/javascript") %>;

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -878,6 +878,7 @@ class BundledAssetTest < Sprockets::TestCase
 define("application.js", "application-955b2dddd0d1449b1c617124b83b46300edadec06d561104f7f6165241b31a94.js")
 define("application.css", "application-46d50149c56fc370805f53c29f79b89a52d4cc479eeebcdc8db84ab116d7ab1a.css")
 define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png")
+;
     EOS
     assert_equal [
       "file://#{fixture_path_for_uri("asset/POW.png")}?type=image/png&id=xxx",
@@ -896,6 +897,7 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
 define("application.js", "application-955b2dddd0d1449b1c617124b83b46300edadec06d561104f7f6165241b31a94.js")
 define("application.css", "application-46d50149c56fc370805f53c29f79b89a52d4cc479eeebcdc8db84ab116d7ab1a.css")
 define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png")
+;
     EOS
 
     assert_equal [
@@ -1050,12 +1052,12 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
   end
 
   test "appends missing semicolons" do
-    assert_equal "var Bar\n;\n\n(function() {\n  var Foo\n})\n",
+    assert_equal "var Bar\n;\n\n(function() {\n  var Foo\n})\n;\n",
       asset("semicolons.js").to_s
   end
 
   test 'keeps code in same line after multi-line comments' do
-    assert_equal "/******/ function foo() {\n}\n",
+    assert_equal "/******/ function foo() {\n}\n;\n",
       asset('multi_line_comment.js').to_s
   end
 

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -50,10 +50,10 @@ class TestContext < Sprockets::TestCase
   end
 
   test "resolve with content type" do
-    assert_equal [
-      "file://#{fixture_path_for_uri("context/foo.js")}?type=application/javascript",
-      "file://#{fixture_path_for_uri("context/foo.js")}?type=application/javascript"
-    ].join(",\n"), @env["resolve_content_type.js"].to_s.strip
+    assert_equal(<<-FILE, @env["resolve_content_type.js"].to_s)
+file://#{fixture_path_for_uri("context/foo.js")}?type=application/javascript;
+file://#{fixture_path_for_uri("context/foo.js")}?type=application/javascript;
+FILE
   end
 end
 

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -744,7 +744,7 @@ class TestEnvironment < Sprockets::TestCase
     assert processor = @env.preprocessors['application/javascript'][0]
     assert_kind_of Sprockets::DirectiveProcessor, processor
     @env.unregister_preprocessor('application/javascript', processor)
-    assert_equal "// =require \"notfound\"\n", @env["missing_require.js"].to_s
+    assert_equal "// =require \"notfound\"\n;\n", @env["missing_require.js"].to_s
   end
 end
 

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -90,15 +90,20 @@ class TestUtils < MiniTest::Test
   end
 
   def test_concat_javascript_sources
-    assert_equal "var foo;\n", concat_javascript_sources(String.new(""), "var foo;\n".freeze)
-    assert_equal "\nvar foo;\n", concat_javascript_sources(String.new("\n"), "var foo;\n".freeze)
-    assert_equal " \nvar foo;\n", concat_javascript_sources(String.new(" "), "var foo;\n".freeze)
+    assert_equal "var foo;\n", apply_concat_javascript_sources("".freeze, "var foo;\n".freeze)
+    assert_equal "\nvar foo;\n", apply_concat_javascript_sources("\n".freeze, "var foo;\n".freeze)
+    assert_equal " \nvar foo;\n", apply_concat_javascript_sources(" ".freeze, "var foo;\n".freeze)
 
-    assert_equal "var foo;\nvar bar;\n", concat_javascript_sources(String.new("var foo;\n"), "var bar;\n".freeze)
-    assert_equal "var foo;\nvar bar", concat_javascript_sources(String.new("var foo"), "var bar".freeze)
-    assert_equal "var foo;\nvar bar;", concat_javascript_sources(String.new("var foo;"), "var bar;".freeze)
-    assert_equal "var foo;\nvar bar;", concat_javascript_sources(String.new("var foo"), "var bar;".freeze)
+    assert_equal "var foo;\nvar bar;\n", apply_concat_javascript_sources("var foo;\n".freeze, "var bar;\n".freeze)
+    assert_equal "var foo;\nvar bar;\n", apply_concat_javascript_sources("var foo".freeze, "var bar".freeze)
+    assert_equal "var foo;\nvar bar;\n", apply_concat_javascript_sources("var foo;".freeze, "var bar;".freeze)
+    assert_equal "var foo;\nvar bar;\n", apply_concat_javascript_sources("var foo".freeze, "var bar;".freeze)
   end
+
+  def apply_concat_javascript_sources(*args)
+    args.reduce(String.new(""), &method(:concat_javascript_sources))
+  end
+
 
   def test_post_order_depth_first_search
     m = []


### PR DESCRIPTION
### Summary

If a UTF8-encoded Ruby string contains unicode characters, then indexing into that string becomes O(N). This can lead to very bad performance in `string_end_with_semicolon?`, as it would have to scan through the whole buffer for every single file. This commit fixes it to use UTF32 if there are any non-ascii characters in the files.

### More info

I was doing some tracing on asset compilation time in Shopify, and I discovered that we would spend an excessive amount of time recompiling our JS bundle, even if only a single file changed.

We have the following profiling script:

```ruby
#!/usr/bin/env ruby
require_relative '../config/environment'

StackProf.run(raw: true, mode: :wall, out: 'tmp/stackprof-cpu-assets.dump') do
  puts Rails.application.assets.cache.inspect
  start_time = Process.clock_gettime Process::CLOCK_MONOTONIC
  Rails.application.precompiled_assets
  puts "Total time: %.2fs" % [Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time]
  puts Rails.application.assets.cache.inspect
end
```

This is what StackProf would show me, from a warm cache after changing just a single file:

```
Total time: 26.66s

==================================
  Mode: wall(1000)
  Samples: 20265 (24.77% miss rate)
  GC: 2966 (14.64%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      5156  (25.4%)        5156  (25.4%)     Sprockets::Utils#string_end_with_semicolon?
      5537  (27.3%)        5003  (24.7%)     block in Sprockets::Cache::FileStore#get
      6208  (30.6%)         671   (3.3%)     Sprockets::Cache::FileStore#safe_open
       408   (2.0%)         408   (2.0%)     URI::RFC3986_Parser#split
       407   (2.0%)         407   (2.0%)     Sprockets::PathUtils#stat
       364   (1.8%)         346   (1.7%)     Sprockets::DigestUtils#digest
       335   (1.7%)         335   (1.7%)     Sprockets::PathUtils#split_subpath
       332   (1.6%)         332   (1.6%)     #<Module:0x007fc1498c7ac8>.load_with_autoloading
       592   (2.9%)         317   (1.6%)     Sprockets::URITar#initialize
       304   (1.5%)         304   (1.5%)     block in FileUtils#touch
       275   (1.4%)         275   (1.4%)     Sprockets::Paths#root
       254   (1.3%)         254   (1.3%)     Sprockets::PathUtils#path_extnames
       323   (1.6%)         252   (1.2%)     Sprockets::URITar#expand
       210   (1.0%)         210   (1.0%)     block in Sprockets::Manifest.compile_match_filter
```

As you can see, a crazy amount of time is spent in `string_end_with_semicolon?`

This is what the same script tells me after this PR:

```
Total time: 16.24s

==================================
  Mode: wall(1000)
  Samples: 12230 (26.24% miss rate)
  GC: 2690 (22.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      2316  (18.9%)        1679  (13.7%)     block in Sprockets::Cache::FileStore#get
      3126  (25.6%)         810   (6.6%)     Sprockets::Cache::FileStore#safe_open
       465   (3.8%)         465   (3.8%)     URI::RFC3986_Parser#split
       468   (3.8%)         449   (3.7%)     Sprockets::DigestUtils#digest
       437   (3.6%)         437   (3.6%)     Sprockets::PathUtils#stat
       435   (3.6%)         435   (3.6%)     #<Module:0x007f91bb0c7ae8>.load_with_autoloading
       346   (2.8%)         346   (2.8%)     Sprockets::PathUtils#split_subpath
       659   (5.4%)         331   (2.7%)     Sprockets::URITar#initialize
       328   (2.7%)         328   (2.7%)     Sprockets::Paths#root
       319   (2.6%)         319   (2.6%)     block in FileUtils#touch
       280   (2.3%)         280   (2.3%)     Sprockets::PathUtils#path_extnames
       317   (2.6%)         247   (2.0%)     Sprockets::URITar#expand
       212   (1.7%)         212   (1.7%)     block in Sprockets::Manifest.compile_match_filter
       637   (5.2%)         202   (1.7%)     Sprockets::EncodingUtils#unmarshaled_deflated
```

Essentially Sprockets would run into the same issue as http://accidentallyquadratic.tumblr.com/post/139210135602/ruby-parser-gem did.

cc @rafaelfranca 