### PR TITLE
3.x perf

### DIFF
--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -100,7 +100,7 @@ module Sprockets
     end
 
     def compress_from_root(uri)
-      URITar.new(uri, self).compress
+      URITar.fast_compress(uri, self.root)
     end
 
     def expand_from_root(uri)

--- a/lib/sprockets/cache.rb
+++ b/lib/sprockets/cache.rb
@@ -60,7 +60,7 @@ module Sprockets
     # cache - A compatible backend cache store instance.
     def initialize(cache = nil, logger = self.class.default_logger)
       @cache_wrapper = get_cache_wrapper(cache)
-      @fetch_cache   = Cache::MemoryStore.new(1024)
+      @fetch_cache   = Cache::MemoryStore.new
       @logger        = logger
     end
 

--- a/lib/sprockets/cache/memory_store.rb
+++ b/lib/sprockets/cache/memory_store.rb
@@ -12,7 +12,7 @@ module Sprockets
     #
     class MemoryStore
       # Internal: Default key limit for store.
-      DEFAULT_MAX_SIZE = 1000
+      DEFAULT_MAX_SIZE = 10000
 
       # Public: Initialize the cache store.
       #

--- a/lib/sprockets/digest_utils.rb
+++ b/lib/sprockets/digest_utils.rb
@@ -84,6 +84,39 @@ module Sprockets
     }
     private_constant :ADD_VALUE_TO_DIGEST
 
+    def a_v_t_d(c, v, d)
+      case c
+      when 'String'.freeze then d << v
+      when 'FalseClass'.freeze then d << 'FalseClass'.freeze
+      when 'TrueClass'.freeze then d << 'TrueClass'.freeze
+      when 'NilClass'.freeze then d << 'NilClass'.freeze
+      when 'Symbol'.freeze
+        d << 'Symbol'.freeze
+        d << v.to_s
+      when 'Integer'.freeze
+        d << 'Integer'.freeze
+        d << v.to_s
+      when 'Array'.freeze
+        d << 'Array'.freeze
+        v.each { |element| a_v_t_d(element.class.name, element, d) }
+      when 'Hash'.freeze
+        d << 'Hash'.freeze
+        v.sort.each { |array| a_v_t_d('Array', array, d) }
+      when 'Set'.freeze
+        d << 'Set'.freeze
+        a_v_t_d('Array',v.to_a, d)
+      when 'Encoding'.freeze
+        d << 'Encoding'.freeze
+        d << v.name
+      when 'Fixnum'.freeze
+        d << 'Integer'.freeze
+        d << v.to_s
+      when 'Bignum'.freeze
+        d << 'Integer'.freeze
+        d << v.to_s
+      else raise TypeError, "couldn't digest #{c} - #{c.class} -- #{v}"
+      end
+    end
     # Internal: Generate a hexdigest for a nested JSON serializable object.
     #
     # This is used for generating cache keys, so its pretty important its
@@ -94,8 +127,8 @@ module Sprockets
     # Returns a String digest of the object.
     def digest(obj)
       digest = digest_class.new
-
-      ADD_VALUE_TO_DIGEST[obj.class].call(obj, digest)
+      a_v_t_d(obj.class.name, obj, digest)
+      # ADD_VALUE_TO_DIGEST[obj.class].call(obj, digest)
       digest.digest
     end
 

--- a/lib/sprockets/http_utils.rb
+++ b/lib/sprockets/http_utils.rb
@@ -56,6 +56,7 @@ module Sprockets
     #
     # Returns Array of matched Strings from available Array or [].
     def find_q_matches(q_values, available, &matcher)
+      return [] if available == []
       matcher ||= lambda { |a, b| a == b }
 
       matches = []

--- a/lib/sprockets/uri_tar.rb
+++ b/lib/sprockets/uri_tar.rb
@@ -13,11 +13,11 @@ module Sprockets
       @root = env.root
       @env  = env
       uri   = uri.to_s
-      if uri.include?("://".freeze)
-        @scheme, _, @path = uri.partition("://".freeze)
-        @scheme << "://".freeze
+      if uri.include?('://'.freeze)
+        @scheme, _, @path = uri.partition('://'.freeze)
+        @scheme << '://'.freeze
       else
-        @scheme = "".freeze
+        @scheme = ''.freeze
         @path   = uri
       end
     end
@@ -33,6 +33,21 @@ module Sprockets
     # Returns String
     def compress
       scheme + compressed_path
+    end
+
+    def self.fast_compress(uri, root)
+      if uri.include?('://'.freeze)
+        scheme, _, path = uri.partition('://'.freeze)
+        scheme << '://'.freeze
+      else
+        scheme = ''.freeze
+        path   = uri
+      end
+      if compressed_path = PathUtils.split_subpath(root, path)
+        scheme + compressed_path
+      else
+        scheme + path
+      end
     end
 
     # Internal: Tells us if we are using an absolute path
