### PR TITLE
Don't allocate Uglifier/Closure until they're needed

### DIFF
--- a/lib/sprockets/closure_compressor.rb
+++ b/lib/sprockets/closure_compressor.rb
@@ -35,11 +35,12 @@ module Sprockets
     attr_reader :cache_key
 
     def initialize(options = {})
-      @compiler = Autoload::Closure::Compiler.new(options)
+      @options = options
       @cache_key = "#{self.class.name}:#{Autoload::Closure::VERSION}:#{Autoload::Closure::COMPILER_VERSION}:#{VERSION}:#{DigestUtils.digest(options)}".freeze
     end
 
     def call(input)
+      @compiler ||= Autoload::Closure::Compiler.new(@options)
       @compiler.compile(input[:data])
     end
   end

--- a/lib/sprockets/uglifier_compressor.rb
+++ b/lib/sprockets/uglifier_compressor.rb
@@ -44,11 +44,12 @@ module Sprockets
         options[:comments] ||= :none
       end
 
-      @uglifier = Autoload::Uglifier.new(options)
+      @options = options
       @cache_key = "#{self.class.name}:#{Autoload::Uglifier::VERSION}:#{VERSION}:#{DigestUtils.digest(options)}".freeze
     end
 
     def call(input)
+      @uglifier ||= Autoload::Uglifier.new(@options)
       @uglifier.compile(input[:data])
     end
   end


### PR DESCRIPTION
This avoids starting a V8 VM until they're actually needed, and most importantly avoids starting them if you have custom configuration in your Rails production initializer.

cc @rafaelfranca 