### PR TITLE
[close #440] Fix circular directives

### DIFF
--- a/lib/sprockets/bundle.rb
+++ b/lib/sprockets/bundle.rb
@@ -16,10 +16,26 @@ module Sprockets
     def self.call(input)
       env  = input[:environment]
       type = input[:content_type]
+      input[:links] ||= Set.new
       dependencies = Set.new(input[:metadata][:dependencies])
 
       processed_uri, deps = env.resolve(input[:filename], accept: type, pipeline: :self)
       dependencies.merge(deps)
+
+      # DirectiveProcessor (and any other transformers called here with pipeline=self)
+      primary_asset = env.load(processed_uri)
+      to_load = primary_asset.metadata.delete(:to_load) || Set.new
+      to_link = primary_asset.metadata.delete(:to_link) || Set.new
+
+      to_load.each do |uri|
+        loaded_asset = env.load(uri)
+        dependencies.merge(loaded_asset.metadata[:dependencies])
+        if to_link.include?(uri)
+          primary_metadata = primary_asset.metadata
+          input[:links]            << loaded_asset.uri
+          primary_metadata[:links] << loaded_asset.uri
+        end
+      end
 
       find_required = proc { |uri| env.load(uri).metadata[:required] }
       required = Utils.dfs(processed_uri, &find_required)

--- a/test/fixtures/asset/circle_depend_on_asset/a.js
+++ b/test/fixtures/asset/circle_depend_on_asset/a.js
@@ -1,0 +1,2 @@
+//= depend_on_asset circle_depend_on_asset/b.js
+var A;

--- a/test/fixtures/asset/circle_depend_on_asset/b.js
+++ b/test/fixtures/asset/circle_depend_on_asset/b.js
@@ -1,0 +1,2 @@
+//= depend_on_asset circle_depend_on_asset/a.js
+var B;

--- a/test/fixtures/asset/circle_link/a.js
+++ b/test/fixtures/asset/circle_link/a.js
@@ -1,0 +1,2 @@
+//= link circle_link/b.js
+var A;

--- a/test/fixtures/asset/circle_link/b.js
+++ b/test/fixtures/asset/circle_link/b.js
@@ -1,0 +1,2 @@
+//= link circle_link/a.js
+var B;

--- a/test/fixtures/asset/circle_link_directory/a.js
+++ b/test/fixtures/asset/circle_link_directory/a.js
@@ -1,0 +1,2 @@
+//= link_directory ./b
+var A;

--- a/test/fixtures/asset/circle_link_directory/b/b.js
+++ b/test/fixtures/asset/circle_link_directory/b/b.js
@@ -1,0 +1,2 @@
+//= link_directory ../
+var A;

--- a/test/fixtures/asset/circle_link_tree/a.js
+++ b/test/fixtures/asset/circle_link_tree/a.js
@@ -1,0 +1,2 @@
+//= link_tree ./b
+var A;

--- a/test/fixtures/asset/circle_link_tree/b/b.js
+++ b/test/fixtures/asset/circle_link_tree/b/b.js
@@ -1,0 +1,2 @@
+//= link_tree ../
+var A;

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -995,6 +995,26 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
     assert_equal "var Foo = {};\n\n\n\n", asset("stub/application").to_s
   end
 
+  test "resolves circular link_tree" do
+    assert_equal 'var A;',
+      asset("circle_link_tree/a.js").to_s.chomp
+  end
+
+  test "resolves circular link_directory" do
+    assert_equal 'var A;',
+      asset("circle_link_directory/a.js").to_s.chomp
+  end
+
+  test "resolves circular link" do
+    assert_equal 'var A;',
+      asset("circle_link/a.js").to_s.chomp
+  end
+
+  test "resolves circular depend_on_asset" do
+    assert_equal 'var A;',
+      asset("circle_depend_on_asset/a.js").to_s.chomp
+  end
+
   test "resolves circular requires" do
     assert_equal "var A;\nvar C;\nvar B;\n",
       asset("circle/a.js").to_s


### PR DESCRIPTION
We de-couple the directive parsing and "resolving" from the "loading" so that a file does not have the ability to accidentally load itself when it is itself trying to load.

In the `DirectiveProcessor` we no longer run `load` instead we store the things we want to load on the asset metadata. Later we pull those things out and load them. Here's a tree representation of what's now happening for a `link` directive in `a.js` that points at an asset `b.js` that is "link"-ing to `a.js` (making a circular dependency):

- env.load("a.js") (pipeline=default)
  - env.load("a.js") (pipeline=source)
    - No processors for pipeline=source
    - Return pipeline=source
  - Processors for (pipeline=default): `[Bundle]`
    - env.load("a.js") (pipeline=self)
      - Processors for (pipeline=self): `[DirectiveProcessor]`
        - //= link b.js
          - b.s is added to `to_load` and `to_link` sets
      - pipeline=self asset returns
    - URIs pulled out of `to_load`, `to_link` sets and loaded
      - env.load("b.js") (pipeline=default)
        -  ...
        - return b.js (pipeline=default)
    - URIs pulled out of `required` set and loaded (existing behavior)
    - Merge required files to form top level asset
- Return top level asset

There is one concern here in that the extra `to_link` and `to_load` metadata gets stored in the cache for the `pipeline=self` asset. Also this asset would have traditionally have full URIs stored in the `links` metadata key, which can't be done yet because it expects fully expanded uris with digests. However, none of the tests fail, so I guess we're good? 

I think this is okay because we never actually use the file cache of `pipeline=self` (maybe?) instead we're always using the top level `pipeline=source` cache (I think). If that's the case we could save some processing overhead by not storing the same asset in the cache three different times. I honestly see no reason why this has to be recursive. It just makes the coder harder to reason about...but that's for a different PR/day.
