### PR TITLE
Add failing case for circular directives

### DIFF
--- a/test/fixtures/asset/circle_depend_on_asset/a.js
+++ b/test/fixtures/asset/circle_depend_on_asset/a.js
@@ -1,0 +1,2 @@
+//= depend_on_asset circle_depend_on_asset/b.js
+var A;

--- a/test/fixtures/asset/circle_depend_on_asset/b.js
+++ b/test/fixtures/asset/circle_depend_on_asset/b.js
@@ -1,0 +1,2 @@
+//= depend_on_asset circle_depend_on_asset/a.js
+var B;

--- a/test/fixtures/asset/circle_link/a.js
+++ b/test/fixtures/asset/circle_link/a.js
@@ -1,0 +1,2 @@
+//= link circle_link/b.js
+var A;

--- a/test/fixtures/asset/circle_link/b.js
+++ b/test/fixtures/asset/circle_link/b.js
@@ -1,0 +1,2 @@
+//= link circle_link/a.js
+var B;

--- a/test/fixtures/asset/circle_link_directory/a.js
+++ b/test/fixtures/asset/circle_link_directory/a.js
@@ -1,0 +1,2 @@
+//= link_directory ./b
+var A;

--- a/test/fixtures/asset/circle_link_directory/b/b.js
+++ b/test/fixtures/asset/circle_link_directory/b/b.js
@@ -1,0 +1,2 @@
+//= link_directory ../
+var A;

--- a/test/fixtures/asset/circle_link_tree/a.js
+++ b/test/fixtures/asset/circle_link_tree/a.js
@@ -1,0 +1,2 @@
+//= link_tree ./b
+var A;

--- a/test/fixtures/asset/circle_link_tree/b/b.js
+++ b/test/fixtures/asset/circle_link_tree/b/b.js
@@ -1,0 +1,2 @@
+//= link_tree ../
+var A;

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -995,6 +995,26 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
     assert_equal "var Foo = {};\n\n\n\n", asset("stub/application").to_s
   end
 
+  test "resolves circular link_tree" do
+    assert_equal 'var A;',
+      asset("circle_link_tree/a.js").to_s.chomp
+  end
+
+  test "resolves circular link_directory" do
+    assert_equal 'var A;',
+      asset("circle_link_directory/a.js").to_s.chomp
+  end
+
+  test "resolves circular link" do
+    assert_equal 'var A;',
+      asset("circle_link/a.js").to_s.chomp
+  end
+
+  test "resolves circular depend_on_asset" do
+    assert_equal 'var A;',
+      asset("circle_depend_on_asset/a.js").to_s.chomp
+  end
+
   test "resolves circular requires" do
     assert_equal "var A;\nvar C;\nvar B;\n",
       asset("circle/a.js").to_s


### PR DESCRIPTION
When you call `load` inside of a `process_#{name}_directive` method on two assets that call the same method on each other, then you get an infinite loop. That is because the `load` call triggers directives of the asset being loaded, if the asset being loaded needs to load the original asset then neither can return because neither is fully loaded but they depend on each other to be loaded.

This is tested and fixed for `require` but not for any other directives.

I added failing tests for:

- link_tree
- link_directory
- link
- depend_on_asset