### PR TITLE
Fix uglifier comment stripping default

### DIFF
--- a/lib/sprockets/uglifier_compressor.rb
+++ b/lib/sprockets/uglifier_compressor.rb
@@ -41,7 +41,7 @@ module Sprockets
         options[:copyright] ||= false
       else
         # Uglifier >= 2.x
-        options[:copyright] ||= :none
+        options[:comments] ||= :none
       end
 
       @uglifier = Autoload::Uglifier.new(options)

--- a/test/test_uglifier_compressor.rb
+++ b/test/test_uglifier_compressor.rb
@@ -6,7 +6,7 @@ class TestUglifierCompressor < MiniTest::Test
   def test_compress_javascript
     input = {
       content_type: 'application/javascript',
-      data: "function foo() {\n  return true;\n}",
+      data: "/* Copyright Rails */\nfunction foo() {\n  return true;\n}",
       cache: Sprockets::Cache.new
     }
     output = "function foo(){return!0}"


### PR DESCRIPTION
There was a type in the uglifier compressor for the `3.x` branch, where `copyright` should've been `comments`. I've also amended the test to fix this