### PR TITLE
Fix relative urls & source maps

### DIFF
--- a/lib/sprockets/asset.rb
+++ b/lib/sprockets/asset.rb
@@ -67,6 +67,13 @@ module Sprockets
       logical_path.sub(/\.(\w+)$/) { |ext| "-#{etag}#{ext}" }
     end
 
+    # Public: Return load path + logical path with digest spliced in.
+    #
+    # Returns String.
+    def full_digest_path
+      File.join(@load_path, digest_path)
+    end
+
     # Public: Returns String MIME type of asset. Returns nil if type is unknown.
     attr_reader :content_type
 

--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -6,6 +6,7 @@ module Sprockets
   # when code actually wants to reference ::FileUtils.
   module PathUtils
     extend self
+    require 'pathname'
 
     # Public: Like `File.stat`.
     #
@@ -73,8 +74,6 @@ module Sprockets
     #
     # Returns true if path is absolute, otherwise false.
     if File::ALT_SEPARATOR
-      require 'pathname'
-
       # On Windows, ALT_SEPARATOR is \
       # Delegate to Pathname since the logic gets complex.
       def absolute_path?(path)
@@ -100,6 +99,18 @@ module Sprockets
     # Returns true if path is relative, otherwise false.
     def relative_path?(path)
       path =~ /^\.\.?($|#{SEPARATOR_PATTERN})/ ? true : false
+    end
+
+    # Public: Get relative path from `start` to `dest`.
+    #
+    # start - String start path (file or dir)
+    # dest  - String destination path
+    #
+    # Returns relative String path from `start` to `dest`
+    def relative_path_from(start, dest)
+      start, dest = Pathname.new(start), Pathname.new(dest)
+      start = start.dirname unless start.directory?
+      dest.relative_path_from(start).to_s
     end
 
     # Internal: Get relative path for root path and subpath.

--- a/lib/sprockets/source_map_comment_processor.rb
+++ b/lib/sprockets/source_map_comment_processor.rb
@@ -21,8 +21,10 @@ module Sprockets
       uri, _ = env.resolve!(input[:filename], accept: map_type)
       map = env.load(uri)
 
+      path = PathUtils.relative_path_from(input[:filename], map.full_digest_path)
+
       asset.metadata.merge(
-        data: asset.source + (comment % map.digest_path),
+        data: asset.source + (comment % path),
         links: asset.links + [asset.uri, map.uri]
       )
     end

--- a/lib/sprockets/source_map_utils.rb
+++ b/lib/sprockets/source_map_utils.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'json'
+require 'sprockets/path_utils'
 
 module Sprockets
   module SourceMapUtils

--- a/lib/sprockets/source_map_utils.rb
+++ b/lib/sprockets/source_map_utils.rb
@@ -136,6 +136,9 @@ module Sprockets
       case mappings
       when String
       when Array
+        mappings.each do |m|
+          m[:source] = relative_path_from(filename, m[:source])
+        end if filename
         sources ||= mappings.map { |m| m[:source] }.uniq.compact
         names   ||= mappings.map { |m| m[:name] }.uniq.compact
         mappings = encode_vlq_mappings(mappings, sources: sources, names: names)

--- a/lib/sprockets/source_map_utils.rb
+++ b/lib/sprockets/source_map_utils.rb
@@ -137,7 +137,7 @@ module Sprockets
       when String
       when Array
         mappings.each do |m|
-          m[:source] = relative_path_from(filename, m[:source])
+          m[:source] = PathUtils.relative_path_from(filename, m[:source])
         end if filename
         sources ||= mappings.map { |m| m[:source] }.uniq.compact
         names   ||= mappings.map { |m| m[:name] }.uniq.compact

--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -61,13 +61,13 @@ class TestSourceMaps < Sprockets::TestCase
       map_2 = JSON.parse(@env['dynamic/application.js.map'].source)
 
       assert_equal([
-        "dynamic/unstable.source-43b85c2116b8c894a292c17a6845aa1c9b1491f7dc6bddf764c384668457d55a.js",
-        "dynamic/application.source-5cc94f82fada13ee8ef969d4cef2018e52ce42f9e1c8ccb6f8333cdc0dd5d3b5.coffee"
+        "unstable.source-43b85c2116b8c894a292c17a6845aa1c9b1491f7dc6bddf764c384668457d55a.js",
+        "application.source-5cc94f82fada13ee8ef969d4cef2018e52ce42f9e1c8ccb6f8333cdc0dd5d3b5.coffee"
       ], map_1["sources"])
 
       assert_equal([
-        "dynamic/unstable.source-2ae6f42425799bc9f718842df81be58c5f011dc93a00ca4da17be8877bdb02b3.js",
-        "dynamic/application.source-5cc94f82fada13ee8ef969d4cef2018e52ce42f9e1c8ccb6f8333cdc0dd5d3b5.coffee"
+        "unstable.source-2ae6f42425799bc9f718842df81be58c5f011dc93a00ca4da17be8877bdb02b3.js",
+        "application.source-5cc94f82fada13ee8ef969d4cef2018e52ce42f9e1c8ccb6f8333cdc0dd5d3b5.coffee"
       ], map_2["sources"])
     end
   end
@@ -93,7 +93,7 @@ class TestSourceMaps < Sprockets::TestCase
       "version" => 3,
       "file" => "coffee/main.js",
       "mappings" => "AACA;AAAA,MAAA,sDAAA;IAAA;;EAAA,MAAA,GAAW;;EACX,QAAA,GAAW;;EAGX,IAAgB,QAAhB;IAAA,MAAA,GAAS,CAAC,GAAV;;;EAGA,MAAA,GAAS,SAAC,CAAD;WAAO,CAAA,GAAI;EAAX;;EAGT,IAAA,GAAO,CAAC,CAAD,EAAI,CAAJ,EAAO,CAAP,EAAU,CAAV,EAAa,CAAb;;EAGP,IAAA,GACE;IAAA,IAAA,EAAQ,IAAI,CAAC,IAAb;IACA,MAAA,EAAQ,MADR;IAEA,IAAA,EAAQ,SAAC,CAAD;aAAO,CAAA,GAAI,MAAA,CAAO,CAAP;IAAX,CAFR;;;EAKF,IAAA,GAAO,SAAA;AACL,QAAA;IADM,uBAAQ;WACd,KAAA,CAAM,MAAN,EAAc,OAAd;EADK;;EAIP,IAAsB,8CAAtB;IAAA,KAAA,CAAM,YAAN,EAAA;;;EAGA,KAAA;;AAAS;SAAA,sCAAA;;mBAAA,IAAI,CAAC,IAAL,CAAU,GAAV;AAAA;;;AA1BT",
-      "sources" => ["coffee/main.source-2ee93f5e7f3b843c3002478375432cf923860432879315335f4b987c205057db.coffee"],
+      "sources" => ["main.source-2ee93f5e7f3b843c3002478375432cf923860432879315335f4b987c205057db.coffee"],
       "names" => []
     }, map)
   end
