### PR TITLE
Adds failing tests for ScsscProcessor

### DIFF
--- a/test/test_sassc.rb
+++ b/test/test_sassc.rb
@@ -66,6 +66,7 @@ class TestSprocketsSassc < TestBaseSassc
       env.append_path(fixture_path('compass'))
       env.append_path(fixture_path('octicons'))
       env.register_transformer 'text/sass', 'text/css', Sprockets::SasscProcessor.new
+      env.register_transformer 'text/scss', 'text/css', Sprockets::ScsscProcessor.new
     end
   end
 


### PR DESCRIPTION
Previously tests were passing because `.scss` files were being rendered with the Ruby `ScssProcessor` (instead of `ScsscProcessor`).

With this change

```
$ rake test TEST=/Users/richardschneeman/Documents/projects/sprockets/test/test_sassc.rb

  1) Failure:
TestSasscFunctions#test_"modify partial causes it to recompile" [/Users/richardschneeman/Documents/projects/sprockets/test/shared_sass_tests.rb:181]:
--- expected
+++ actual
@@ -1,3 +1,3 @@
 "body {
-  background: blue; }
+  background: red; }
 "



  2) Failure:
TestSasscFunctions#test_"@import css file from load path" [/Users/richardschneeman/Documents/projects/sprockets/test/shared_sass_tests.rb:117]:
--- expected
+++ actual
@@ -1,2 +1 @@
-"
-"
+""



  3) Failure:
TestSprocketsSassc#test_"@import css file from load path" [/Users/richardschneeman/Documents/projects/sprockets/test/shared_sass_tests.rb:117]:
--- expected
+++ actual
@@ -1,2 +1 @@
-"
-"
+""



  4) Failure:
TestSprocketsSassc#test_"modify partial causes it to recompile" [/Users/richardschneeman/Documents/projects/sprockets/test/shared_sass_tests.rb:181]:
--- expected
+++ actual
@@ -1,3 +1,3 @@
 "body {
-  background: blue; }
+  background: red; }
 "


37 runs, 94 assertions, 4 failures, 0 errors, 2 skips
```
