### PR TITLE
Remove source map hack

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -99,13 +99,7 @@ module Sprockets
   end
 
   register_pipeline :default do |env, type, file_type|
-    # TODO: Hack for to inject source map transformer
-    if (type == "application/js-sourcemap+json" && file_type != "application/js-sourcemap+json") ||
-        (type == "application/css-sourcemap+json" && file_type != "application/css-sourcemap+json")
-      [SourceMapProcessor]
-    else
-      env.default_processors_for(type, file_type)
-    end
+    env.default_processors_for(type, file_type)
   end
 
   require 'sprockets/source_map_comment_processor'

--- a/lib/sprockets/directive_processor.rb
+++ b/lib/sprockets/directive_processor.rb
@@ -70,7 +70,9 @@ module Sprockets
       @uri          = input[:uri]
       @filename     = input[:filename]
       @dirname      = File.dirname(@filename)
-      @content_type = input[:content_type]
+      # If loading a source map file like `application.js.map` resolve
+      # dependencies using `.js` instead of `.js.map`
+      @content_type = SourceMapProcessor.original_content_type(input[:content_type], error_when_not_found: false)
       @required     = Set.new(input[:metadata][:required])
       @stubbed      = Set.new(input[:metadata][:stubbed])
       @links        = Set.new(input[:metadata][:links])

--- a/lib/sprockets/source_map_processor.rb
+++ b/lib/sprockets/source_map_processor.rb
@@ -3,21 +3,23 @@ require 'set'
 
 module Sprockets
   class SourceMapProcessor
-    def self.call(input)
-      case input[:content_type]
+    def self.original_content_type(source_map_content_type, error_when_not_found: true)
+      case source_map_content_type
       when "application/js-sourcemap+json"
         accept = "application/javascript"
       when "application/css-sourcemap+json"
         accept = "text/css"
       else
-        fail input[:content_type]
+        fail(source_map_content_type) if error_when_not_found
+        source_map_content_type
       end
+    end
 
+    def self.call(input)
       links = Set.new(input[:metadata][:links])
-
       env = input[:environment]
 
-      uri, _ = env.resolve!(input[:filename], accept: accept)
+      uri, _ = env.resolve!(input[:filename], accept: original_content_type(input[:content_type]))
       asset  = env.load(uri)
       map    = asset.metadata[:map]
 


### PR DESCRIPTION
When trying to load a source map file such as `application.js.map` it will load the `application.js` file and run the `SourceMapProcessor` on it as a transformer, before it can do that it needs to load dependencies in `application.js` the accept type for the directive processor will be "application/js-sourcemap+json". If the `application.js file has dependencies such as `//= require project` then it will try to find a `project` file with the same content type of the parent file which is `application/js-sourcemap+json` which would mean it's looking for a `project.js.map` which does not exist on disk. Instead it actually needs the `project.js` file.

This change checks if source map content type is being used in the directive processor and if so, it converts it to the original content type of the file. So a `application/js-sourcemap+json` will be converted to `application/javascript` for the directive processor.