### PR TITLE
Add env dependency resolver

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -210,6 +210,10 @@ module Sprockets
   register_dependency_resolver 'processors' do |env, str|
     env.resolve_processors_cache_key_uri(str)
   end
+  register_dependency_resolver 'env' do |env, str|
+    _, var = str.split(':', 2)
+    ENV[var]
+  end
 
   depend_on 'environment-version'
   depend_on 'environment-paths'

--- a/lib/sprockets/context.rb
+++ b/lib/sprockets/context.rb
@@ -18,6 +18,24 @@ module Sprockets
   # The `Context` also collects dependencies declared by
   # assets. See `DirectiveProcessor` for an example of this.
   class Context
+    # Internal: Proxy for ENV that keeps track of the environment variables used
+    class ENVProxy < SimpleDelegator
+      def initialize(context)
+        @context = context
+        super(ENV)
+      end
+
+      def [](key)
+        @context.depend_on_env(key)
+        super
+      end
+
+      def fetch(key, *)
+        @context.depend_on_env(key)
+        super
+      end
+    end
+
     attr_reader :environment, :filename
 
     def initialize(input)
@@ -40,6 +58,10 @@ module Sprockets
         stubbed: @stubbed,
         links: @links,
         dependencies: @dependencies }
+    end
+
+    def env_proxy
+      ENVProxy.new(self)
     end
 
     # Returns the environment path that contains the file.
@@ -120,6 +142,15 @@ module Sprockets
     # the target asset's dependencies.
     def depend_on_asset(path)
       load(resolve(path))
+    end
+
+    # `depend_on_env` allows you to state a dependency on an environment
+    # variable.
+    #
+    # This is used for caching purposes. Any changes in the value of the
+    # environment variable will invalidate the cache of the source file.
+    def depend_on_env(key)
+      @dependencies << "env:#{key}"
     end
 
     # `require_asset` declares `path` as a dependency of the file. The

--- a/lib/sprockets/erb_processor.rb
+++ b/lib/sprockets/erb_processor.rb
@@ -20,11 +20,14 @@ module Sprockets
 
     def call(input)
       engine = ::ERB.new(input[:data], nil, '<>')
+      engine.filename = input[:filename]
+
       context = input[:environment].context_class.new(input)
       klass = (class << context; self; end)
+      klass.const_set(:ENV, context.env_proxy)
       klass.class_eval(&@block) if @block
-      engine.def_method(klass, :_evaluate_template, input[:filename])
-      data = context._evaluate_template
+
+      data = engine.result(context.instance_eval('binding'))
       context.metadata.merge(data: data)
     end
   end

--- a/test/test_dependency.rb
+++ b/test/test_dependency.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require "sprockets_test"
+
+class DependencyTest < Sprockets::TestCase
+  def setup
+    ENV['DEPENDENCY_TEST_VALUE'] = 'Hello'
+    @env = Sprockets::Environment.new
+  end
+
+  def test_env_dependency
+    assert_equal @env.resolve_dependency('env:DEPENDENCY_TEST_VALUE'), 'Hello'
+    assert_nil @env.resolve_dependency('env:NONEXISTANT_DEPENDENCY_TEST_VALUE')
+  end
+end

--- a/test/test_dependency.rb
+++ b/test/test_dependency.rb
@@ -3,8 +3,13 @@ require "sprockets_test"
 
 class DependencyTest < Sprockets::TestCase
   def setup
+    @old_env_value = ENV['DEPENDENCY_TEST_VALUE']
     ENV['DEPENDENCY_TEST_VALUE'] = 'Hello'
     @env = Sprockets::Environment.new
+  end
+
+  def teardown
+    ENV['DEPENDENCY_TEST_VALUE'] = @old_env_value
   end
 
   def test_env_dependency

--- a/test/test_erb_processor.rb
+++ b/test/test_erb_processor.rb
@@ -27,6 +27,55 @@ class TestERBProcessor < MiniTest::Test
     assert_equal output, Sprockets::ERBProcessor.call(input)[:data]
   end
 
+  def test_compile_erb_template_that_depends_on_env
+    old_env_value = ::ENV['ERB_ENV_TEST_VALUE']
+    ::ENV['ERB_ENV_TEST_VALUE'] = 'success'
+
+    root = File.expand_path("../fixtures", __FILE__)
+    environment = Sprockets::Environment.new(root)
+    environment.append_path 'default'
+
+    input = {
+      environment: environment,
+      filename: "foo.js.erb",
+      content_type: 'application/javascript',
+      data: "<%= ENV['ERB_ENV_TEST_VALUE'] %>;",
+      metadata: {},
+      cache: Sprockets::Cache.new
+    }
+
+    output = "success;"
+    result = Sprockets::ERBProcessor.call(input)
+    assert_equal output, result[:data]
+    assert_equal "env:ERB_ENV_TEST_VALUE", result[:dependencies].first
+  ensure
+    ::ENV['ERB_ENV_TEST_VALUE'] = old_env_value
+  end
+
+  def test_compile_erb_template_that_depends_on_empty_env
+    old_env_value = ::ENV.delete('ERB_ENV_TEST_VALUE')
+
+    root = File.expand_path("../fixtures", __FILE__)
+    environment = Sprockets::Environment.new(root)
+    environment.append_path 'default'
+
+    input = {
+      environment: environment,
+      filename: "foo.js.erb",
+      content_type: 'application/javascript',
+      data: "<%= ENV['ERB_ENV_TEST_VALUE'] %>;",
+      metadata: {},
+      cache: Sprockets::Cache.new
+    }
+
+    output = ";"
+    result = Sprockets::ERBProcessor.call(input)
+    assert_equal output, result[:data]
+    assert_equal "env:ERB_ENV_TEST_VALUE", result[:dependencies].first
+  ensure
+    ::ENV['ERB_ENV_TEST_VALUE'] = old_env_value
+  end
+
   def test_compile_erb_template_with_depend_on_call
     root = File.expand_path("../fixtures", __FILE__)
     environment = Sprockets::Environment.new(root)


### PR DESCRIPTION
This adds a dependency resolver for environment variables, which is useful if you write an ERB file that you want to conditionally change depending on an environment variable. After this PR you just need to add `<% @dependencies << 'env:SOME_VAR' %>` to do so.

@rafaelfranca 