### PR TITLE
Add cache_key to BabelProcessor

### DIFF
--- a/lib/sprockets/babel_processor.rb
+++ b/lib/sprockets/babel_processor.rb
@@ -16,6 +16,12 @@ module Sprockets
       instance.call(input)
     end
 
+    def self.cache_key
+      instance.cache_key
+    end
+
+    attr_reader :cache_key
+
     def initialize(options = {})
       @options = options.merge({
         'blacklist' => (options['blacklist'] || []) + ['useStrict'],

--- a/test/test_babel_processor.rb
+++ b/test/test_babel_processor.rb
@@ -168,4 +168,15 @@ System.register("mod2", ["foo"], function (_export) {
 });
     JS
   end
+
+  def test_cache_key
+    assert Sprockets::BabelProcessor.cache_key
+
+    amd_processor_1 = Sprockets::BabelProcessor.new('modules' => 'amd')
+    amd_processor_2 = Sprockets::BabelProcessor.new('modules' => 'amd')
+    assert_equal amd_processor_1.cache_key, amd_processor_2.cache_key
+
+    system_processor = Sprockets::BabelProcessor.new('modules' => 'system')
+    refute_equal amd_processor_1.cache_key, system_processor.cache_key
+  end
 end


### PR DESCRIPTION
This ensures the cache will be invalidated if `BabelProcessor`'s options are changed. (See [this test](https://github.com/rails/sprockets/blob/9db6aa1c8bec0c445c58d2783d7166f7c44a58f0/test/test_caching.rb#L138-L146).)