### PR TITLE
Explicit API to error when an asset is not found

### DIFF
--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -93,6 +93,9 @@ module Sprockets
       find_asset(*args)
     end
 
+    # Find asset by logical path or expanded path.
+    #
+    # If the asset is not found an error will be raised.
     def find_asset!(*args)
       asset = find_asset(*args)
       if asset

--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -93,6 +93,15 @@ module Sprockets
       find_asset(*args)
     end
 
+    def find_asset!(*args)
+      asset = find_asset(*args)
+      if asset
+        return asset
+      else
+        raise_on_unknown_asset(*args)
+      end
+    end
+
     # Pretty inspect
     def inspect
       "#<#{self.class}:0x#{object_id.to_s(16)} " +
@@ -107,5 +116,13 @@ module Sprockets
     def expand_from_root(uri)
       URITar.new(uri, self).expand
     end
+
+    private
+      def raise_on_unknown_asset(*args)
+        asset_name = args.shift
+        msg = String.new("Could not load asset #{ asset_name.inspect }")
+        msg << "with options #{ args.inspect }" unless args.empty?
+        raise Sprockets::NotFound, msg
+      end
   end
 end

--- a/lib/sprockets/environment.rb
+++ b/lib/sprockets/environment.rb
@@ -31,6 +31,10 @@ module Sprockets
       cached.find_asset(*args)
     end
 
+    def find_asset!(*args)
+      cached.find_asset!(*args)
+    end
+
     def find_all_linked_assets(*args, &block)
       cached.find_all_linked_assets(*args, &block)
     end

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -47,6 +47,18 @@ module EnvironmentTests
     assert_equal "hello: world\n", context.call("JST['hello']", name: "world")
   end
 
+  test "find_asset! does not raise an exception when asset is found" do
+    @env.find_asset!("hello.js") # assert no raise
+  end
+
+  test "find_asset! raises an error when asset is not found" do
+    does_not_exist_file_name = "doesnotexist.blerg"
+    error = assert_raises(Sprockets::NotFound) do
+      @env.find_asset!(does_not_exist_file_name)
+    end
+    assert_match %r{#{does_not_exist_file_name}}, error.message
+  end
+
   test "asset_data_uri helper" do
     assert asset = @env["with_data_uri.css"]
     assert_equal "body {\n  background-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAP%2F%2F%2FwAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw%3D%3D) no-repeat;\n}\n", asset.to_s


### PR DESCRIPTION
The goal here is that we can eventually extend this to look for common problems. For example in the future if you try to load `asset_path(assets/javascripts/application.js)` you might get an error telling you that you that you should leave off the paths in front of the asset. We could also look for assets with the same name and different file extensions as well as do a `did you mean` type levenshtein lookup for possible asset mis-spellings.

We can't do any of that today because there is no guarantee that you expect `find_asset` to return a valid result. By introducing an explicit api `find_asset!` we can guarantee the user either wants an asset or an error.