### PR TITLE
Concurrent asset compile

### DIFF
--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -573,7 +573,7 @@ class TestManifest < Sprockets::TestCase
   end
 
   # Sleep duration to context switch between concurrent threads.
-  CONTEXT_SWITCH_DURATION = 0.001
+  CONTEXT_SWITCH_DURATION = 0.1
 
   # Record Exporter sequence with a delay to test concurrency.
   class SlowExporter < Sprockets::Exporters::Base


### PR DESCRIPTION
This PR extends the existing code that executes Exporters concurrently to execute the asset-compilation process concurrently as well. This allows time-consuming custom Processor steps (in my use-case, an image-optimization preprocessor provided by [`image_optim_rails`](https://github.com/toy/image_optim_rails)) to leverage multiple CPU cores for performance gains in a similar way to how the GZip/Zopfli Exporters currently do.

The [`sprockets-derailleur`](https://github.com/steel/sprockets-derailleur) gem added multi-process functionality to Sprockets 2. I'd like to land an optimization upstream with proper test coverage so it can evolve alongside Sprockets more directly and benefit all users of this gem, hopefully by default.

I've tried to make the code diff as minimal as possible and maintain the existing enumerable-stream style (which I assume is meant to minimize memory consumption?). A few points worth noting:

1. I removed `Concurrent::FixedThreadPool.new(Concurrent.processor_count)` and a condition block from `#compile`, replacing it with a `#exporter` method that returns `:fast` or `:immediate` symbols depending on the environment configuration. This simplifies the concurrent-execution code by using the default [Global Thread Pool](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/doc/thread_pools.md#global-thread-pools) for concurrent execution (`:fast`), and the [`ImmediateExecutor`](http://ruby-concurrency.github.io/concurrent-ruby/Concurrent/ImmediateExecutor.html) (`:immediate`) when concurrency is disabled. This simplification isn't strictly necessary for the feature and could be reverted if desired.
2. Related to the previous point, I reused the existing `export_concurrent` configuration to determine whether to process assets concurrently. My preference was to have one configuration option controlling all concurrency stemming from `Manifest#compile` rather than two separate options, but this new functionality could be controlled by a separate configuration option if desired.
3. Because the results of `#find` are streamed to the `Enumerable` as they become available, the order of the returned assets is no longer consistent based on the input arguments. I needed to add `.sort` to a test that broke because it implicitly depended on a consistent ordering of the results. I didn't think this would be an issue for most non-test use-cases, but if this is a potential issue it would be possible to retain the original fixed order (at the expense of not being able to stream the results).
4. Unit tests for concurrent asset processing and also for the existing concurrent exporting feature are included. The tests currently run `sleep` with a small, fixed duration (currently `0.1` sec) to force a context-switch between threads with minimal test duration, but this approach doesn't seem to be reliable across all the platforms being tested (failed the Windows tests on AppVeyor). If anyone knows of a more reliable method of running a multi-threaded test cross-platform please let me know.