### PR TITLE
Make environment version affect asset digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprockets/blob/master/UPGRADING.md
 
+## Next Release
+
+- Changing the version now busts the digest of all assets [#404]
+
 ## 4.0.0.beta3
 
 - Source Map fixes [#255] [#367]

--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -163,7 +163,7 @@ module Sprockets
           source = result.delete(:data)
           metadata = result
           metadata[:charset] = source.encoding.name.downcase unless metadata.key?(:charset)
-          metadata[:digest]  = digest(source)
+          metadata[:digest]  = digest(self.version + source)
           metadata[:length]  = source.bytesize
         else
           dependencies << build_file_digest_uri(unloaded.filename)

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -671,10 +671,10 @@ class TestEnvironment < Sprockets::TestCase
     assert_equal 2, asset.metadata[:selector_count]
   end
 
-  test "changing version doesn't affect the assets digest" do
+  test "changing version changes the digest of the asset" do
     old_asset_digest = @env["gallery.js"].hexdigest
     @env.version = 'v2'
-    assert old_asset_digest == @env["gallery.js"].hexdigest
+    assert old_asset_digest != @env["gallery.js"].hexdigest
   end
 
   test "bundled asset is stale if its mtime is updated or deleted" do


### PR DESCRIPTION
Based on discussion in https://github.com/rails/sprockets-rails/issues/240, this is an attempt to bring back the behaviour of Sprockets 2.

The intended use case is to force every asset to be regenerated with a new filename by bumping the environment version. This is useful for example when serving assets from a CDN with long expiration times.

The old behaviour was removed in 07e5e29e2ec93c70c6783c4fc6f3c34f1a3442a8. The entire digest setup has changed a lot since then. It's not entirely clear to me where the best spot now would be to reintroduce the version – should it affect all digest calculation throughout the library, or just the digest which ends up as part of the filename?

I've started by making a very minimal change that would achieve the intended behaviour. I assume that this will not be the version that gets merged, but maybe it can serve as a starting point. :) Let me know your thoughts.