### PR TITLE
Fix index alias source maps

### DIFF
--- a/lib/sprockets/source_map_comment_processor.rb
+++ b/lib/sprockets/source_map_comment_processor.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+require 'sprockets/uri_utils'
+require 'sprockets/path_utils'
+
 module Sprockets
   class SourceMapCommentProcessor
     def self.call(input)
@@ -21,7 +24,9 @@ module Sprockets
       uri, _ = env.resolve!(input[:filename], accept: map_type)
       map = env.load(uri)
 
-      path = PathUtils.relative_path_from(input[:filename], map.full_digest_path)
+      uri, _ = URIUtils.parse_asset_uri(input[:uri])
+      uri = env.expand_from_root(_[:index_alias]) if _[:index_alias]
+      path = PathUtils.relative_path_from(uri, map.full_digest_path)
 
       asset.metadata.merge(
         data: asset.source + (comment % path),

--- a/lib/sprockets/source_map_comment_processor.rb
+++ b/lib/sprockets/source_map_comment_processor.rb
@@ -24,8 +24,8 @@ module Sprockets
       uri, _ = env.resolve!(input[:filename], accept: map_type)
       map = env.load(uri)
 
-      uri, _ = URIUtils.parse_asset_uri(input[:uri])
-      uri = env.expand_from_root(_[:index_alias]) if _[:index_alias]
+      uri, params = URIUtils.parse_asset_uri(input[:uri])
+      uri = env.expand_from_root(params[:index_alias]) if params[:index_alias]
       path = PathUtils.relative_path_from(uri, map.full_digest_path)
 
       asset.metadata.merge(

--- a/test/fixtures/source-maps/foo/file.coffee
+++ b/test/fixtures/source-maps/foo/file.coffee
@@ -1,0 +1,1 @@
+console.log("foo/file.coffee") if 1 < 2

--- a/test/fixtures/source-maps/foo/index.js
+++ b/test/fixtures/source-maps/foo/index.js
@@ -1,0 +1,2 @@
+//= require ./file
+console.log("foo.js");

--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -251,6 +251,19 @@ class TestSourceMaps < Sprockets::TestCase
     assert_equal "main.css", map['file']
     assert_equal 172, map['mappings'].size
   end
+
+  test "source maps work with index alias" do
+    asset = @env.find_asset("foo.js",  pipeline: :debug)
+    mapUrl = asset.source.match(/^\/\/# sourceMappingURL=(.*)$/)[1]
+    assert_equal "foo/index.js-f0762afcb2fb7da09c19868c366b58f81324dc7128b5a64a2757e9eab1e02837.map", mapUrl
+
+    map = @env.find_asset('foo/index.js.map')
+    sources = JSON.parse(map.source.match(/"sources":(\[.*?\])/)[1])
+    assert_equal [
+      "file.source-db1eb561f880aead3f69d072274e15ee404921dfebe30a35b12e2d8c47e33803.coffee",
+      "index.source-8b27c2df3fc22ff7f0800e09e0b26088dac8c711f6e3b1765aae1d632fd83798.js"
+    ], sources
+  end
 end
 
 


### PR DESCRIPTION
Presently source maps do not work for index aliased files.

So, if you have:
```
foo
├── file.coffee
└── index.js
```
Then `<%= javascript_include_tag "foo" %>` renders `foo.js` with `//# sourceMappingURL= index.js.map`since it tries to make the url relative to the file `foo/index.js`. However, when chrome requests `foo.js`, it will look for `index.js.map` relative from `foo.js` and thus not find it. 

This PR revises `SourceMapCommentProcessor` to ensure the url is relative from the correct location. i.e. `//# sourceMappingURL= foo/index.js.map`.