### PR TITLE
Appends the load paths to error message

### DIFF
--- a/lib/sprockets/resolve.rb
+++ b/lib/sprockets/resolve.rb
@@ -60,6 +60,7 @@ module Sprockets
         end
 
         message << " with type '#{options[:accept]}'" if options[:accept]
+        message << "\nLooked up these paths: #{config[:paths]}"
 
         raise FileNotFound, message
       end

--- a/lib/sprockets/resolve.rb
+++ b/lib/sprockets/resolve.rb
@@ -60,7 +60,7 @@ module Sprockets
         end
 
         message << " with type '#{options[:accept]}'" if options[:accept]
-        message << "\nLooked up these paths: #{config[:paths]}"
+        message << "\nChecked in these paths: \n  #{ config[:paths].join("\n  ") }"
 
         raise FileNotFound, message
       end

--- a/test/test_resolve.rb
+++ b/test/test_resolve.rb
@@ -251,6 +251,18 @@ class TestResolve < Sprockets::TestCase
       @env.each_logical_path("application.js", /gallery\.css/).to_a
   end
 
+  test "adds paths to exceptions" do
+    random_path = SecureRandom.hex
+    @env.append_path(random_path)
+
+    error = assert_raises(Sprockets::FileNotFound) do
+      uri, _ = @env.resolve!("thisfiledoesnotexistandshouldraiseerrors", {})
+      uri
+    end
+
+    assert_match /#{ random_path }/, error.message
+  end
+
   def resolve(path, options = {})
     uri, _ = @env.resolve(path, options.merge(compat: false))
     uri

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -283,7 +283,7 @@ class TestServer < Sprockets::TestCase
   test "re-throw JS exceptions in the browser" do
     get "/assets/missing_require.js"
     assert_equal 200, last_response.status
-    assert_equal "throw Error(\"Sprockets::FileNotFound: couldn't find file 'notfound' with type 'application/javascript'\\n  (in #{fixture_path("server/vendor/javascripts/missing_require.js")}:1)\")", last_response.body
+    assert_equal "throw Error(\"Sprockets::FileNotFound: couldn't find file 'notfound' with type 'application/javascript'\\nLooked up these paths: #{@env.paths}\\n  (in #{fixture_path("server/vendor/javascripts/missing_require.js")}:1)\")", last_response.body
   end
 
   test "display CSS exceptions in the browser" do

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -283,7 +283,8 @@ class TestServer < Sprockets::TestCase
   test "re-throw JS exceptions in the browser" do
     get "/assets/missing_require.js"
     assert_equal 200, last_response.status
