### PR TITLE
updated predicate method in extending_sprockets.md

### DIFF
--- a/guides/extending_sprockets.md
+++ b/guides/extending_sprockets.md
@@ -418,7 +418,7 @@ if env.respond_to?(:register_transformer)
   env.register_preprocessor 'text/css', MySprocketsExtension
 end
 
-if env.respond_to(:register_engine)
+if env.respond_to?(:register_engine)
   args = ['.css', MySprocketsExtension]
   args << { mime_type: 'text/css', silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
   env.register_engine(*args)


### PR DESCRIPTION
#### Super small typo fix

Added missing question mark in `env.respond_to(:register_engine)`. It is now `env.respond_to?(:register_engine)`