### PR TITLE
Fix typo in guide [ci-skip]

### DIFF
--- a/guides/extending_sprockets.md
+++ b/guides/extending_sprockets.md
@@ -290,7 +290,7 @@ Your extension may have multiple parts for example some people use `.coffee.js` 
 
 
 ```ruby
-Sprockets.register_mime_type 'text/coffeescript', extensions: ['.coffee', '.js.coffee']
+Sprockets.register_mime_type 'text/coffeescript', extensions: ['.coffee', '.coffee.js']
 ```
 
 ## Adding Directives to your Extension


### PR DESCRIPTION
The text states that the intent is to allow `.coffee.js` files...