### PR TITLE
Handle passing non-string paths to 'resolve' in a friendlier way

### DIFF
--- a/lib/sprockets/resolve.rb
+++ b/lib/sprockets/resolve.rb
@@ -22,6 +22,12 @@ module Sprockets
     #
     # The String Asset URI is returned or nil if no results are found.
     def resolve(path, load_paths: config[:paths], accept: nil, pipeline: nil, base_path: nil)
+      unless path.is_a?(String)
+        # This can use the deprecation framework once it's merged
+        @logger.warn("Passing #{path.class.name} to `Sprockets#resolve` is deprecated: #{path}") if @logger
+        return
+      end
+
       paths = load_paths
 
       if valid_asset_uri?(path)


### PR DESCRIPTION
This is a workaround for #117 

I'd suggest that this should remain deprecated but handled in Sprockets 4, not just 3. Some reasons: 
* https://github.com/rails/sprockets-rails/issues/269 still hasn't been resolved a year later
* `bootstrap-sass`, where I and others ran into this, can't be upgraded to a fixed version without also upgrading `sass` itself