### PR TITLE
Faster hexdigest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source "https://rubygems.org"
-gem "rack", github: 'rack/rack'
 gemspec
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.2.2")
   gem 'rack', '< 2.0'
+else
+  gem "rack", github: 'rack/rack'
 end
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.0")

--- a/lib/sprockets/digest_utils.rb
+++ b/lib/sprockets/digest_utils.rb
@@ -67,7 +67,7 @@ module Sprockets
       },
       Set => ->(val, digest) {
         digest << 'Set'.freeze
-        ADD_VALUE_TO_DIGEST[Array].call(val.to_a, digest)
+        ADD_VALUE_TO_DIGEST[Array].call(val, digest)
       },
       Encoding => ->(val, digest) {
         digest << 'Encoding'.freeze

--- a/lib/sprockets/digest_utils.rb
+++ b/lib/sprockets/digest_utils.rb
@@ -88,10 +88,18 @@ module Sprockets
     #
     # Returns a String digest of the object.
     def digest(obj)
-      digest = digest_class.new
+      build_digest(obj).digest
+    end
 
-      ADD_VALUE_TO_DIGEST[obj.class].call(obj, digest)
-      digest.digest
+    # Internal: Generate a hexdigest for a nested JSON serializable object.
+    #
+    # The same as `pack_hexdigest(digest(obj))`.
+    #
+    # obj - A JSON serializable object.
+    #
+    # Returns a String digest of the object.
+    def hexdigest(obj)
+      build_digest(obj).hexdigest!
     end
 
     # Internal: Pack a binary digest to a hex encoded string.
@@ -171,5 +179,13 @@ module Sprockets
     def hexdigest_integrity_uri(hexdigest)
       integrity_uri(unpack_hexdigest(hexdigest))
     end
+
+    private
+      def build_digest(obj)
+        digest = digest_class.new
+
+        ADD_VALUE_TO_DIGEST[obj.class].call(obj, digest)
+        digest
+      end
   end
 end

--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -186,7 +186,7 @@ module Sprockets
           dependencies_digest: DigestUtils.digest(resolve_dependencies(metadata[:dependencies]))
         }
 
-        asset[:id]  = pack_hexdigest(digest(asset))
+        asset[:id]  = hexdigest(asset)
         asset[:uri] = build_asset_uri(unloaded.filename, unloaded.params.merge(id: asset[:id]))
 
         store_asset(asset, unloaded)


### PR DESCRIPTION
Instead of generating a digest string and then hex unpacking it we can generate the hexdigest directly. This is faster:

```ruby
require 'set'
require 'digest/md5'
require 'digest/sha1'
require 'digest/sha2'

require 'benchmark/ips'

ADD_VALUE_TO_DIGEST = {
  String     => ->(val, digest) { digest << val },
  FalseClass => ->(val, digest) { digest << 'FalseClass'.freeze },
  TrueClass  => ->(val, digest) { digest << 'TrueClass'.freeze  },
  NilClass   => ->(val, digest) { digest << 'NilClass'.freeze   },

  Symbol => ->(val, digest) {
    digest << 'Symbol'.freeze
    digest << val.to_s
  },
  Fixnum => ->(val, digest) {
    digest << 'Fixnum'.freeze
    digest << val.to_s
  },
  Bignum => ->(val, digest) {
    digest << 'Bignum'.freeze
    digest << val.to_s
  },
  Array => ->(val, digest) {
    digest << 'Array'.freeze
    val.each do |element|
      ADD_VALUE_TO_DIGEST[element.class].call(element, digest)
    end
  },
  Hash => ->(val, digest) {
    digest << 'Hash'.freeze
    val.sort.each do |array|
      ADD_VALUE_TO_DIGEST[Array].call(array, digest)
    end
  },
  Set => ->(val, digest) {
    digest << 'Set'.freeze
    ADD_VALUE_TO_DIGEST[Array].call(val.to_a, digest)
  },
  Encoding => ->(val, digest) {
    digest << 'Encoding'.freeze
    digest << val.name
  },
}
ADD_VALUE_TO_DIGEST.default_proc = ->(_, val) {
  raise TypeError, "couldn't digest #{ val }"
}

def digest(obj)
  build_digest(obj).digest
end

def hex_digest(obj)
  build_digest(obj).hexdigest!
end

private def build_digest(obj)
  digest = Digest::SHA256.new

  ADD_VALUE_TO_DIGEST[obj.class].call(obj, digest)
  digest
end

def pack_hexdigest(bin)
  bin.unpack('H*'.freeze).first
end

string = "foo"


puts hex_digest(string) ==  pack_hexdigest(digest(string))
Benchmark.ips do |x|
  x.report("hexdigest!") { |num|
    i = 0
    while i < num
      hex_digest(string)
      i += 1
    end
  }
  x.report("current   ") { |num|
    i = 0
    while i < num
      pack_hexdigest(digest(string))
      i += 1
    end
  }

  x.compare!
end
```

gives us

```
Warming up --------------------------------------
          hexdigest!    41.436k i/100ms
          current       31.106k i/100ms
Calculating -------------------------------------
          hexdigest!    461.626k (±10.9%) i/s -      2.279M in   5.021881s
          current       337.497k (± 8.6%) i/s -      1.680M in   5.023593s

Comparison:
          hexdigest!:   461625.9 i/s
          current   :   337497.0 i/s - 1.37x slower
```