### PR TITLE
"fixes" #209 for @mikem's example app

### DIFF
--- a/lib/sprockets/context.rb
+++ b/lib/sprockets/context.rb
@@ -139,6 +139,7 @@ module Sprockets
     #     <%= require_asset "#{framework}.js" %>
     #
     def require_asset(path)
+      @content_type = "application/jsx" if path.match(/\.js\.jsx/)
       @required << resolve(path, accept: @content_type, pipeline: :self, compat: false)
       nil
     end


### PR DESCRIPTION
This terrible awfulness should not be merged.

Instead, it just provides a hack which hopefully sheds light on the issue.

Working against the provided [example app](https://github.com/mikem/sprockets_jsx_bug), this one-line fix solves the problem that the example app has. It also, as far as I can tell, demonstrates that `@content_type` is getting set incorrectly in the `Context`.

(Edit: this works with Rails 5.0.0.1 and Sprockets 3.7.0. The example app uses older versions.)