-    assert_equal "throw Error(\"Sprockets::FileNotFound: couldn't find file 'notfound' with type 'application/javascript'\\nLooked up these paths: #{@env.paths}\\n  (in #{fixture_path("server/vendor/javascripts/missing_require.js")}:1)\")", last_response.body
+    assert_match /Sprockets::FileNotFound: couldn't find file 'notfound' with type 'application\/javascript'/, last_response.body
+    assert_match /(in #{fixture_path("server/vendor/javascripts/missing_require.js")}:1)/, last_response.body
   end
 
   test "display CSS exceptions in the browser" do


### PR DESCRIPTION
When `resolve!` raises an error, it would not display the paths that
were used to look up the assets. If we raise this error we can be even
more helpful and display the `config[:path]` as well. This makes it
easier for users to debug their asset paths.

I am unsure whether you like the way I introduced the load paths into the error message. Please see below.

Original error messages:

``` bash
ActionView::Template::Error (couldn't find file '../other_javascripts/f' under '/Users/holger/projects/ikusei/opensource/sprockets-test-app/app/assets/javascripts' with type 'application/javascript'):
    3: <head>
    4:   <title>SprocketsTestApp</title>
    5:   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
    6:   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
    7:   <%= csrf_meta_tags %>
    8: </head>
    9: <body>
  app/assets/javascripts/application.js:20
  app/views/layouts/application.html.erb:6:in `_app_views_layouts_application_html_erb___2173404954647428090_70191239104980'


  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.2.5.1/lib/action_dispatch/middleware/templates/rescues/_source.erb (5.9ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.2.5.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (3.4ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.2.5.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (0.7ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.2.5.1/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (54.1ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/_markup.html.erb (0.3ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/_inner_console_markup.html.erb within layouts/inlined_string (0.2ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/_prompt_box_markup.html.erb within layouts/inlined_string (0.4ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/style.css.erb within layouts/inlined_string (0.3ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/console.js.erb within layouts/javascript (50.5ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/main.js.erb within layouts/javascript (0.3ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/error_page.js.erb within layouts/javascript (0.4ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/index.html.erb (109.3ms)
```

New error messages:

``` bash
ActionView::Template::Error (couldn't find file '../other_javascripts/f' under '/Users/holger/projects/ikusei/opensource/sprockets-test-app/app/assets/javascripts' with type 'application/javascript'
Looked up these paths: ["/Users/holger/projects/ikusei/opensource/sprockets-test-app/app/assets/images", "/Users/holger/projects/ikusei/opensource/sprockets-test-app/app/assets/javascripts", "/Users/holger/projects/ikusei/opensource/sprockets-test-app/app/assets/other_javascripts", "/Users/holger/projects/ikusei/opensource/sprockets-test-app/app/assets/stylesheets", "/Users/holger/projects/ikusei/opensource/sprockets-test-app/lib/assets/javascripts", "/Users/holger/projects/ikusei/opensource/sprockets-test-app/vendor/assets/javascripts", "/Users/holger/projects/ikusei/opensource/sprockets-test-app/vendor/assets/stylesheets", "/Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/turbolinks-2.5.3/lib/assets/javascripts", "/Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/jquery-rails-4.1.0/vendor/assets/javascripts", "/Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/coffee-rails-4.1.1/lib/assets/javascripts"]):
    3: <head>
    4:   <title>SprocketsTestApp</title>
    5:   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
    6:   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
    7:   <%= csrf_meta_tags %>
    8: </head>
    9: <body>
  app/assets/javascripts/application.js:20
  app/views/layouts/application.html.erb:6:in `_app_views_layouts_application_html_erb___3948160733622279578_70177100816340'


  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.2.5.1/lib/action_dispatch/middleware/templates/rescues/_source.erb (6.2ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.2.5.1/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (5.1ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.2.5.1/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (0.7ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.2.5.1/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (61.7ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/_markup.html.erb (0.3ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/_inner_console_markup.html.erb within layouts/inlined_string (0.3ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/_prompt_box_markup.html.erb within layouts/inlined_string (0.3ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/style.css.erb within layouts/inlined_string (0.3ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/console.js.erb within layouts/javascript (67.6ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/main.js.erb within layouts/javascript (0.3ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/error_page.js.erb within layouts/javascript (0.7ms)
  Rendered /Users/holger/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/web-console-2.3.0/lib/web_console/templates/index.html.erb (137.7ms)
```

**I could not get the test to pass, because of the double escaping quotes:**
Any help would be appreciated.

``` bash
TestServer#test_"re-throw JS exceptions in the browser" [/Users/holger/projects/ikusei/opensource/sprockets/test/test_server.rb:244]:
--- expected
+++ actual
@@ -1,3 +1,3 @@
 "throw Error(\"Sprockets::FileNotFound: couldn't find file 'notfound' with type 'application/javascript'\
-Looked up these paths: [\"/Users/holger/projects/ikusei/opensource/sprockets/test/fixtures/server/app/javascripts\", \"/Users/holger/projects/ikusei/opensource/sprockets/test/fixtures/server/app/images\", \"/Users/holger/projects/ikusei/opensource/sprockets/test/fixtures/server/vendor/javascripts\", \"/Users/holger/projects/ikusei/opensource/sprockets/test/fixtures/server/vendor/stylesheets\"]\
+Looked up these paths: [\\\"/Users/holger/projects/ikusei/opensource/sprockets/test/fixtures/server/app/javascripts\\\", \\\"/Users/holger/projects/ikusei/opensource/sprockets/test/fixtures/server/app/images\\\", \\\"/Users/holger/projects/ikusei/opensource/sprockets/test/fixtures/server/vendor/javascripts\\\", \\\"/Users/holger/projects/ikusei/opensource/sprockets/test/fixtures/server/vendor/stylesheets\\\"]\
   (in /Users/holger/projects/ikusei/opensource/sprockets/test/fixtures/server/vendor/javascripts/missing_require.js:1)\")"
```

References #252