### PR TITLE
Implement Exporting feature

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -6,6 +6,8 @@ require 'sprockets/cache'
 require 'sprockets/environment'
 require 'sprockets/errors'
 require 'sprockets/manifest'
+require 'sprockets/exporter'
+
 
 module Sprockets
   require 'sprockets/processor_utils'
@@ -34,8 +36,10 @@ module Sprockets
     registered_transformers: [].freeze,
     root: __dir__.dup.freeze,
     transformers: Hash.new { |h, k| {}.freeze }.freeze,
+    exporters: Hash.new { |h, k| Set.new.freeze }.freeze,
     version: "",
-    gzip_enabled: true
+    gzip_enabled: true,
+    export_concurrent: true
   }.freeze
 
   @context_class = Context
@@ -197,6 +201,11 @@ module Sprockets
   register_mime_type 'application/html+ruby', extensions: ['.html.erb', '.erb', '.rhtml'], charset: :html
   register_mime_type 'application/xml+ruby', extensions: ['.xml.erb', '.rxml']
 
+  # Gzip
+  require 'sprockets/gzip_exporter'
+  require 'sprockets/file_exporter'
+  register_exporter '*/*', Sprockets::FileExporter
+  register_exporter '*/*', Sprockets::GzipExporter
 
   register_dependency_resolver 'environment-version' do |env|
     env.version

--- a/lib/sprockets/configuration.rb
+++ b/lib/sprockets/configuration.rb
@@ -4,12 +4,13 @@ require 'sprockets/dependencies'
 require 'sprockets/mime'
 require 'sprockets/paths'
 require 'sprockets/processing'
+require 'sprockets/exporting'
 require 'sprockets/transformers'
 require 'sprockets/utils'
 
 module Sprockets
   module Configuration
-    include Paths, Mime, Transformers, Processing, Compressing, Dependencies, Utils
+    include Paths, Mime, Transformers, Processing, Exporting, Compressing, Dependencies, Utils
 
     def initialize_configuration(parent)
       @config = parent.config

--- a/lib/sprockets/exporter.rb
+++ b/lib/sprockets/exporter.rb
@@ -1,0 +1,40 @@
+module Sprockets
+  class Exporter
+    def initialize(environment, asset, source, directory, logger, mtime)
+      @environment = environment
+      @asset = asset
+      @source = source
+      @directory = directory
+      @logger = logger
+      @mtime = mtime
+    end
+
+    def write(extension = nil)
+      if extension
+        target = extension[0] == '.' ? "#{source}#{extension}" : extension
+      else
+        target = source
+      end
+
+      if File.exist?(target)
+        logger.debug "Skipping #{target}, already exists"
+      else
+        logger.info "Exporting #{target}"
+        begin
+          yield target
+          logger.warn "#{target} was not exported" if !File.exist?(target)
+        rescue => e
+          logger.error "#{e} while exporting #{target}"
+          raise e
+        end
+      end
+    end
+
+    attr_reader :environment
+    attr_reader :asset
+    attr_reader :source
+    attr_reader :directory
+    attr_reader :logger
+    attr_reader :mtime
+  end
+end

--- a/lib/sprockets/exporting.rb
+++ b/lib/sprockets/exporting.rb
@@ -1,0 +1,56 @@
+module Sprockets
+  # `Exporting` is an internal mixin whose public methods are exposed on
+  # the `Environment` and `CachedEnvironment` classes.
+  module Exporting
+    # Exporters are ran on the assets:precompile task
+    def exporters
+      config[:exporters]
+    end
+
+    # Registers a new Exporter `klass` for `mime_type`.
+    #
+    #     register_preprocessor '*/*', Sprockets::GzipExporter
+    #
+    def register_exporter(mime_types, proc = nil, &block)
+      proc ||= block
+
+      if mime_types.is_a? String
+        mime_types = [mime_types]
+      end
+      mime_types.each do |mime_type|
+        self.config = hash_reassoc(config, :exporters, mime_type) do |_exporters|
+          _exporters << proc
+        end
+      end
+    end
+
+    def unregister_exporter(mime_types, exporter = nil)
+      unless mime_types.is_a? Array
+        if mime_types.is_a? String
+          mime_types = [mime_types]
+        elsif mime_types < Exporter
+          exporter = mime_types
+          mime_types = nil
+        end
+      end
+
+      self.config = hash_reassoc(config, :exporters) do |_exporters|
+        _exporters.each do |mime_type, exporters_array|
+          next if mime_types && !mime_types.include?(mime_type)
+          if exporters_array.include? exporter
+            _exporters[mime_type] = exporters_array.dup.delete exporter
+          end
+        end
+      end
+    end
+
+    def export_concurrent
+      config[:export_concurrent]
+    end
+
+    def export_concurrent=(export_concurrent)
+      self.config = config.merge(export_concurrent: export_concurrent).freeze
+    end
+
+  end
+end

--- a/lib/sprockets/file_exporter.rb
+++ b/lib/sprockets/file_exporter.rb
@@ -1,0 +1,11 @@
+require 'sprockets/exporter'
+
+module Sprockets
+  class FileExporter < Exporter
+    def call
+      write do |target|
+        asset.write_to target
+      end
+    end
+  end
+end

--- a/lib/sprockets/gzip_exporter.rb
+++ b/lib/sprockets/gzip_exporter.rb
@@ -1,0 +1,16 @@
+require 'sprockets/exporter'
+require 'sprockets/utils/gzip'
+
+module Sprockets
+  class GzipExporter < Exporter
+    def call
+      return if environment.skip_gzip?
+      gzip = Utils::Gzip.new(asset)
+      return if gzip.cannot_compress?(environment.mime_types)
+
+      write '.gz' do
+        gzip.compress(source)
+      end
+    end
+  end
+end

