### PR TITLE
Include `version` as a part of the asset digest

### DIFF
--- a/lib/sprockets/cached_digest_utils.rb
+++ b/lib/sprockets/cached_digest_utils.rb
@@ -1,0 +1,17 @@
+module Sprockets
+  module CachedDigestUtils
+    extend self
+
+    def cached_version_digest
+      version_string = defined?(version) ? version : ''
+
+      # Compute the initial digest using the implementation class. The
+      # Sprockets release version and custom environment version are
+      # mixed in. So any new releases will affect all your assets.
+      @cached_version_digest ||= digest_class.new.update(version_string.to_s)
+
+      # Returned a dupped copy so the caller can safely mutate it with `.update`
+      @cached_version_digest.dup
+    end
+  end
+end

--- a/lib/sprockets/cached_environment.rb
+++ b/lib/sprockets/cached_environment.rb
@@ -15,6 +15,8 @@ module Sprockets
       initialize_configuration(environment)
 
       @cache   = environment.cache
+      @cached_version_digest = environment.cached_version_digest
+
       @stats   = Hash.new { |h, k| h[k] = _stat(k) }
       @entries = Hash.new { |h, k| h[k] = _entries(k) }
       @uris    = Hash.new { |h, k| h[k] = _load(k) }

--- a/lib/sprockets/digest_utils.rb
+++ b/lib/sprockets/digest_utils.rb
@@ -2,11 +2,13 @@ require 'digest/md5'
 require 'digest/sha1'
 require 'digest/sha2'
 require 'set'
+require 'sprockets/cached_digest_utils'
 
 module Sprockets
   # Internal: Hash functions and digest related utilities. Mixed into
   # Environment.
   module DigestUtils
+    include CachedDigestUtils
     extend self
 
     # Internal: Default digest class.

--- a/lib/sprockets/path_digest_utils.rb
+++ b/lib/sprockets/path_digest_utils.rb
@@ -15,10 +15,10 @@ module Sprockets
     def stat_digest(path, stat)
       if stat.directory?
         # If its a directive, digest the list of filenames
-        digest_class.digest(self.entries(path).join(','))
+        cached_version_digest.digest(self.entries(path).join(',').freeze)
       elsif stat.file?
         # If its a file, digest the contents
-        digest_class.file(path.to_s).digest
+        cached_version_digest.file(path.to_s).digest
       else
         raise TypeError, "stat was not a directory or file: #{stat.ftype}"
       end

--- a/lib/sprockets/unloaded_asset.rb
+++ b/lib/sprockets/unloaded_asset.rb
@@ -21,11 +21,12 @@ module Sprockets
     def initialize(uri, env)
       @uri               = uri.to_s
       @env               = env
+      @version           = env.version
       @compressed_path   = URITar.new(uri, env).compressed_path
       @params            = nil # lazy loaded
       @filename          = nil # lazy loaded
     end
-    attr_reader :compressed_path, :uri
+    attr_reader :compressed_path, :uri, :version
 
     # Internal: Full file path without schema
     #
@@ -123,7 +124,7 @@ module Sprockets
     #
     # Returns a String.
     def file_digest_key(stat)
-      "file_digest:#{compressed_path}:#{stat}"
+      "file_digest:#{compressed_path}:#{stat}:#{version}"
     end
 
     private

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -721,12 +721,6 @@ class TestEnvironment < Sprockets::TestCase
     assert_equal 2, asset.metadata[:selector_count]
   end
 
-  test "changing version changes the digest of the asset" do
-    old_asset_digest = @env["gallery.js"].hexdigest
-    @env.version = 'v2'
-    assert old_asset_digest != @env["gallery.js"].hexdigest
-  end
-
   test "bundled asset is stale if its mtime is updated or deleted" do
     filename = File.join(fixture_path("default"), "tmp.js")
 

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -721,10 +721,10 @@ class TestEnvironment < Sprockets::TestCase
     assert_equal 2, asset.metadata[:selector_count]
   end
 
-  test "changing version doesn't affect the assets digest" do
+  test "changing version changes the digest of the asset" do
     old_asset_digest = @env["gallery.js"].hexdigest
     @env.version = 'v2'
-    assert old_asset_digest == @env["gallery.js"].hexdigest
+    assert old_asset_digest != @env["gallery.js"].hexdigest
   end
 
   test "bundled asset is stale if its mtime is updated or deleted" do


### PR DESCRIPTION
Updates the file digest to take into account the configured version
which allows tasks like invalidating all assets possible again.

Backports #404 to 3.x using patch from sellect/sprockets#1

cc @lime who initially made the changes for `master`.