@@ -138,7 +138,7 @@ class TestSourceMaps < Sprockets::TestCase
       "version" => 3,
       "file" => "babel/main.js",
       "mappings" => ";;;;;;;;;;AACA,IAAI,IAAI,GAAG,KAAK,CAAC,GAAG,CAAC,UAAA,CAAC;SAAI,CAAC,GAAG,CAAC;CAAA,CAAC,CAAC;AACjC,IAAI,IAAI,GAAG,KAAK,CAAC,GAAG,CAAC,UAAC,CAAC,EAAE,CAAC;SAAK,CAAC,GAAG,CAAC;CAAA,CAAC,CAAC;;IAEhC,WAAW;YAAX,WAAW;;AACJ,WADP,WAAW,CACH,QAAQ,EAAE,SAAS,EAAE;0BAD7B,WAAW;;AAEb,+BAFE,WAAW,6CAEP,QAAQ,EAAE,SAAS,EAAE;GAE5B;;eAJG,WAAW;;WAKT,gBAAC,MAAM,EAAE;AACb,iCANE,WAAW,wCAME;KAChB;;;WACmB,yBAAG;AACrB,aAAO,IAAI,KAAK,CAAC,OAAO,EAAE,CAAC;KAC5B;;;SAVG,WAAW;GAAS,KAAK,CAAC,IAAI;;AAapC,IAAI,SAAS,uBACV,MAAM,CAAC,QAAQ,0BAAG;MACb,GAAG,EAAM,GAAG,EAEV,IAAI;;;;AAFN,WAAG,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC;;;AAEd,YAAI,GAAG,GAAG;;AACd,WAAG,GAAG,GAAG,CAAC;AACV,WAAG,IAAI,IAAI,CAAC;;eACN,GAAG;;;;;;;;;;;CAEZ,EACF,CAAA",