--- a/test/test_exporting.rb
+++ b/test/test_exporting.rb
@@ -1,0 +1,108 @@
+require 'sprockets_test'
+
+class TestExporting < Sprockets::TestCase
+  def setup
+    @env = Sprockets::Environment.new(".") do |env|
+      env.append_path(fixture_path('default'))
+    end
+    @dir = File.join(Dir::tmpdir, 'sprockets/manifest')
+    FileUtils.mkdir_p(@dir)
+    @manifest = Sprockets::Manifest.new(@env, File.join(@dir, 'manifest.json'))
+  end
+
+  def teardown
+    # FileUtils.rm_rf(@dir)
+    # wtf, dunno
+    system "rm -rf #{@dir}"
+    assert Dir["#{@dir}/*"].empty?
+  end
+
+  test 'extension exporters' do
+    @env.register_exporter 'application/javascript', ReverseExtensionExporter
+    @env.register_exporter '*/*', DoubleExtensionExporter
+
+    @manifest.compile('application.js')
+    @manifest.compile('blank.gif')
+
+    js_path = @env['application.js'].digest_path
+    gif_path = @env['blank.gif'].digest_path
+
+    reverse_js_path = "#{@dir}/#{js_path[0..-4]}.sj"
+    double_js_path = "#{@dir}/#{js_path}js"
+    reverse_gif_path = "#{@dir}/#{gif_path[0..-5]}.fig"
+    double_gif_path = "#{@dir}/#{gif_path}gif"
+
+    assert File.exist?(reverse_js_path)
+    assert !File.exist?(reverse_gif_path)
+    assert File.exist?(double_js_path)
+    assert File.exist?(double_gif_path)
+  end
+
+  test 'unregistering exporter without mime type' do
+    @env.register_exporter '*/*', DoubleExtensionExporter
+    @env.unregister_exporter DoubleExtensionExporter
+
+    @manifest.compile('application.js')
+
+    js_path = @env['application.js'].digest_path
+    double_js_path = "#{@dir}/#{js_path}js"
+
+    assert !File.exist?(double_js_path)
+  end
+
+  test 'unregistering exporter with mime type' do
+    @env.register_exporter 'application/javascript', DoubleExtensionExporter
+    @env.unregister_exporter 'application/javascript', DoubleExtensionExporter
+
+    @manifest.compile('application.js')
+
+    js_path = @env['application.js'].digest_path
+    double_js_path = "#{@dir}/#{js_path}js"
+
+    assert !File.exist?(double_js_path)
+  end
+
+  test 'unregistering exporter with multiple mime types' do
+    @env.register_exporter %w(application/javascript image/gif), ReverseExtensionExporter
+    @env.unregister_exporter %w(application/javascript image/gif), ReverseExtensionExporter
+
+    @manifest.compile('application.js')
+    @manifest.compile('blank.gif')
+
+    js_path = @env['application.js'].digest_path
+    gif_path = @env['blank.gif'].digest_path
+
+    reverse_js_path = "#{@dir}/#{js_path[0..-4]}.sj"
+    double_js_path = "#{@dir}/#{js_path}js"
+    reverse_gif_path = "#{@dir}/#{gif_path[0..-5]}.fig"
+    double_gif_path = "#{@dir}/#{gif_path}gif"
+
+    assert !File.exist?(reverse_js_path)
+    assert !File.exist?(reverse_gif_path)
+    assert !File.exist?(double_js_path)
+    assert !File.exist?(double_gif_path)
+  end
+end
+
+class ReverseExtensionExporter < Sprockets::Exporter
+  def call
+    split = source.split('.')
+    split[1] = split[1].reverse
+    new_target = split.join('.')
+
+    write new_target do |target|
+      FileUtils.touch target
+    end
+  end
+end
+
+class DoubleExtensionExporter < Sprockets::Exporter
+  def call
+    split = source.split('.')
+    new_target = source + split[1]
+
+    write new_target do |target|
+      FileUtils.touch target
+    end
+  end
+end


### PR DESCRIPTION
I created an exporting feature, which replaces `manifest.compile`. There is now an api for exporters, like there is an api for processors. Gzip is an example of an exporter. You can register an exporter like this:

```ruby
env.register_exporter 'application/javascript', Sprockets::GzipExporter
```

There are no breaking changes. I created this api so I could implement a Brotli exporter, which I will use with `ngx_brotli`. That will look like this:

```ruby
class BrotliExporter
  def self.call(env, asset, target, dir, logger, wait)
    if File.exist?("#{target}.br")
      logger.debug "Skipping #{target}.br, already exists"
      return
    else
      logger.info "Writing #{target}.br"
      return Concurrent::Future.execute do
        wait.call
        `bro --quality 9 --input #{target} --output #{target}.br`
      end
    end
  end
end

Rails.application.config.assets.configure do |env|
  env.register_exporter %w(text/css application/javascript), BrotliExporter
end
```

There is room for improvement:
- The wait.call needs review, I'm not an expert on concurrency
- The syntax needs review: `(env, asset, target, dir, logger, wait)` is quite long
- Makes no use of dependency resolving, I don't know if that can be used here
- I am not sure about checking if a file has a certain mime type, is there already some way of checking if `'text/html'` matches `'text/*'`? If not, I can certainly implement that, it can also be used for processors then.

I will write a guide when this (or something like this) gets merged.