### PR TITLE
Ruby 2.4.0-preview1 compatability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.1
+  - 2.4.0-preview1
 
 matrix:
   include:

--- a/test/test_digest_utils.rb
+++ b/test/test_digest_utils.rb
@@ -18,15 +18,20 @@ class TestDigestUtils < MiniTest::Test
     assert_equal Digest::SHA512, detect_digest_class(sha512)
   end
 
-  def hexdigest(obj)
-    pack_hexdigest(digest(obj))
-  end
-
   def test_digest
+    if Fixnum == Bignum # Ruby 2.4+
+      assert_equal "f899a3d2245b5b18b9366e01085c5de1ef2fc075503a5a61f0e18d186dabd33d", hexdigest(42)
+      assert_equal "5bdbf1eb09f2cb8722c41135a3de8ba29cc1d722c1e7a17a96050bc41145966f", hexdigest([[:foo, 1]])
+      assert_equal "fe35e16f5d2a681d24c12c4354ec527165bfdb09c14a08ff71e913da6d84ae6c", hexdigest([{foo: 1}])
+    else
+      assert_equal "0d4af38194cb7dc915a75b04926886f6753ffc5b4f54513adfc582fdf3642e8c", hexdigest(42)
+      assert_equal "905e6cc86eccb1849ae6c1e0bb01b96fedb3e341ad3d60f828e93e9b5e469a4f", hexdigest([[:foo, 1]])
+      assert_equal "9500d3562922431a8ccce61bd510d341ca8d61cf6b6e5ae620e7b1598436ed73", hexdigest([{foo: 1}])
+    end
+
     assert_equal "9bda381dac87b1c16b04f996abb623f43f1cdb89ce8be7dda3f67319dc440bc5", hexdigest(nil)
     assert_equal "92de503a8b413365fc38050c7dd4bacf28b0f705e744dacebcaa89f2032dcd67", hexdigest(true)
     assert_equal "bdfd64a7c8febcc3b0b8fb05d60c8e2a4cb6b8c081fcba20db1c9778e9beaf89", hexdigest(false)
-    assert_equal "0d4af38194cb7dc915a75b04926886f6753ffc5b4f54513adfc582fdf3642e8c", hexdigest(42)
     assert_equal "abed5dfa575e89eb850242440d64c316071f76de0db48dd8d416f4aa5ece6afd", hexdigest(2 ** 128)
     assert_equal "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae", hexdigest("foo")
     assert_equal "dea6712e86478d2ee22a35a8c5ac9627e7cbc5ce2407a7da7c645fea2434fe9b", hexdigest(:foo)
@@ -34,8 +39,6 @@ class TestDigestUtils < MiniTest::Test
     assert_equal "ed98cc300019b22ca15e7cd5934028a79e7af4c75f7eeea810f43a3a4353a04d", hexdigest(["foo"])
     assert_equal "54edcfe382f4abaa9ebe93efa9977b05b786c9058496609797989b7fdf8208d4", hexdigest({"foo" => "bar"})
     assert_equal "62427aa539a0b78e90fd710dc0e15f2960771ba44214b5d41d4a93a8b2940a38", hexdigest({"foo" => "baz"})
-    assert_equal "905e6cc86eccb1849ae6c1e0bb01b96fedb3e341ad3d60f828e93e9b5e469a4f", hexdigest([[:foo, 1]])
-    assert_equal "9500d3562922431a8ccce61bd510d341ca8d61cf6b6e5ae620e7b1598436ed73", hexdigest([{foo: 1}])
     assert_equal "94ee40cca7c2c6d2a134033d2f5a31c488cad5d3dcc61a3dbb5e2a858635874b", hexdigest(String.new("foo").force_encoding('UTF-8').encoding)
 
     assert_raises(TypeError) do


### PR DESCRIPTION
Since Fixnum == Bignum in Sprockets the digests change since we're using the class as keys to build file fingerprints. This change updates the test to pass with Ruby 2.4.0+.