### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,17 @@ sudo: false
 
 rvm:
   - 2.2
-  - 2.3.3
-  - 2.4.0
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
 
 matrix:
   include:
-    - rvm: 2.3.0
+    - rvm: 2.3.4
       script: bundle exec rake test_isolated
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true
 
 notifications:
   email: false


### PR DESCRIPTION
I updated rubies to latest version.
I added `ruby-head` as `allow_failures`.

I think this is useful.
Because we can prepare before next version Ruby 2.5 release.

We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.
https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

Is it possible to add it?

Thanks.