### PR TITLE
ensure sassc tests are working properly

### DIFF
--- a/lib/sprockets/sassc_processor.rb
+++ b/lib/sprockets/sassc_processor.rb
@@ -34,6 +34,10 @@ module Sprockets
         change_source(SourceMapUtils.decode_json_source_map(map)["mappings"], input[:source_path])
       )
 
+      engine.dependencies.each do |dependency|
+        context.metadata[:dependencies] << URIUtils.build_file_digest_uri(dependency.filename)
+      end
+
       context.metadata.merge(data: css, map: map)
     end
 

--- a/test/shared_sass_tests.rb
+++ b/test/shared_sass_tests.rb
@@ -114,7 +114,7 @@ li {
   end
 
   test "@import css file from load path" do
-    assert_equal "\n", render('sass/import_load_path.scss')
+    assert_match /\A\s*\z/, render('sass/import_load_path.scss')
   end
 
   test "process css file" do

--- a/test/test_sassc.rb
+++ b/test/test_sassc.rb
@@ -66,6 +66,7 @@ class TestSprocketsSassc < TestBaseSassc
       env.append_path(fixture_path('compass'))
       env.append_path(fixture_path('octicons'))
       env.register_transformer 'text/sass', 'text/css', Sprockets::SasscProcessor.new
+      env.register_transformer 'text/scss', 'text/css', Sprockets::ScsscProcessor.new
     end
   end
 


### PR DESCRIPTION
"@import css file from load path" - I don't think the _exact_ output of this is very important.  I think that empty string and newline are close enough.

As far as the partial update/cache test, looks like we weren't adding the dependencies.