### PR TITLE
Update "Supporting All Versions of Sprockets in Processors"

### DIFF
--- a/guides/extending_sprockets.md
+++ b/guides/extending_sprockets.md
@@ -325,7 +325,7 @@ class MySprocketsExtension
     context  = input[:environment].context_class.new(input)
 
     result = run(filename, source, context)
-    { data: result }
+    context.metadata.merge(data: result)
   end
 end
 


### PR DESCRIPTION
Contents of `legacy_proc_processor.rb`

    def call(input)
      context = input[:environment].context_class.new(input)
      data = @proc.call(context, input[:data])
      context.metadata.merge(data: data.to_str)
    end

Notice that return value is result of merging context's metadata with data, but the example does not show this.
I've had fun time finding out why cache was not being properly invalidated after this upgrade.