### PR TITLE
Implement cache-control immutable

### DIFF
--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -241,7 +241,7 @@ module Sprockets
         # If the request url contains a fingerprint, set a long
         # expires on the response
         if path_fingerprint(env["PATH_INFO"])
-          headers["Cache-Control"] << ", max-age=31536000"
+          headers["Cache-Control"] << ", max-age=31536000, immutable"
 
         # Otherwise set `must-revalidate` since the asset could be modified.
         else

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -210,6 +210,7 @@ class TestServer < Sprockets::TestCase
     get "/assets/application-#{digest}.js"
     assert_equal 200, last_response.status
     assert_match %r{max-age}, last_response.headers['Cache-Control']
+    assert_match %r{immutable}, last_response.headers['Cache-Control']
   end
 
   test "fingerprint digest of file self" do


### PR DESCRIPTION
The recently introduced header `Cache-Control: immutable` lets the browser know that the digested asset is never going to change.

More about `Cache-Control: immutable`:
https://bitsup.blogspot.ca/2016/05/cache-control-immutable.html
https://hacks.mozilla.org/2017/01/using-immutable-caching-to-speed-up-the-web/

@rafaelfranca @schneems 