### PR TITLE
Added Travis CI status in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ assets, as well as a powerful preprocessor pipeline that allows you to
 write assets in languages like CoffeeScript, Sass and SCSS.
 
 
+## Code Status
+
+[![Build Status](https://secure.travis-ci.org/rails/sprockets.svg?branch=master)](http://travis-ci.org/rails/sprockets)
+
 ## Installation
 
 Install Sprockets from RubyGems:


### PR DESCRIPTION
I created a Code Status section and I added the Travis badge into the README.
Before it was only available in the CONTRIBUTING.

I setup Codacy (https://www.codacy.com/app/heliocola/sprockets) and AppVeyor (https://ci.appveyor.com/project/rafaelfranca/sprockets) is already being used as well if you guys agree that it will add value.