-      "sources" => ["babel/main.source-1acb9cf16a3e1ce0fe0a38491472a14a6a97281ceace4b67ec16a904be5fa1b9.es6"],
+      "sources" => ["main.source-1acb9cf16a3e1ce0fe0a38491472a14a6a97281ceace4b67ec16a904be5fa1b9.es6"],
       "names"=>[]
     }, map)
   end
@@ -188,7 +188,7 @@ class TestSourceMaps < Sprockets::TestCase
       "version" => 3,
       "file" => "sass/main.css",
       "mappings" => "AACE,MAAG;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI;AAGlB,MAAG;EAAE,OAAO,EAAE,YAAY;AAE1B,KAAE;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI",
-      "sources" => ["sass/main.source-86fe07ad89fecbab307d376bcadfa23d65ad108e3735b564510246b705f6ced1.scss"],
+      "sources" => ["main.source-86fe07ad89fecbab307d376bcadfa23d65ad108e3735b564510246b705f6ced1.scss"],
       "names" => []
     }, map)
   end
@@ -221,8 +221,8 @@ class TestSourceMaps < Sprockets::TestCase
       "file" => "sass/with-import.css",
       "mappings" => "AAAA,IAAK;EAAE,KAAK,EAAE,GAAG;;ACEjB,GAAI;EAAE,KAAK,EAAE,IAAI",
       "sources" => [
-        "sass/_imported.source-9767e91e9d4b0334e59a1d389e9801bc6a2c5c4a5500a3c2c7915687965b2c16.scss",
-        "sass/with-import.source-5d53742ba113ac26396986bf14ab5c7e19ef193e494d5d868a9362e3e057cb26.scss"
+        "_imported.source-9767e91e9d4b0334e59a1d389e9801bc6a2c5c4a5500a3c2c7915687965b2c16.scss",
+        "with-import.source-5d53742ba113ac26396986bf14ab5c7e19ef193e494d5d868a9362e3e057cb26.scss"
       ],
       "names" => []
     }, map)
@@ -291,7 +291,7 @@ class TestSasscSourceMaps < Sprockets::TestCase
       "version"  => 3,
       "file"     => "sass/main.css",
       "mappings" => "AAAA,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAE;EACV,OAAO,EAAE,CAAE;EACX,UAAU,EAAE,IAAK,GAClB;;AALH,AAOE,GAPC,CAOD,EAAE,CAAC;EAAE,OAAO,EAAE,YAAa,GAAI;;AAPjC,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAM;EACf,OAAO,EAAE,QAAS;EAClB,eAAe,EAAE,IAAK,GACvB",
-      "sources"  => ["sass/main.source-86fe07ad89fecbab307d376bcadfa23d65ad108e3735b564510246b705f6ced1.scss"],
+      "sources"  => ["main.source-86fe07ad89fecbab307d376bcadfa23d65ad108e3735b564510246b705f6ced1.scss"],
       "names"    => []
     }, map)
   end


### PR DESCRIPTION
This PR fixes two issues related to source maps and relative URLs. 

1. As reported in #284, the `SourceMapCommentProcessor` uses the logical path as the source mapping url which is relative to the load path. However, from the [source map revision 3 proposal](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit), the url should be relative to the `.debug` file itself. This meant that source maps didn't work when loading assets not located in the assets root directory. 
2. A similar issue to the first popped up within the `.map` files. Sources should be linked relative to the `.map` file itself, however again they were being linked relative to the load path. 

I don't believe I have the best solution for this problem, specifically the hack in `source_map_utils.rb`, and it's likely that there are edge cases where it breaks down, but it's necessary to get source maps functioning. I'd love to hear suggestions on ways to improve this solution. 

fixes #284 

@rafaelfranca @bouk 