### PR TITLE
Remove `source_path`

### DIFF
--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -140,10 +140,6 @@ module Sprockets
 
         # Read into memory and process if theres a processor pipeline
         if processors.any?
-          source_uri, _ = resolve!(unloaded.filename, pipeline: :source)
-          source_asset = load(source_uri)
-
-          source_path = source_asset.digest_path
 
           result = call_processors(processors, {
             environment: self,
@@ -151,7 +147,6 @@ module Sprockets
             uri: unloaded.uri,
             filename: unloaded.filename,
             load_path: load_path,
-            source_path: source_path,
             name: name,
             content_type: type,
             metadata: {


### PR DESCRIPTION
When generating an asset we pass in a `source_path` to the processors:

https://github.com/rails/sprockets/blob/e6d65c0b6a2ac3e1f148ed523a0b5654156bb4cc/lib/sprockets/loader.rb#L143-L146

When I delete this code and re-run the tests (including removing the element from the hash passed into the processors everything passes.

To generate the `source_path` we have to read the original source file into memory, and digest it. This takes time. If we're not using it anywhere, we can get rid of it. If it is useful, then we should add tests.

The only place it is referenced is in some examples in the docs that can be easily changed.


cc/ @bouk @TylerHorth @rafaelfranca