### PR TITLE
Speed up digests with refinements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 2.0.0
-  - 2.1
   - 2.2
   - 2.3.1
   - 2.4.0-preview1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
-**Master**
-
 Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprockets/blob/master/UPGRADING.md
 
 ## Master
 
+- Minimum Ruby version now 2.2 to support refinements, required keyword args, and symbol GC.
 
 ## 4.0.0.beta4
 

--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "yui-compressor", "~> 0.12"
   s.add_development_dependency "zopfli", "~> 0.0.4"
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.2.0'
 
   s.authors = ["Sam Stephenson", "Joshua Peek"]
   s.email = ["sstephenson@gmail.com", "josh@joshpeek.com"]


### PR DESCRIPTION
Huge thank you to @bouk who did all the work here. This is a follow up from the conversation at https://github.com/rails/sprockets/issues/383#issuecomment-258276143.

Running asset generation in a loop on codetriage.com

```
task "assets:bench" do
  measure = []

  50.times do |i|
    puts "== Running (#{i})"
    measure << Benchmark.measure do
      `rm -rf tmp/cache/assets/sprockets/v4.0/ ; rm -rf public/assets; touch tmp; time RAILS_ENV=production bundle exec rake assets:precompile`
    end.real
  end
  puts "================ DONE ================"
  puts measure.join("\n")
end
```

I get these numbers:

```
            Avg         STDev
Refinements 10.06318182 0.2621523045
Hash        12.08513782 1.944694921
```

Based on this refinements is faster than the current hash (8-16% in a real world assets:precompile app), but there is a high variance.