### PR TITLE
Don't allocate Uglifier/Closure until they're needed

### DIFF
--- a/lib/sprockets/closure_compressor.rb
+++ b/lib/sprockets/closure_compressor.rb
@@ -36,11 +36,12 @@ module Sprockets
     attr_reader :cache_key
 
     def initialize(options = {})
-      @compiler = Autoload::Closure::Compiler.new(options)
+      @options = options
       @cache_key = "#{self.class.name}:#{Autoload::Closure::VERSION}:#{Autoload::Closure::COMPILER_VERSION}:#{VERSION}:#{DigestUtils.digest(options)}".freeze
     end
 
     def call(input)
+      @compiler ||= Autoload::Closure::Compiler.new(@options)
       @compiler.compile(input[:data])
     end
   end

--- a/lib/sprockets/uglifier_compressor.rb
+++ b/lib/sprockets/uglifier_compressor.rb
@@ -39,7 +39,7 @@ module Sprockets
     def initialize(options = {})
       options[:comments] ||= :none
 
-      @uglifier = Autoload::Uglifier.new(options)
+      @options = options
       @cache_key = "#{self.class.name}:#{Autoload::Uglifier::VERSION}:#{VERSION}:#{DigestUtils.digest(options)}".freeze
     end
 
@@ -47,6 +47,7 @@ module Sprockets
       if Autoload::Uglifier::VERSION.to_i < 2
         raise "uglifier 1.x is no longer supported, please upgrade to 2.x"
       end
+      @uglifier ||= Autoload::Uglifier.new(@options)
 
       js, map = @uglifier.compile_with_map(input[:data])
       map = SourceMapUtils.combine_source_maps(


### PR DESCRIPTION
This avoids starting a V8 VM until they are actually needed, and most importantly avoid starting them if you have custom configuration in your Rails production initializer.

see also https://github.com/rails/sprockets/pull/358 for the same change against 3.x branch