### PR TITLE
Short circuit entry check

### DIFF
--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -178,6 +178,7 @@ module Sprockets
     def find_matching_path_for_extensions(path, basename, extensions)
       matches = []
       entries(path).each do |entry|
+        next unless File.basename(entry).start_with?(basename)
         extname, value = match_path_extname(entry, extensions)
         if basename == entry.chomp(extname)
           filename = File.join(path, entry)


### PR DESCRIPTION
The method `match_path_extname` is expensive. We know that if the name of the file on disk does not start with the same basename that we're looking for then it won't matter what extensions it's got. This check is pretty fast.

On the example app

https://github.com/nfm/sprockets-3.x-performance-regressions

It reduced asset lookup from 15 seconds to 2.6 seconds. It's still not perfect but it's a 400% + speed increase in the case of looking for an asset in a huge directory.

Related comment https://github.com/rails/sprockets/issues/84#issuecomment-228968798