### PR TITLE
Fix link for upgrading sprockets 2.x to 3.x in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@
 
 **3.0.0** (April 12, 2015)
 
-[Guide to upgrading from Sprockets 2.x to 3.x](https://github.com/rails/sprockets/blob/master/UPGRADING.md)
+[Guide to upgrading from Sprockets 2.x to 3.x](https://github.com/rails/sprockets/blob/3.x/UPGRADING.md)
 
 * New processor API. Tilt interface is deprecated.
 * Improved file store caching backend.


### PR DESCRIPTION
this should be linked to [this](https://github.com/rails/sprockets/blob/3.x/UPGRADING.md) but now, is linked to [this](https://github.com/rails/sprockets/blob/master/UPGRADING.md)