### PR TITLE
Don't add newlines when concatenating JS

### DIFF
--- a/lib/sprockets/utils.rb
+++ b/lib/sprockets/utils.rb
@@ -107,10 +107,8 @@ module Sprockets
         # This will lead to O(N^2) performance in string_end_with_semicolon?, so we should use 32 bit encoding to make sure indexing stays O(1)
         source = source.encode(Encoding::UTF_32LE) unless source.ascii_only?
 
-        if !string_end_with_semicolon?(source)
-          buf << ";\n"
-        elsif source[source.size - 1].ord != 0x0A
-          buf << "\n"
+        unless string_end_with_semicolon?(source)
+          buf << ";"
         end
       end
 

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -876,8 +876,8 @@ class BundledAssetTest < Sprockets::TestCase
     expected = '
 define("application.js", "application-955b2dddd0d1449b1c617124b83b46300edadec06d561104f7f6165241b31a94.js")
 define("application.css", "application-46d50149c56fc370805f53c29f79b89a52d4cc479eeebcdc8db84ab116d7ab1a.css")
-define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png")
-;'
+define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png");
+'
 
     assert_equal expected, asset.to_s
     assert_equal [
@@ -895,8 +895,8 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
 
 define("application.js", "application-955b2dddd0d1449b1c617124b83b46300edadec06d561104f7f6165241b31a94.js")
 define("application.css", "application-46d50149c56fc370805f53c29f79b89a52d4cc479eeebcdc8db84ab116d7ab1a.css")
-define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png")
-;'
+define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png");
+'
     assert_equal expected, asset.to_s
 
     assert_equal [
@@ -1051,12 +1051,12 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
   end
 
   test "appends missing semicolons" do
-    assert_equal "var Bar\n;\n(function() {\n  var Foo\n})\n;",
+    assert_equal "var Bar;\n\n(function() {\n  var Foo\n});\n",
       asset("semicolons.js").to_s
   end
 
   test 'keeps code in same line after multi-line comments' do
-    assert_equal "/******/ function foo() {\n}\n;",
+    assert_equal "/******/ function foo() {\n};\n",
       asset('multi_line_comment.js').to_s
   end
 

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -873,13 +873,13 @@ class BundledAssetTest < Sprockets::TestCase
 
   test "linked asset depends on target asset" do
     assert asset = asset("require_manifest.js")
-    assert_equal <<-EOS, asset.to_s
-
+    expected = '
 define("application.js", "application-955b2dddd0d1449b1c617124b83b46300edadec06d561104f7f6165241b31a94.js")
 define("application.css", "application-46d50149c56fc370805f53c29f79b89a52d4cc479eeebcdc8db84ab116d7ab1a.css")
 define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png")
-;
-    EOS
+;'
+
+    assert_equal expected, asset.to_s
     assert_equal [
       "file://#{fixture_path_for_uri("asset/POW.png")}?type=image/png&id=xxx",
       "file://#{fixture_path_for_uri("asset/application.css")}?type=text/css&id=xxx",
@@ -889,16 +889,15 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
 
   test "directive linked asset depends on target asset" do
     assert asset = asset("require_manifest2.js")
-    assert_equal <<-EOS, asset.to_s
-
+    expected = '
 
 
 
 define("application.js", "application-955b2dddd0d1449b1c617124b83b46300edadec06d561104f7f6165241b31a94.js")
 define("application.css", "application-46d50149c56fc370805f53c29f79b89a52d4cc479eeebcdc8db84ab116d7ab1a.css")
 define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png")
-;
-    EOS
+;'
+    assert_equal expected, asset.to_s
 
     assert_equal [
       "file://#{fixture_path_for_uri("asset/POW.png")}?type=image/png&id=xxx",
@@ -1052,12 +1051,12 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
   end
 
   test "appends missing semicolons" do
-    assert_equal "var Bar\n;\n\n(function() {\n  var Foo\n})\n;\n",
+    assert_equal "var Bar\n;\n(function() {\n  var Foo\n})\n;",
       asset("semicolons.js").to_s
   end
 
   test 'keeps code in same line after multi-line comments' do
-    assert_equal "/******/ function foo() {\n}\n;\n",
+    assert_equal "/******/ function foo() {\n}\n;",
       asset('multi_line_comment.js').to_s
   end
 

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -801,7 +801,7 @@ class TestEnvironment < Sprockets::TestCase
     assert processor = @env.preprocessors['application/javascript'][0]
     assert_kind_of Sprockets::DirectiveProcessor, processor
     @env.unregister_preprocessor('application/javascript', processor)
-    assert_equal "// =require \"notfound\"\n;\n", @env["missing_require.js"].to_s
+    assert_equal "// =require \"notfound\"\n;", @env["missing_require.js"].to_s
   end
 
   test "disabling processors by class name also disables processors which are instances of that class" do

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -801,7 +801,7 @@ class TestEnvironment < Sprockets::TestCase
     assert processor = @env.preprocessors['application/javascript'][0]
     assert_kind_of Sprockets::DirectiveProcessor, processor
     @env.unregister_preprocessor('application/javascript', processor)
-    assert_equal "// =require \"notfound\"\n;", @env["missing_require.js"].to_s
+    assert_equal "// =require \"notfound\";\n", @env["missing_require.js"].to_s
   end
 
   test "disabling processors by class name also disables processors which are instances of that class" do

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -70,34 +70,35 @@ class TestUtils < MiniTest::Test
   end
 
   def test_string_ends_with_semicolon
-    assert string_end_with_semicolon?("var foo;")
-    refute string_end_with_semicolon?("var foo")
+    assert_nil semicolon_insertion_location("var foo;")
+    assert_equal 7, semicolon_insertion_location("var foo")
 
-    assert string_end_with_semicolon?("var foo;\n")
-    refute string_end_with_semicolon?("var foo\n")
+    assert_nil semicolon_insertion_location("var foo;\n")
+    assert_equal 7, semicolon_insertion_location("var foo\n")
 
-    assert string_end_with_semicolon?("var foo;\n\n")
-    refute string_end_with_semicolon?("var foo\n\n")
+    assert_nil semicolon_insertion_location("var foo;\n\n")
+    assert_equal 7, semicolon_insertion_location("var foo\n\n")
 
-    assert string_end_with_semicolon?("  var foo;\n  \n")
-    refute string_end_with_semicolon?("  var foo\n  \n")
+    assert_nil semicolon_insertion_location("  var foo;\n  \n")
+    assert_equal 9, semicolon_insertion_location("  var foo\n  \n")
 
-    assert string_end_with_semicolon?("\tvar foo;\n\t\n")
-    refute string_end_with_semicolon?("\tvar foo\n\t\n")
+    assert_nil semicolon_insertion_location("\tvar foo;\n\t\n")
+    assert_equal 8, semicolon_insertion_location("\tvar foo\n\t\n")
 
-    assert string_end_with_semicolon?("var foo\n;\n")
-    refute string_end_with_semicolon?("var foo\n\n")
+    assert_nil semicolon_insertion_location("var foo\n;\n")
+    assert_equal 7, semicolon_insertion_location("var foo\n\n")
   end
 
   def test_concat_javascript_sources
-    assert_equal "var foo;\n", apply_concat_javascript_sources("".freeze, "var foo;\n".freeze)
-    assert_equal "\nvar foo;\n", apply_concat_javascript_sources("\n".freeze, "var foo;\n".freeze)
-    assert_equal " var foo;\n", apply_concat_javascript_sources(" ".freeze, "var foo;\n".freeze)
+    assert_equal "var foo;\n", apply_concat_javascript_sources("", "var foo;\n")
+    assert_equal "\nvar foo;\n", apply_concat_javascript_sources("\n", "var foo;\n")
+    assert_equal " var foo;\n", apply_concat_javascript_sources(" ", "var foo;\n")
 
-    assert_equal "var foo;\nvar bar;\n", apply_concat_javascript_sources("var foo;\n".freeze, "var bar;\n".freeze)
-    assert_equal "var foo;var bar;", apply_concat_javascript_sources("var foo".freeze, "var bar".freeze)
-    assert_equal "var foo;var bar;", apply_concat_javascript_sources("var foo;".freeze, "var bar;".freeze)
-    assert_equal "var foo;var bar;", apply_concat_javascript_sources("var foo".freeze, "var bar;".freeze)
+    assert_equal "var foo;\nvar bar;\n", apply_concat_javascript_sources("var foo;\n", "var bar;\n")
+    assert_equal "var foo;var bar;", apply_concat_javascript_sources("var foo", "var bar")
+    assert_equal "var foo;var bar;", apply_concat_javascript_sources("var foo;", "var bar;")
+    assert_equal "var foo;var bar;", apply_concat_javascript_sources("var foo", "var bar;")
+    assert_equal "'😁';var bar;", apply_concat_javascript_sources("'😁'", "var bar;")
   end
 
   def apply_concat_javascript_sources(*args)

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -92,18 +92,17 @@ class TestUtils < MiniTest::Test
   def test_concat_javascript_sources
     assert_equal "var foo;\n", apply_concat_javascript_sources("".freeze, "var foo;\n".freeze)
     assert_equal "\nvar foo;\n", apply_concat_javascript_sources("\n".freeze, "var foo;\n".freeze)
-    assert_equal " \nvar foo;\n", apply_concat_javascript_sources(" ".freeze, "var foo;\n".freeze)
+    assert_equal " var foo;\n", apply_concat_javascript_sources(" ".freeze, "var foo;\n".freeze)
 
     assert_equal "var foo;\nvar bar;\n", apply_concat_javascript_sources("var foo;\n".freeze, "var bar;\n".freeze)
-    assert_equal "var foo;\nvar bar;\n", apply_concat_javascript_sources("var foo".freeze, "var bar".freeze)
-    assert_equal "var foo;\nvar bar;\n", apply_concat_javascript_sources("var foo;".freeze, "var bar;".freeze)
-    assert_equal "var foo;\nvar bar;\n", apply_concat_javascript_sources("var foo".freeze, "var bar;".freeze)
+    assert_equal "var foo;var bar;", apply_concat_javascript_sources("var foo".freeze, "var bar".freeze)
+    assert_equal "var foo;var bar;", apply_concat_javascript_sources("var foo;".freeze, "var bar;".freeze)
+    assert_equal "var foo;var bar;", apply_concat_javascript_sources("var foo".freeze, "var bar;".freeze)
   end
 
   def apply_concat_javascript_sources(*args)
     args.reduce(String.new(""), &method(:concat_javascript_sources))
   end
-
 
   def test_post_order_depth_first_search
     m = []


### PR DESCRIPTION
This ensures sourcemaps don't get misaligned

For review @schneems 

@SamSaffron @danshultz I know you're interested in this 

Fixes https://github.com/rails/sprockets/issues/388
Fixes https://github.com/rails/sprockets/issues/416