### PR TITLE
Speed up Hash lookups with constants

### DIFF
--- a/lib/sprockets/digest_utils.rb
+++ b/lib/sprockets/digest_utils.rb
@@ -80,6 +80,9 @@ module Sprockets
         digest << val.to_s
       }
     end
+
+    ADD_VALUE_TO_DIGEST.compare_by_identity.rehash
+
     ADD_VALUE_TO_DIGEST.default_proc = ->(_, val) {
       raise TypeError, "couldn't digest #{ val }"
     }


### PR DESCRIPTION
Since we are always looking up these hashes with an identical duplicate (not just the same value, the same object) we can take advantage of Hash.compare_by_identity.

Suggested by @dgynn in https://github.com/rails/sprockets/issues/383#issuecomment-260101585