### PR TITLE
Fix broken bold markdown in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-** 3.7.0** (July 21, 2016)
+**3.7.0** (July 21, 2016)
 
 * Deprecated interfaces now emit deprecation warnings #345
 


### PR DESCRIPTION
Fixes`v3.7.0` string which is not bolded In CHANGELOG.md.