### PR TITLE
Fix source maps for @imported sass files w/ sassc processor

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -128,6 +128,7 @@ module Sprockets
   register_bundle_metadata_reducer '*/*', :data, proc { String.new("") }, :concat
   register_bundle_metadata_reducer 'application/javascript', :data, proc { String.new("") }, Utils.method(:concat_javascript_sources)
   register_bundle_metadata_reducer '*/*', :links, :+
+  register_bundle_metadata_reducer '*/*', :sources, proc { [] }, :+
   register_bundle_metadata_reducer '*/*', :map, SourceMapUtils.method(:concat_source_maps)
 
   require 'sprockets/closure_compressor'

--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -113,6 +113,21 @@ module Sprockets
       dest.relative_path_from(start).to_s
     end
 
+    # Public: Joins path to base path.
+    #
+    # base - Root path
+    # path - Extending path
+    #
+    # Example
+    #
+    #     join('base/path/', '../file.js')
+    #     # => 'base/file.js'
+    #
+    # Returns string path starting from base and ending at path
+    def join(base, path)
+      (Pathname.new(base) + path).to_s
+    end
+
     # Internal: Get relative path for root path and subpath.
     #
     # path    - String path

--- a/lib/sprockets/sass_processor.rb
+++ b/lib/sprockets/sass_processor.rb
@@ -100,11 +100,14 @@ module Sprockets
 
     private
 
+    def expand_source(source, env)
+      uri, _ = env.resolve!(source, pipeline: :source)
+      env.load(uri).digest_path
+    end
+
     def expand_map_sources(mapping, env)
       mapping.each do |map|
-        uri, _ = env.resolve!(map[:source], pipeline: :source)
-        source_path = env.load(uri).digest_path
-        map[:source] = source_path
+        map[:source] = expand_source(map[:source], env)
       end
     end
 

--- a/lib/sprockets/source_map_processor.rb
+++ b/lib/sprockets/source_map_processor.rb
@@ -17,9 +17,10 @@ module Sprockets
 
       env = input[:environment]
 
-      uri, _ = env.resolve!(input[:filename], accept: accept)
-      asset  = env.load(uri)
-      map    = asset.metadata[:map] || []
+      uri, _  = env.resolve!(input[:filename], accept: accept)
+      asset   = env.load(uri)
+      map     = asset.metadata[:map] || []
+      sources = asset.metadata[:sources]
 
       # TODO: Because of the default piplene hack we have to apply dependencies
       #       from compiled asset to the source map, otherwise the source map cache
@@ -39,7 +40,7 @@ module Sprockets
         links << uri
       end
 
-      json = env.encode_json_source_map(map, filename: asset.logical_path)
+      json = env.encode_json_source_map(map, sources: sources, filename: asset.logical_path)
 
       { data: json, links: links, dependencies: dependencies }
     end

--- a/lib/sprockets/source_map_utils.rb
+++ b/lib/sprockets/source_map_utils.rb
@@ -140,7 +140,8 @@ module Sprockets
         mappings.each do |m|
           m[:source] = PathUtils.relative_path_from(filename, m[:source])
         end if filename
-        sources ||= mappings.map { |m| m[:source] }.uniq.compact
+        sources = sources.map { |s| PathUtils.relative_path_from(filename, s) } if filename && sources
+        sources = (Array(sources) + mappings.map { |m| m[:source] }).uniq.compact
         names   ||= mappings.map { |m| m[:name] }.uniq.compact
         mappings = encode_vlq_mappings(mappings, sources: sources, names: names)
       else

--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rack-test", "~> 0.6"
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "sass", "~> 3.4"
-  s.add_development_dependency "sassc", "~> 1.7"
+  s.add_development_dependency "sassc", ">= 1.10.1", "< 2.0"
   s.add_development_dependency "uglifier", "~> 2.3"
   s.add_development_dependency "yui-compressor", "~> 0.12"
   s.add_development_dependency "zopfli", "~> 0.0.4"

--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -295,4 +295,39 @@ class TestSasscSourceMaps < Sprockets::TestCase
       "names"    => []
     }, map)
   end
+
+  test "compile scss source map with imported dependencies" do
+    asset = silence_warnings do
+      @env.find_asset("sass/with-import.css")
+    end
+    assert asset
+    assert_equal fixture_path('source-maps/sass/with-import.scss'), asset.filename
+    assert_equal "text/css", asset.content_type
+
+    assert_match "body {\n  color: red; }", asset.source
+
+    asset = silence_warnings do
+      @env.find_asset("sass/with-import.css.map")
+    end
+    assert asset
+    assert_equal fixture_path('source-maps/sass/with-import.scss'), asset.filename
+    assert_equal "sass/with-import.css.map", asset.logical_path
+    assert_equal "application/css-sourcemap+json", asset.content_type
+    assert_equal [
+      "file://#{fixture_path_for_uri('source-maps/sass/_imported.scss')}?type=text/scss&pipeline=source",
+      "file://#{fixture_path_for_uri('source-maps/sass/with-import.scss')}?type=text/scss&pipeline=source"
+    ], normalize_uris(asset.links)
+
+    assert map = JSON.parse(asset.source)
+    assert_equal({
+      "version" => 3,
+      "file" => "sass/with-import.css",
+      "mappings" => "ACAA,AAAA,IAAI,CAAC;EAAE,KAAK,EAAE,GAAI,GAAI;;ADEtB,AAAA,GAAG,CAAC;EAAE,KAAK,EAAE,IAAK,GAAI",
+      "sources" => [
+        "with-import.source-5d53742ba113ac26396986bf14ab5c7e19ef193e494d5d868a9362e3e057cb26.scss",
+        "_imported.source-9767e91e9d4b0334e59a1d389e9801bc6a2c5c4a5500a3c2c7915687965b2c16.scss"
+      ],
+      "names" => []
+    }, map)
+  end
 end


### PR DESCRIPTION
Currently, source maps are generated by the sassc engine and inlined, then the sassc processor strips them out and decodes them. As a consequence to this process the source urls are not relative to the map file, and as such they are discarded. Thus we don't get content maps for any but the root level file. 

The simplest solution to this problem is to forgo the inline shenanigans and use source maps natively from libsass. I updated the sassc gem with a [source map getter](https://github.com/sass/sassc-ruby/pull/48) which will allow us to do this. 

`engine.source_map` made it into sassc version `1.10.1`, unfortunately the [`omit_source_map_url` option](https://github.com/sass/sassc-ruby/pull/49) didn't. Without this a useless `sourceMappingURL` comment is added to the bottom of the debug file just before the actual url. However, I don't believe this will be a problem since the url won't resolve to anything and thus should be ignored. 

The test will likely fail until #390 is merged.