### PR TITLE
Fix unregister processor behaviour for class names

### DIFF
--- a/lib/sprockets/processing.rb
+++ b/lib/sprockets/processing.rb
@@ -218,9 +218,9 @@ module Sprockets
         end
       end
 
-      def unregister_config_processor(type, mime_type, proccessor)
+      def unregister_config_processor(type, mime_type, processor)
         self.config = hash_reassoc(config, type, mime_type) do |processors|
-          processors.delete(proccessor)
+          processors.delete_if { |p| p == processor || p.class == processor }
           processors
         end
       end

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -746,6 +746,19 @@ class TestEnvironment < Sprockets::TestCase
     @env.unregister_preprocessor('application/javascript', processor)
     assert_equal "// =require \"notfound\"\n;\n", @env["missing_require.js"].to_s
   end
+
+  test "disabling processors by class name also disables processors which are instances of that class" do
+    space_and_whitespace_compressor = Class.new(WhitespaceCompressor)
+
+    @env.register_preprocessor('text/html', WhitespaceCompressor)
+    @env.register_preprocessor('text/html', WhitespaceCompressor.new)
+    @env.register_preprocessor('text/html', space_and_whitespace_compressor)
+    assert_equal 3, @env.preprocessors['text/html'].size
+
+    @env.unregister_preprocessor('text/html', WhitespaceCompressor)
+    assert_equal 1, @env.preprocessors['text/html'].size
+    assert_equal space_and_whitespace_compressor, @env.preprocessors['text/html'][0]
+  end
 end
 
 class TestCached < Sprockets::TestCase


### PR DESCRIPTION
Closes #266

This example will unregister all registered processors of given class
(instances and classes):

```ruby
Rails.application.config.assets.configure do |env|
  env.unregister_processor('application/javascript', Sprockets::DirectiveProcessor)
end
```