### PR TITLE
[close #331] Smarter entry lookup

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -162,6 +162,7 @@ module Sprockets
   require 'sprockets/eco_processor'
   require 'sprockets/ejs_processor'
   require 'sprockets/jst_processor'
+  register_mime_type 'application/javascript+function', extensions: []
   register_mime_type 'text/eco', extensions: ['.eco', '.jst.eco']
   register_mime_type 'text/ejs', extensions: ['.ejs', '.jst.ejs']
   register_transformer 'text/eco', 'application/javascript+function', EcoProcessor

--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -177,16 +177,30 @@ module Sprockets
     # Returns an Array of [String path, Object value] matches.
     def find_matching_path_for_extensions(path, basename, extensions)
       matches = []
-      entries(path).each do |entry|
-        next unless File.basename(entry).start_with?(basename)
-        extname, value = match_path_extname(entry, extensions)
-        if basename == entry.chomp(extname)
-          filename = File.join(path, entry)
-          if file?(filename)
-            matches << [filename, value]
+      # Requires a file touch for each extension
+      # In the case where lots of extensions are given, it may be faster to search the directory
+      if extensions.length < 3
+        extensions.each do |(extension, mime_type)|
+          file = File.join(path, basename + extension)
+          matches << [file, mime_type] if File.exist?(file)
+        end
+      end
+
+      # Used when files don't have registered mime types or
+      # when a large number of extensions would require too many file touches.
+      if matches.empty?
+        entries(path).each do |entry|
+          next unless File.basename(entry).start_with?(basename)
+          extname, value = match_path_extname(entry, extensions)
+          if basename == entry.chomp(extname)
+            filename = File.join(path, entry)
+            if file?(filename)
+              matches << [filename, value]
+            end
           end
         end
       end
+
       matches
     end
 

--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -178,6 +178,7 @@ module Sprockets
     def find_matching_path_for_extensions(path, basename, extensions)
       matches = []
       entries(path).each do |entry|
+        next unless File.basename(entry).start_with?(basename)
         extname, value = match_path_extname(entry, extensions)
         if basename == entry.chomp(extname)
           filename = File.join(path, entry)

--- a/lib/sprockets/resolve.rb
+++ b/lib/sprockets/resolve.rb
@@ -180,7 +180,20 @@ module Sprockets
           method(:resolve_alts_under_path),
           method(:resolve_index_under_path)
         ]
-        mime_exts = config[:mime_exts]
+
+        mime_exts = {}
+        accepts.each do |mime, version|
+          if '*/*'.freeze == mime
+            mime_exts = config[:mime_exts]
+            break
+          end
+
+          mime_hash = config[:mime_types][mime]
+          raise "No valid mime type found for #{ mime.inspect }. Valid types #{ config[:mime_types].keys.inspect }" unless mime_hash
+          mime_hash[:extensions].each do |extension|
+            mime_exts[extension] = mime
+          end
+        end
 
         paths.each do |load_path|
           candidates = []

--- a/test/test_path_utils.rb
+++ b/test/test_path_utils.rb
@@ -44,7 +44,7 @@ class TestPathUtils < MiniTest::Test
       "source-maps",
       "symlink"
     ], entries(File.expand_path("../fixtures", __FILE__))
-    
+
     [ ['a', 'b'], ['a', 'b', '.', '..'] ].each do |dir_contents|
       Dir.stub :entries, dir_contents do
         assert_equal ['a', 'b'], entries(Dir.tmpdir)
@@ -185,7 +185,7 @@ class TestPathUtils < MiniTest::Test
     assert_equal [
       ["#{dirname}/hello.jst.ejs", "application/ejs"],
       ["#{dirname}/hello.txt", "text/plain"]
-    ], find_matching_path_for_extensions(dirname, "hello", extensions)
+    ].sort, find_matching_path_for_extensions(dirname, "hello", extensions).sort
 
   end
 


### PR DESCRIPTION
Instead of iterating every entry in a given path, we only pass in valid mime types and explicitly check for basenames that match the extensions we are looking for (when extensions are sufficiently small). 

For example if we are looking for `foo` with mime of `image/png` instead of looking at EVERY entry in the directory instead we will explicitly look for:

- foo.png

This only works for mime types that have few extensions. It does not scale well for mime types like javascript that would require many many file touches (.coffee, .coffee.erb, .js, .js.erb, .eco, .eco.erb, etc.) even though there may only be a few entries in the directory. When confronted with many extensions (using magic number 3) we go back to the old method of looping through all entries in the directory.

This PR makes searching for files with no transforms very fast. For example images in large directories will be much faster as they will only require one lookup instead of looping through all entries.

Using the same script from #331

```
$ be rake sprockets:benchmark
Running benchmark...
1500 lookups of the same asset took 1.369423
1500 lookups of 1500 different assets took 2.058736
```

Which is a substantial speedup.

In the future if we could imply the user's preferred extension i.e if a user uses `.coffee.erb` for all JS files and never uses `.eco.js` then we could make this even faster. We could record the file extensions that are used when running in the cache, prefer those when available, when not available fall back to this logic and record the file extension.