@@ -66,7 +81,7 @@ module Sprockets
         else
           # We always want to return an absolute uri,
           # make sure the path starts with a slash.
-          scheme + File.join("/".freeze, root, path)
+          scheme + File.join('/'.freeze, root, path)
         end
       end
     end
@@ -82,8 +97,8 @@ module Sprockets
     # Returns String
     def compressed_path
       # windows
-      if !@root.start_with?("/".freeze) && path.start_with?("/".freeze)
-        consistent_root = "/".freeze + @root
+      if !@root.start_with?('/'.freeze) && path.start_with?('/'.freeze)
+        consistent_root = '/'.freeze + @root
       else
         consistent_root = @root
       end

--- a/lib/sprockets/uri_utils.rb
+++ b/lib/sprockets/uri_utils.rb
@@ -48,7 +48,7 @@ module Sprockets
       path.force_encoding(Encoding::UTF_8)
 
       # Hack for parsing Windows "file:///C:/Users/IEUser" paths
-      path.gsub!(/^\/([a-zA-Z]:)/, '\1'.freeze) if File::ALT_SEPARATOR
+      path = path[1..-1] if File::ALT_SEPARATOR
 
       [scheme, host, path, query]
     end

--- a/lib/sprockets/uri_utils.rb
+++ b/lib/sprockets/uri_utils.rb
@@ -48,7 +48,7 @@ module Sprockets
       path.force_encoding(Encoding::UTF_8)
 
       # Hack for parsing Windows "file:///C:/Users/IEUser" paths
-      path.gsub!(/^\/([a-zA-Z]:)/, '\1'.freeze)
+      path.gsub!(/^\/([a-zA-Z]:)/, '\1'.freeze) if File::ALT_SEPARATOR
 
       [scheme, host, path, query]
     end
@@ -59,7 +59,7 @@ module Sprockets
     def join_file_uri(scheme, host, path, query)
       str = "#{scheme}://"
       str << host if host
-      path = "/#{path}" unless path.start_with?("/")
+      path = "/#{path}" unless path.start_with?('/'.freeze)
       str << URI::Generic::DEFAULT_PARSER.escape(path)
       str << "?#{query}" if query
       str
@@ -72,7 +72,7 @@ module Sprockets
     # Returns true or false.
     def valid_asset_uri?(str)
       # Quick prefix check before attempting a full parse
-      str.start_with?("file://") && parse_asset_uri(str) ? true : false
+      str.start_with?('file://'.freeze) && parse_asset_uri(str) ? true : false
     rescue URI::InvalidURIError
       false
     end
@@ -109,7 +109,7 @@ module Sprockets
     #
     # Returns String URI.
     def build_asset_uri(path, params = {})
-      join_file_uri("file", nil, path, encode_uri_query_params(params))
+      join_file_uri('file', nil, path, encode_uri_query_params(params))
     end
 
     # Internal: Parse file-digest dependency URI.

--- a/test/test_uri_utils.rb
+++ b/test/test_uri_utils.rb
@@ -45,15 +45,16 @@ class TestURIUtils < MiniTest::Test
 
     parts = split_file_uri("file:///usr/local/var/github/app/assets/javascripts/application.js")
     assert_equal ['file', nil, '/usr/local/var/github/app/assets/javascripts/application.js', nil], parts
+    if DOSISH
+      parts = split_file_uri("file:///C:/Documents%20and%20Settings/davris/FileSchemeURIs.doc")
+      assert_equal ['file', nil, 'C:/Documents and Settings/davris/FileSchemeURIs.doc', nil], parts
 
-    parts = split_file_uri("file:///C:/Documents%20and%20Settings/davris/FileSchemeURIs.doc")
-    assert_equal ['file', nil, 'C:/Documents and Settings/davris/FileSchemeURIs.doc', nil], parts
+      parts = split_file_uri("file:///D:/Program%20Files/Viewer/startup.htm")
+      assert_equal ['file', nil, 'D:/Program Files/Viewer/startup.htm', nil], parts
 
-    parts = split_file_uri("file:///D:/Program%20Files/Viewer/startup.htm")
-    assert_equal ['file', nil, 'D:/Program Files/Viewer/startup.htm', nil], parts
-
-    parts = split_file_uri("file:///C:/Program%20Files/Music/Web%20Sys/main.html?REQUEST=RADIO")
-    assert_equal ['file', nil, 'C:/Program Files/Music/Web Sys/main.html', 'REQUEST=RADIO'], parts
+      parts = split_file_uri("file:///C:/Program%20Files/Music/Web%20Sys/main.html?REQUEST=RADIO")
+      assert_equal ['file', nil, 'C:/Program Files/Music/Web Sys/main.html', 'REQUEST=RADIO'], parts
+    end
   end
 
   def test_join_uri_path
