### PR TITLE
Correct version which introduced manifest

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -31,7 +31,7 @@ Previously, if you wanted Rails to serve a non-standard named asset (any CSS not
 config.assets.precompile += ["marketing.css"]
 ```
 
-Sprockets 3 introduced the concept of a "manifest" file that could list all assets you want to make available using the `link` directive. In this case, to compile the `marketing.css` you would set precompile to:
+Sprockets 4 introduced the concept of a "manifest" file that could list all assets you want to make available using the `link` directive. In this case, to compile the `marketing.css` you would set precompile to:
 
 ```ruby
 config.assets.precompile = ["manifest.js"]


### PR DESCRIPTION
<img width="923" alt="sprockets_upgrading_md_at_master_ _rails_sprockets" src="https://cloud.githubusercontent.com/assets/173701/17379563/dc2460a4-5977-11e6-82ce-8c9d4b258dae.png">

This led me to trying to use the manifest in version 3 of Sprockets. Hopefully this tiniest of fixes will prevent confusion for others.