### PR TITLE
Allow weak tags to be processed by sprockets.

### DIFF
--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -50,11 +50,11 @@ module Sprockets
       if fingerprint
         if_match = fingerprint
       elsif env['HTTP_IF_MATCH']
-        if_match = env['HTTP_IF_MATCH'][/^"(\w+)"$/, 1]
+        if_match = env['HTTP_IF_MATCH'][/"(\w+)"$/, 1]
       end
 
       if env['HTTP_IF_NONE_MATCH']
-        if_none_match = env['HTTP_IF_NONE_MATCH'][/^"(\w+)"$/, 1]
+        if_none_match = env['HTTP_IF_NONE_MATCH'][/"(\w+)"$/, 1]
       end
 
       # Look up the asset.


### PR DESCRIPTION
Since nginx 1.7.3, strong ETags are transformed into weak ETags "starting with W/" if the request is compressed. That means that when the browser re-requests the assets in development mode, sprockets will see an ETag starting with "W/..." which will never match, and as such, cache will never work. So I'm relaxing the regex here a little to handle that.