@@ -98,8 +99,10 @@ class TestURIUtils < MiniTest::Test
       parse_asset_uri("file:///usr/local/var/github/app/assets/javascripts/application.js")
     assert_equal ["/usr/local/var/github/app/assets/javascripts/foo bar.js", {}],
       parse_asset_uri("file:///usr/local/var/github/app/assets/javascripts/foo%20bar.js")
-    assert_equal ["C:/Users/IEUser/Documents/github/app/assets/javascripts/application.js", {}],
-      parse_asset_uri("file:///C:/Users/IEUser/Documents/github/app/assets/javascripts/application.js")
+    if DOSISH
+      assert_equal ["C:/Users/IEUser/Documents/github/app/assets/javascripts/application.js", {}],
+        parse_asset_uri("file:///C:/Users/IEUser/Documents/github/app/assets/javascripts/application.js")
+    end
   end
 
   def test_parse_query_params
@@ -152,8 +155,10 @@ class TestURIUtils < MiniTest::Test
       parse_file_digest_uri("file-digest:///usr/local/var/github/app/assets/javascripts/application.js")
     assert_equal "/usr/local/var/github/app/assets/javascripts/foo bar.js",
       parse_file_digest_uri("file-digest:///usr/local/var/github/app/assets/javascripts/foo%20bar.js")
-    assert_equal "C:/Users/IEUser/Documents/github/app/assets/javascripts/application.js",
-      parse_file_digest_uri("file-digest:///C:/Users/IEUser/Documents/github/app/assets/javascripts/application.js")
+    if DOSISH
+      assert_equal "C:/Users/IEUser/Documents/github/app/assets/javascripts/application.js",
+        parse_file_digest_uri("file-digest:///C:/Users/IEUser/Documents/github/app/assets/javascripts/application.js")
+    end
   end
 
   def test_build_file_digest_uri


### PR DESCRIPTION
numbers without cache adjustment
```
3.x
tests:
Finished in 29.491941s, 27.0582 runs/s, 116.6081 assertions/s.
798 runs, 3439 assertions, 0 failures, 0 errors, 2 skips

first page get:
o_jit:   0.520000   0.080000   0.600000 (  0.598037)
o_jit:   3.860000   0.570000   4.430000 (  4.425943)
second page get:
o_jit:   0.400000   0.020000   0.420000 (  0.422710)
o_jit:   2.510000   0.090000   2.600000 (  2.602424)
recompile first page get:
o_jit:   0.420000   0.020000   0.440000 (  0.440247)
o_jit:  10.140000   2.850000  12.990000 ( 13.115074)
recompile second page get:
o_jit:   0.400000   0.020000   0.420000 (  0.419903)
o_jit:   9.200000   2.840000  12.040000 ( 12.052266)

combined asset:
o_jit_c_first:   4.970000   0.790000   5.760000 (  5.802336)
o_jit_c_second:   3.220000   0.110000   3.330000 (  3.345740)
o_jit_c_recomp_first:  12.120000   3.290000  15.410000 ( 15.490749)
o_jit_c_recomp_second: 11.320000   3.300000  14.620000 ( 14.694551)  

assets:precompile: real	2m55.506s
```

```
3.x_perf
tests:
798 runs, 3434 assertions, 0 failures, 0 errors, 2 skips
Finished in 28.709360s, 27.7958 runs/s, 119.6126 assertions/s.

first page get:
o_jit:   0.390000   0.070000   0.460000 (  0.463624)
o_jit:   3.020000   0.550000   3.570000 (  3.573947)
second page get:
o_jit:   0.280000   0.010000   0.290000 (  0.302562)
o_jit:   1.690000   0.060000   1.750000 (  1.750890)
recompile first page get:
o_jit:   0.250000   0.010000   0.260000 (  0.265351)
o_jit:   7.260000   1.580000   8.840000 (  8.831509)
recompile second page get:
o_jit:   0.270000   0.010000   0.280000 (  0.282441)
o_jit:   6.860000   1.550000   8.410000 (  8.408544)

combined asset:
o_jit_c_first:  3.030000   0.630000   3.660000 (  3.661370)
o_jit_c_second:   2.020000   0.070000   2.090000 (  2.113375)
o_jit_c_recomp_first:  8.800000   1.940000  10.740000 ( 10.784423)
o_jit_c_recomp_second:   8.300000   1.790000  10.090000 ( 10.112734)

assets:precompile: real	2m45.752s
```

o_jit: measured from within opals javascript_include_tag
recompile meaning recompiling an opal .rb file with sprockets
first ojit is an large static asset
second o_jit is the dynamic one for recompile

patches beside the regexp patch are for compiling performance.

tests run with matz ruby 2.4.2

#503 