### PR TITLE
Compress source maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 
 ## Master
 
+- Source map metadata uses compressed form specified by the [source map v3 spec](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k). [#402] **[BREAKING]**
+- Generate [index maps](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#heading=h.535es3xeprgt) when decoding source maps isn't necessary. [#402]
+- Remove fingerprints from source map files. [#402]
 
 ## 4.0.0.beta4
 

--- a/guides/extending_sprockets.md
+++ b/guides/extending_sprockets.md
@@ -219,9 +219,9 @@ Example:
 # See metadata section for more info
 {
   dependencies: [].to_set
-  map: [
+  map: {
     # ...
-  ]
+  }
 }
 ```
 
@@ -244,12 +244,7 @@ CoffeeScript file, Sprockets will generate a JavaScript file which is what the b
 this javascript file it helps if you know where the in your original CoffeeScript file the generated JavaScript code
 came from. The source map tells the browser how to map from a generated file to an original.
 
-Sprockets expects an array of hashes for this map. Each hash must have a `:source` key, the name of the original file
-from which generated content came.
-
-```ruby
-return {data: data, map: [{ source: "original.coffee", # ... }]}
-```
+Sprockets expects this map to follow the [source map spec](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k).
 
 - charset: This key contains the mime charset for an asset.
 

--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -129,7 +129,7 @@ module Sprockets
   register_bundle_metadata_reducer 'application/javascript', :data, proc { String.new("") }, Utils.method(:concat_javascript_sources)
   register_bundle_metadata_reducer '*/*', :links, :+
   register_bundle_metadata_reducer '*/*', :sources, proc { [] }, :+
-  register_bundle_metadata_reducer '*/*', :map, SourceMapUtils.method(:concat_source_maps)
+  register_bundle_metadata_reducer '*/*', :map, proc { |input| { "version" => 3, "file" => PathUtils.split_subpath(input[:load_path], input[:filename]), "sections" => [] } }, SourceMapUtils.method(:concat_source_maps)
 
   require 'sprockets/closure_compressor'
   require 'sprockets/sass_compressor'

--- a/lib/sprockets/babel_processor.rb
+++ b/lib/sprockets/babel_processor.rb
@@ -42,11 +42,11 @@ module Sprockets
 
       result = input[:cache].fetch(@cache_key + [input[:filename]] + [data]) do
         opts = {
-          'sourceRoot' => input[:load_path],
           'moduleRoot' => nil,
           'filename' => input[:filename],
           'filenameRelative' => PathUtils.split_subpath(input[:load_path], input[:filename]),
-          'sourceFileName' => input[:source_path]
+          'sourceFileName' => File.basename(input[:filename]),
+          'sourceMapTarget' => input[:filename]
         }.merge(@options)
 
         if opts['moduleIds'] && opts['moduleRoot']
@@ -57,8 +57,8 @@ module Sprockets
         Autoload::Babel::Transpiler.transform(data, opts)
       end
 
-      map = SourceMapUtils.decode_json_source_map(JSON.generate(result['map']))
-      map = SourceMapUtils.combine_source_maps(input[:metadata][:map], map["mappings"])
+      map = SourceMapUtils.format_source_map(result["map"], input)
+      map = SourceMapUtils.combine_source_maps(input[:metadata][:map], map)
 
       { data: result['code'], map: map }
     end

--- a/lib/sprockets/bundle.rb
+++ b/lib/sprockets/bundle.rb
@@ -32,21 +32,22 @@ module Sprockets
       end
 
       reducers = Hash[env.match_mime_type_keys(env.config[:bundle_reducers], type).flat_map(&:to_a)]
-      process_bundle_reducers(assets, reducers).merge(dependencies: dependencies, included: assets.map(&:uri))
+      process_bundle_reducers(input, assets, reducers).merge(dependencies: dependencies, included: assets.map(&:uri))
     end
 
     # Internal: Run bundle reducers on set of Assets producing a reduced
     # metadata Hash.
     #
+    # filename - String bundle filename
     # assets - Array of Assets
     # reducers - Array of [initial, reducer_proc] pairs
     #
     # Returns reduced asset metadata Hash.
-    def self.process_bundle_reducers(assets, reducers)
+    def self.process_bundle_reducers(input, assets, reducers)
       initial = {}
       reducers.each do |k, (v, _)|
         if v.respond_to?(:call)
-          initial[k] = v.call
+          initial[k] = v.call(input)
         elsif !v.nil?
           initial[k] = v
         end

--- a/lib/sprockets/coffee_script_processor.rb
+++ b/lib/sprockets/coffee_script_processor.rb
@@ -21,11 +21,18 @@ module Sprockets
       data = input[:data]
 
       js, map = input[:cache].fetch([self.cache_key, data]) do
-        result = Autoload::CoffeeScript.compile(data, sourceMap: true, sourceFiles: [input[:source_path]])
-        [result['js'], SourceMapUtils.decode_json_source_map(result['v3SourceMap'])['mappings']]
+        result = Autoload::CoffeeScript.compile(
+          data,
+          sourceMap: true,
+          sourceFiles: [File.basename(input[:filename])],
+          generatedFile: input[:filename]
+        )
+        [result['js'], JSON.parse(result['v3SourceMap'])]
       end
 
+      map = SourceMapUtils.format_source_map(map, input)
       map = SourceMapUtils.combine_source_maps(input[:metadata][:map], map)
+
       { data: js, map: map }
     end
   end

--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -155,8 +155,7 @@ module Sprockets
             name: name,
             content_type: type,
             metadata: {
-              dependencies: dependencies,
-              map: []
+              dependencies: dependencies
             }
           })
           validate_processor_result!(result)

--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -128,6 +128,30 @@ module Sprockets
       (Pathname.new(base) + path).to_s
     end
 
+    # Public: Sets pipeline for path
+    #
+    # path       - String path
+    # extensions - List of file extensions
+    # pipeline   - Pipeline
+    #
+    # Examples
+    #
+    #     set_pipeline('path/file.js.erb', config[:mime_exts], config[:pipeline_exts], :source)
+    #     # => 'path/file.source.js.erb'
+    #
+    #     set_pipeline('path/some.file.source.js.erb', config[:mime_exts], config[:pipeline_exts], :debug)
+    #     # => 'path/some.file.debug.js.erb'
+    #
+    # Returns string path with pipeline parsed in
+    def set_pipeline(path, mime_exts, pipeline_exts, pipeline)
+      extension, _ = match_path_extname(path, mime_exts)
+      path.chomp!(extension)
+      pipeline_old, _ = match_path_extname(path, pipeline_exts)
+      path.chomp!(pipeline_old)
+
+      "#{path}.#{pipeline}#{extension}"
+    end
+
     # Internal: Get relative path for root path and subpath.
     #
     # path    - String path

--- a/lib/sprockets/preprocessors/default_source_map.rb
+++ b/lib/sprockets/preprocessors/default_source_map.rb
@@ -9,16 +9,36 @@ module Sprockets
     # available.
     class DefaultSourceMap
       def call(input)
-        result = { data: input[:data] }
-        map    = input[:metadata][:map]
+        result        = { data: input[:data] }
+        map           = input[:metadata][:map]
+        filename      = input[:filename]
+        load_path     = input[:load_path]
+        lines         = input[:data].lines.count
+        basename      = File.basename(filename)
+        mime_exts     = input[:environment].config[:mime_exts]
+        pipeline_exts = input[:environment].config[:pipeline_exts]
         if map.nil? || map.empty?
-          result[:map] ||= []
-          input[:data].each_line.with_index do |_, index|
-            line = index + 1
-            result[:map] << { source: input[:source_path], generated: [line , 0], original: [line, 0] }
-          end
+          result[:map] = {
+            "version"   => 3,
+            "file"      => PathUtils.split_subpath(load_path, filename),
+            "mappings"  => default_mappings(lines),
+            "sources"   => [PathUtils.set_pipeline(basename, mime_exts, pipeline_exts, :source)],
+            "names"     => []
+          }
         end
         return result
+      end
+      
+      private
+
+      def default_mappings(lines)
+        if (lines == 0)
+          ""
+        elsif (lines == 1)
+          "AAAA"
+        else
+          "AAAA;" + "AACA;"*(lines - 2) + "AACA"
+        end
       end
     end
   end

--- a/lib/sprockets/sass_compressor.rb
+++ b/lib/sprockets/sass_compressor.rb
@@ -49,15 +49,13 @@ module Sprockets
     def call(input)
       css, map = Autoload::Sass::Engine.new(
         input[:data],
-        @options.merge(filename: 'filename')
+        @options.merge(filename: input[:filename])
       ).render_with_sourcemap('')
 
       css = css.sub("/*# sourceMappingURL= */\n", '')
 
-      map = SourceMapUtils.combine_source_maps(
-        input[:metadata][:map],
-        SourceMapUtils.decode_json_source_map(map.to_json(css_uri: 'uri'))["mappings"]
-      )
+      map = SourceMapUtils.format_source_map(JSON.parse(map.to_json(css_uri: '')), input)
+      map = SourceMapUtils.combine_source_maps(input[:metadata][:map], map)
 
       { data: css, map: map }
     end

--- a/lib/sprockets/sass_processor.rb
+++ b/lib/sprockets/sass_processor.rb
@@ -80,13 +80,8 @@ module Sprockets
 
       css = css.sub("\n/*# sourceMappingURL= */\n", '')
 
-      map = SourceMapUtils.combine_source_maps(
-        input[:metadata][:map],
-        expand_map_sources(
-          SourceMapUtils.decode_json_source_map(map.to_json(css_uri: '', type: :inline))["mappings"],
-          input[:environment]
-        )
-      )
+      map = SourceMapUtils.format_source_map(JSON.parse(map.to_json(css_uri: '')), input)
+      map = SourceMapUtils.combine_source_maps(input[:metadata][:map], map)
 
       # Track all imported files
       sass_dependencies = Set.new([input[:filename]])
@@ -99,17 +94,6 @@ module Sprockets
     end
 
     private
-
-    def expand_source(source, env)
-      uri, _ = env.resolve!(source, pipeline: :source)
-      env.load(uri).digest_path
-    end
-
-    def expand_map_sources(mapping, env)
-      mapping.each do |map|
-        map[:source] = expand_source(map[:source], env)
-      end
-    end
 
     # Public: Build the cache store to be used by the Sass engine.
     #

--- a/lib/sprockets/source_map_comment_processor.rb
+++ b/lib/sprockets/source_map_comment_processor.rb
@@ -26,7 +26,7 @@ module Sprockets
 
       uri, params = URIUtils.parse_asset_uri(input[:uri])
       uri = env.expand_from_root(params[:index_alias]) if params[:index_alias]
-      path = PathUtils.relative_path_from(uri, map.full_digest_path)
+      path = PathUtils.relative_path_from(PathUtils.split_subpath(input[:load_path], uri), map.digest_path)
 
       asset.metadata.merge(
         data: asset.source + (comment % path),

--- a/lib/sprockets/uglifier_compressor.rb
+++ b/lib/sprockets/uglifier_compressor.rb
@@ -47,13 +47,13 @@ module Sprockets
       if Autoload::Uglifier::VERSION.to_i < 2
         raise "uglifier 1.x is no longer supported, please upgrade to 2.x"
       end
-      @uglifier ||= Autoload::Uglifier.new(@options)
+      @uglifier ||= Autoload::Uglifier.new(@options.merge({ source_filename: input[:filename] }))
 
       js, map = @uglifier.compile_with_map(input[:data])
-      map = SourceMapUtils.combine_source_maps(
-        input[:metadata][:map],
-        SourceMapUtils.decode_json_source_map(map)["mappings"]
-      )
+
+      map = SourceMapUtils.format_source_map(JSON.parse(map), input)
+      map = SourceMapUtils.combine_source_maps(input[:metadata][:map], map)
+
       { data: js, map: map }
     end
   end

--- a/test/fixtures/source-maps/sub/a.js
+++ b/test/fixtures/source-maps/sub/a.js
@@ -1,0 +1,3 @@
+function a() {
+  console.log('sub/a.js')  
+}

--- a/test/fixtures/source-maps/sub/directory.js
+++ b/test/fixtures/source-maps/sub/directory.js
@@ -1,0 +1,4 @@
+//= require ./a
+//= require ./modules/something
+console.log('sub/directory.js');
+a();

--- a/test/fixtures/source-maps/sub/modules/something.js
+++ b/test/fixtures/source-maps/sub/modules/something.js
@@ -1,0 +1,1 @@
+console.log("something.js")

--- a/test/shared_sass_tests.rb
+++ b/test/shared_sass_tests.rb
@@ -202,11 +202,19 @@ end
 module SharedSassTestCompressor
   extend Sprockets::TestDefinition
 
+  def setup
+    @env = Sprockets::Environment.new
+    @env.append_path File.expand_path("../fixtures", __FILE__)
+  end
+
   test "compress css" do
     silence_warnings do
       uncompressed = "p {\n  margin: 0;\n  padding: 0;\n}\n"
       compressed   = "p{margin:0;padding:0}\n"
       input = {
+        environment: @env,
+        filename: File.expand_path("../fixtures/uncompressed.css", __FILE__),
+        load_path: File.expand_path("../fixtures", __FILE__),
         data: uncompressed,
         metadata: {},
         cache: Sprockets::Cache.new

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -1106,7 +1106,7 @@ class DebugAssetTest < Sprockets::TestCase
   end
 
   test "digest path" do
-    assert_equal "application.debug-2f5fde4066077205c961164247ca6ae471977d347b4ef96d9d6e2e17d9d9906c.js",
+    assert_equal "application.debug-60cfa762e3139c2580dbfbefd46a5359803225363eaef31efb725e6731ab6849.js",
       @asset.digest_path
   end
 
@@ -1123,7 +1123,7 @@ class DebugAssetTest < Sprockets::TestCase
   end
 
   test "to_s" do
-    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\nvar Users = {\n  find: function(id) {\n  }\n};\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n\n//# sourceMappingURL=application.js-a1ddc843806213ded8eaf93eb6502617575c906ebb3c8826825abe53344c8806.map", @asset.to_s
+    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\nvar Users = {\n  find: function(id) {\n  }\n};\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n\n//# sourceMappingURL=application.js-161f7edec524c6e94ab3b89924c4fb96d4552bb83b32d975c074b7fb9a84c454.map", @asset.to_s
   end
 
   def asset(logical_path, options = {})

--- a/test/test_babel_processor.rb
+++ b/test/test_babel_processor.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
+require 'sprockets_test'
 require 'minitest/autorun'
 require 'sprockets/cache'
 require 'sprockets/babel_processor'
 
 class TestBabelProcessor < MiniTest::Test
+  def setup
+    @env = Sprockets::Environment.new
+    @env.append_path File.expand_path("../fixtures", __FILE__)
+  end
+
   def test_compile_es6_features_to_es5
     input = {
+      environment: @env,
       content_type: 'application/ecmascript-6',
       data: "const square = (n) => n * n",
       metadata: {},
@@ -22,6 +29,7 @@ class TestBabelProcessor < MiniTest::Test
 
   def test_transform_arrow_function
     input = {
+      environment: @env,
       content_type: 'application/ecmascript-6',
       data: "var square = (n) => n * n",
       metadata: {},
@@ -41,6 +49,7 @@ var square = function square(n) {
 
   def test_common_modules
     input = {
+      environment: @env,
       content_type: 'application/ecmascript-6',
       data: "import \"foo\";",
       metadata: {},
@@ -58,6 +67,7 @@ require("foo");
 
   def test_amd_modules
     input = {
+      environment: @env,
       content_type: 'application/ecmascript-6',
       data: "import \"foo\";",
       metadata: {},
@@ -75,6 +85,7 @@ define(["exports", "foo"], function (exports, _foo) {});
 
   def test_amd_modules_with_ids
     input = {
+      environment: @env,
       content_type: 'application/ecmascript-6',
       data: "import \"foo\";",
       metadata: {},
@@ -92,6 +103,7 @@ define("mod", ["exports", "foo"], function (exports, _foo) {});
 
   def test_system_modules
     input = {
+      environment: @env,
       content_type: 'application/ecmascript-6',
       data: "import \"foo\";",
       metadata: {},
@@ -114,6 +126,7 @@ System.register(["foo"], function (_export) {
 
   def test_system_modules_with_ids
     input = {
+      environment: @env,
       content_type: 'application/ecmascript-6',
       data: "import \"foo\";",
       metadata: {},
@@ -136,6 +149,7 @@ System.register("mod", ["foo"], function (_export) {
 
   def test_caching_takes_filename_into_account
     mod1 = {
+      environment: @env,
       content_type: 'application/ecmascript-6',
       data: "import \"foo\";",
       metadata: {},

--- a/test/test_bundle.rb
+++ b/test/test_bundle.rb
@@ -13,6 +13,7 @@ class TestStylesheetBundle < Sprockets::TestCase
       environment: environment,
       uri: "file://#{filename}?type=text/css",
       filename: filename,
+      load_path: fixture_path('asset'),
       content_type: 'text/css',
       metadata: {}
     }
@@ -35,6 +36,7 @@ class TestStylesheetBundle < Sprockets::TestCase
       environment: environment,
       uri: "file://#{filename}?type=text/css",
       filename: filename,
+      load_path: fixture_path('asset'),
       content_type: 'text/css',
       metadata: {}
     }
@@ -64,6 +66,7 @@ class TestStylesheetBundle < Sprockets::TestCase
       environment: environment,
       uri: "file://#{filename}?type=application/javascript",
       filename: filename,
+      load_path: fixture_path('asset'),
       content_type: 'application/javascript',
       metadata: {}
     }
@@ -86,6 +89,7 @@ class TestStylesheetBundle < Sprockets::TestCase
       environment: environment,
       uri: "file://#{filename}?type=application/javascript",
       filename: filename,
+      load_path: fixture_path('asset'),
       content_type: 'application/javascript',
       metadata: {}
     }

--- a/test/test_processor_utils.rb
+++ b/test/test_processor_utils.rb
@@ -52,6 +52,11 @@ class TestProcessorUtils < MiniTest::Test
     end
   end
 
+  def setup
+    @env = Sprockets::Environment.new
+    @env.append_path File.expand_path("../fixtures", __FILE__)
+  end
+
   def test_call_nothing
     a = proc {}
 
@@ -247,6 +252,9 @@ class TestProcessorUtils < MiniTest::Test
     processor = compose_processors(Sprockets::UglifierCompressor, Sprockets::CoffeeScriptProcessor)
 
     input = {
+      environment: @env,
+      load_path: File.expand_path("../fixtures", __FILE__),
+      filename: File.expand_path("../fixtures/compose.coffee", __FILE__),
       content_type: 'application/javascript',
       data: "self.square = (n) -> n * n",
       cache: Sprockets::Cache.new

--- a/test/test_uglifier_compressor.rb
+++ b/test/test_uglifier_compressor.rb
@@ -1,16 +1,31 @@
 # frozen_string_literal: true
+require 'sprockets_test'
 require 'minitest/autorun'
 require 'sprockets/cache'
 require 'sprockets/uglifier_compressor'
 
 class TestUglifierCompressor < MiniTest::Test
+  def setup
+    @env = Sprockets::Environment.new
+    @env.append_path File.expand_path("../fixtures", __FILE__)
+  end
+
   def test_compress_javascript
     input = {
+      environment: @env,
+      load_path: File.expand_path("../fixtures", __FILE__),
+      filename: File.expand_path("../fixtures/file.js", __FILE__),
       content_type: 'application/javascript',
       data: "function foo() {\n  return true;\n}",
       cache: Sprockets::Cache.new,
       metadata: {
-        mapping: []
+        map: {
+          "version" => 3,
+          "file" => "test/file.js",
+          "mappings" => "AAAA",
+          "sources" => ["file.js"],
+          "names" => []
+        }
       }
     }
     output = "function foo(){return!0}"


### PR DESCRIPTION
Currently the source map processor expects sources to be in the format of a logical path, however the source map spec only supports source maps with absolute paths or relative paths. I introduced a workaround in #390 which [changed logical paths to relative paths](https://github.com/rails/sprockets/blob/master/lib/sprockets/source_map_utils.rb#L140-L142). But this solution is extremely fragile. 

This PR introduces a proper fix. The source map processor now expects either relative paths, or absolute paths, and takes care of the necessary processing such that they are resolved properly. The overall effect of this is that individual processors no longer need to worry about producing sprockets compatible maps, that logic is handled by the source map processor. 

This PR also removes fingerprinting from source files as reported in #343.  Since the source map processor includes fingerprinted sources in the asset's metadata, it is not necessary to also include them in the data. I modified the test introduced in #367 to reflect this change.
