### PR TITLE
PathUtils: *always* prefer longer to shorter extension match

### DIFF
--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -150,16 +150,19 @@ module Sprockets
     #
     # Returns [String extname, Object value] or nil nothing matched.
     def match_path_extname(path, extensions)
-      match, key = nil, String.new("")
-      path_extnames(path).reverse_each do |extname|
-        key.prepend(extname)
-        if value = extensions[key]
-          match = [key.dup, value]
-        elsif match
-          break
+      basename = File.basename(path)
+
+      i = basename.index('.'.freeze)
+      while i && i < basename.length - 1
+        extname = basename[i..-1]
+        if value = extensions[extname]
+          return extname, value
         end
+
+        i = basename.index('.'.freeze, i+1)
       end
-      match
+
+      nil
     end
 
     # Internal: Match paths in a directory against available extensions.

--- a/test/test_path_utils.rb
+++ b/test/test_path_utils.rb
@@ -171,6 +171,9 @@ class TestPathUtils < MiniTest::Test
     refute match_path_extname("jquery.map", extensions)
     refute match_path_extname("jquery.map.js", extensions)
     refute match_path_extname("jquery.map.css", extensions)
+
+    extensions = { ".coffee" => "application/coffeescript", ".js" => "application/javascript", ".js.jsx.coffee" => "application/jsx+coffee" }
+    assert_equal [".js.jsx.coffee", "application/jsx+coffee"], match_path_extname("component.js.jsx.coffee", extensions)
   end
 
   def test_find_matching_path_for_extensions


### PR DESCRIPTION
The older logic would *usually* prefer a longer to a shorter extension
match, but not in the case with a three-or-more-component extension
when one of the intermediate extensions wasn't recognized, e.g.
".coffee" would be preferred over ".js.jsx.coffee" unless ".jsx.coffee"
was also a recognized extension.

(".js.jsx.coffee" is the preferred Coffee+React extension with
the react-rails gem)