### PR TITLE
Backport #331 - Asset lookup 4x Faster in large directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3.1
 
 matrix:
   include:

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,10 @@
 source "https://rubygems.org"
 gemspec
+
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.2.2")
+  gem 'rack', '< 2.0'
+end
+
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.0")
+  gem 'json', '< 2.0'
+end

--- a/gemfiles/Gemfile-1.9
+++ b/gemfiles/Gemfile-1.9
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 gemspec path: '..'
 gem 'sass', '< 3.4'
+gem 'rack', '< 2.0'
+gem 'json', '< 2.0'

--- a/lib/sprockets/resolve.rb
+++ b/lib/sprockets/resolve.rb
@@ -178,6 +178,7 @@ module Sprockets
         candidates = []
         entries = self.entries(dirname)
         entries.each do |entry|
+          next unless File.basename(entry).start_with?(basename)
           name, type, _, _ = parse_path_extnames(entry)
           if basename == name
             candidates << [File.join(dirname, entry), type]


### PR DESCRIPTION
With this patch using the benchmark script https://github.com/schneems/sprockets-3.x-performance-regressions:

```
1500 lookups of the same asset took 2.900005
1500 lookups of 1500 different assets took 2.746331
```

Without this patch using the benchmark script:

```
1500 lookups of the same asset took 12.361615
1500 lookups of 1500 different assets took 12.627099
```

Which is a 4x speed bump.
