### PR TITLE
link_tree content_type hack

### DIFF
--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -296,6 +296,7 @@ module Sprockets
         exporters = [Exporters::FileExporter]
 
         environment.exporters.each do |mime_type, exporter_list|
+          next unless asset.content_type
           next unless environment.match_mime_type? asset.content_type, mime_type
           exporter_list.each do |exporter|
             exporters << exporter


### PR DESCRIPTION
`link_tree` stopped working in Rails 5 citing [`NoMethodError: undefined method 'split' for nil:NilClass`](https://github.com/rails/sprockets/issues/424)

I found the issue was caused by the file not having a `content_type`.

I have yet to determine why this occurs, but created this hotfix if anybody needs to use `link_tree` in production.