### PR TITLE
Fix Sourcemaps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 cache: bundler
 
 sudo: false
-
+before_script: "unset _JAVA_OPTIONS"
 rvm:
   - 2.2
   - 2.3.4

--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -107,10 +107,6 @@ module Sprockets
     [SourceMapCommentProcessor]
   end
 
-  require 'sprockets/preprocessors/default_source_map'
-  register_preprocessor 'text/css', Preprocessors::DefaultSourceMap.new
-  register_preprocessor 'application/javascript', Preprocessors::DefaultSourceMap.new
-
   require 'sprockets/directive_processor'
   register_preprocessor 'text/css', DirectiveProcessor.new(comments: ["//", ["/*", "*/"]])
   register_preprocessor 'application/javascript', DirectiveProcessor.new(comments: ["//", ["/*", "*/"]])
@@ -219,4 +215,8 @@ module Sprockets
 
   depend_on 'environment-version'
   depend_on 'environment-paths'
+
+  require 'sprockets/preprocessors/default_source_map'
+  register_preprocessor 'text/css', Preprocessors::DefaultSourceMap.new
+  register_preprocessor 'application/javascript', Preprocessors::DefaultSourceMap.new
 end

--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -119,7 +119,6 @@ module Sprockets
   register_bundle_metadata_reducer 'application/javascript', :data, proc { String.new("") }, Utils.method(:concat_javascript_sources)
   register_bundle_metadata_reducer '*/*', :links, :+
   register_bundle_metadata_reducer '*/*', :sources, proc { [] }, :+
-  register_bundle_metadata_reducer '*/*', :map, proc { |input| { "version" => 3, "file" => PathUtils.split_subpath(input[:load_path], input[:filename]), "sections" => [] } }, SourceMapUtils.method(:concat_source_maps)
 
   require 'sprockets/closure_compressor'
   require 'sprockets/sass_compressor'
@@ -217,6 +216,9 @@ module Sprockets
   depend_on 'environment-paths'
 
   require 'sprockets/preprocessors/default_source_map'
-  register_preprocessor 'text/css', Preprocessors::DefaultSourceMap.new
+  register_preprocessor 'text/css',               Preprocessors::DefaultSourceMap.new
   register_preprocessor 'application/javascript', Preprocessors::DefaultSourceMap.new
+
+  register_bundle_metadata_reducer 'text/css',               :map, proc { |input| { "version" => 3, "file" => PathUtils.split_subpath(input[:load_path], input[:filename]), "sections" => [] } }, SourceMapUtils.method(:concat_source_maps)
+  register_bundle_metadata_reducer 'application/javascript', :map, proc { |input| { "version" => 3, "file" => PathUtils.split_subpath(input[:load_path], input[:filename]), "sections" => [] } }, SourceMapUtils.method(:concat_source_maps)
 end

--- a/lib/sprockets/cache.rb
+++ b/lib/sprockets/cache.rb
@@ -51,7 +51,7 @@ module Sprockets
     # Internal: Cache key version for this class. Rarely should have to change
     # unless the cache format radically changes. Will be bump on major version
     # releases though.
-    VERSION = '4.0'
+    VERSION = '4.0.0'
 
     def self.default_logger
       logger = Logger.new($stderr)

--- a/lib/sprockets/preprocessors/default_source_map.rb
+++ b/lib/sprockets/preprocessors/default_source_map.rb
@@ -28,9 +28,11 @@ module Sprockets
         else
           result[:map] = map
         end
+
+        result[:map]["x_sprockets_linecount"] = lines
         return result
       end
-      
+
       private
 
       def default_mappings(lines)

--- a/lib/sprockets/preprocessors/default_source_map.rb
+++ b/lib/sprockets/preprocessors/default_source_map.rb
@@ -13,7 +13,7 @@ module Sprockets
         map           = input[:metadata][:map]
         filename      = input[:filename]
         load_path     = input[:load_path]
-        lines         = input[:data].lines.count
+        lines         = input[:data].lines.length
         basename      = File.basename(filename)
         mime_exts     = input[:environment].config[:mime_exts]
         pipeline_exts = input[:environment].config[:pipeline_exts]

--- a/lib/sprockets/preprocessors/default_source_map.rb
+++ b/lib/sprockets/preprocessors/default_source_map.rb
@@ -25,6 +25,8 @@ module Sprockets
             "sources"   => [PathUtils.set_pipeline(basename, mime_exts, pipeline_exts, :source)],
             "names"     => []
           }
+        else
+          result[:map] = map
         end
         return result
       end

--- a/lib/sprockets/source_map_comment_processor.rb
+++ b/lib/sprockets/source_map_comment_processor.rb
@@ -29,7 +29,7 @@ module Sprockets
       path = PathUtils.relative_path_from(PathUtils.split_subpath(input[:load_path], uri), map.digest_path)
 
       asset.metadata.merge(
-        data: asset.source + (comment % path),
+        data: asset.source + (comment % path) + "\n",
         links: asset.links + [asset.uri, map.uri]
       )
     end

--- a/lib/sprockets/source_map_utils.rb
+++ b/lib/sprockets/source_map_utils.rb
@@ -81,16 +81,11 @@ module Sprockets
         # Count the different VLQ sections such as "AACA;" by counting commas
         # mappings do not always end with a semicolon so we check for that
         # and increment
-        last_mappings = a["sections"].last["map"]["mappings"]
-        offset += last_mappings.count(';')
-        offset += 1 if last_mappings[-1] != ";"
+        last_line_count = a["sections"].last["map"].delete("x_sprockets_linecount")
+        offset += last_line_count
 
         last_offset = a["sections"].last["offset"]["line"]
-        if last_offset > 0
-          offset += last_offset
-        else
-          offset += 1
-        end
+        offset += last_offset
       end
 
       a["sections"] += b["sections"].map do |section|

--- a/lib/sprockets/source_map_utils.rb
+++ b/lib/sprockets/source_map_utils.rb
@@ -77,10 +77,6 @@ module Sprockets
 
       offset = 0
       if a["sections"].count != 0 && !a["sections"].last["map"]["mappings"].empty?
-        # Account for length of last asset
-        # Count the different VLQ sections such as "AACA;" by counting commas
-        # mappings do not always end with a semicolon so we check for that
-        # and increment
         last_line_count = a["sections"].last["map"].delete("x_sprockets_linecount")
         offset += last_line_count
 

--- a/lib/sprockets/source_map_utils.rb
+++ b/lib/sprockets/source_map_utils.rb
@@ -48,7 +48,7 @@ module Sprockets
         "sources"  => map["sources"].map do |source|
           source = URIUtils.split_file_uri(source)[2] if source.start_with? "file://"
           source = PathUtils.join(File.dirname(filename), source) unless PathUtils.absolute_path?(source)
-          _, source = PathUtils.paths_split(load_paths, source) 
+          _, source = PathUtils.paths_split(load_paths, source)
           source = PathUtils.relative_path_from(file, source)
           PathUtils.set_pipeline(source, mime_exts, pipeline_exts, :source)
         end,

--- a/lib/sprockets/utils.rb
+++ b/lib/sprockets/utils.rb
@@ -68,6 +68,9 @@ module Sprockets
       end
     end
 
+    WHITESPACE_ORDINALS = {0x0A => "\n", 0x20 => " ", 0x09 => "\t"}
+    private_constant :WHITESPACE_ORDINALS
+
     # Internal: Check if string has a trailing semicolon.
     #
     # str - String
@@ -79,14 +82,9 @@ module Sprockets
         c = str[i].ord
         i -= 1
 
-        # Need to compare against the ordinals because the string can be UTF_8 or UTF_32LE encoded
-        # 0x0A == "\n"
-        # 0x20 == " "
-        # 0x09 == "\t"
-        # 0x3B == ";"
-        unless c == 0x0A || c == 0x20 || c == 0x09
-          return c === 0x3B
-        end
+        next if WHITESPACE_ORDINALS[c]
+
+        return c === 0x3B
       end
 
       true
@@ -100,18 +98,18 @@ module Sprockets
     #
     # Returns buf String.
     def concat_javascript_sources(buf, source)
-      if source.bytesize > 0
-        buf << source
+      return buf if source.bytesize < 0
 
-        # If the source contains non-ASCII characters, indexing on it becomes O(N).
-        # This will lead to O(N^2) performance in string_end_with_semicolon?, so we should use 32 bit encoding to make sure indexing stays O(1)
-        source = source.encode(Encoding::UTF_32LE) unless source.ascii_only?
+      buf << source
+      # If the source contains non-ASCII characters, indexing on it becomes O(N).
+      # This will lead to O(N^2) performance in string_end_with_semicolon?, so we should use 32 bit encoding to make sure indexing stays O(1)
+      source = source.encode(Encoding::UTF_32LE) unless source.ascii_only?
+      return buf if string_end_with_semicolon?(source)
 
-        if !string_end_with_semicolon?(source)
-          buf << ";\n"
-        elsif source[source.size - 1].ord != 0x0A
-          buf << "\n"
-        end
+      if whitespace = WHITESPACE_ORDINALS[buf[-1].ord]
+        buf[-1] = ";#{whitespace}"
+      else
+        buf << ";"
       end
 
       buf

--- a/lib/sprockets/utils.rb
+++ b/lib/sprockets/utils.rb
@@ -106,6 +106,9 @@ module Sprockets
       source = source.encode(Encoding::UTF_32LE) unless source.ascii_only?
       return buf if string_end_with_semicolon?(source)
 
+      # If the last character in the string was whitespace,
+      # such as a newline, then we want to put the semicolon
+      # before the whitespace. Otherwise append a semicolon.
       if whitespace = WHITESPACE_ORDINALS[source[-1].ord]
         buf[-1] = ";#{whitespace}"
       else

--- a/lib/sprockets/utils.rb
+++ b/lib/sprockets/utils.rb
@@ -98,7 +98,7 @@ module Sprockets
     #
     # Returns buf String.
     def concat_javascript_sources(buf, source)
-      return buf if source.bytesize < 0
+      return buf if source.bytesize <= 0
 
       buf << source
       # If the source contains non-ASCII characters, indexing on it becomes O(N).

--- a/lib/sprockets/utils.rb
+++ b/lib/sprockets/utils.rb
@@ -106,7 +106,7 @@ module Sprockets
       source = source.encode(Encoding::UTF_32LE) unless source.ascii_only?
       return buf if string_end_with_semicolon?(source)
 
-      if whitespace = WHITESPACE_ORDINALS[buf[-1].ord]
+      if whitespace = WHITESPACE_ORDINALS[source[-1].ord]
         buf[-1] = ";#{whitespace}"
       else
         buf << ";"

--- a/test/fixtures/source-maps/multi-require.js
+++ b/test/fixtures/source-maps/multi-require.js
@@ -1,0 +1,4 @@
+//= require child.js
+//= require coffee/main.js
+//= require sub/a.js
+//= require plain.js

--- a/test/fixtures/source-maps/plain.js
+++ b/test/fixtures/source-maps/plain.js
@@ -1,0 +1,3 @@
+function plain(input) {
+  console.log("Plain" + input)
+}

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -885,8 +885,7 @@ class BundledAssetTest < Sprockets::TestCase
 
 define("application.js", "application-955b2dddd0d1449b1c617124b83b46300edadec06d561104f7f6165241b31a94.js")
 define("application.css", "application-46d50149c56fc370805f53c29f79b89a52d4cc479eeebcdc8db84ab116d7ab1a.css")
-define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png")
-;
+define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png");
     EOS
     assert_equal [
       "file://#{fixture_path_for_uri("asset/POW.png")}?type=image/png&id=xxx",
@@ -904,8 +903,7 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
 
 define("application.js", "application-955b2dddd0d1449b1c617124b83b46300edadec06d561104f7f6165241b31a94.js")
 define("application.css", "application-46d50149c56fc370805f53c29f79b89a52d4cc479eeebcdc8db84ab116d7ab1a.css")
-define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png")
-;
+define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png");
     EOS
 
     assert_equal [
@@ -1091,8 +1089,11 @@ EOS
   end
 
   test 'keeps code in same line after multi-line comments' do
-    assert_equal "/******/ function foo() {\n}\n;\n",
-      asset('multi_line_comment.js').to_s
+expected = <<-EOS
+/******/ function foo() {
+};
+EOS
+    assert_equal expected, asset('multi_line_comment.js').to_s
   end
 
   test "should not fail if home is not set in environment" do
@@ -1140,7 +1141,7 @@ class DebugAssetTest < Sprockets::TestCase
   end
 
   test "digest path" do
-    assert_equal "application.debug-60cfa762e3139c2580dbfbefd46a5359803225363eaef31efb725e6731ab6849.js",
+    assert_equal "application.debug-dee339ce0ee2dc7cdfa0d36dff3ef946cebe1bd3e414515d40c3cafc49c0a51a.js",
       @asset.digest_path
   end
 
@@ -1149,7 +1150,7 @@ class DebugAssetTest < Sprockets::TestCase
   end
 
   test "length" do
-    assert_equal 264, @asset.length
+    assert_equal 265, @asset.length
   end
 
   test "charset is UTF-8" do
@@ -1157,7 +1158,26 @@ class DebugAssetTest < Sprockets::TestCase
   end
 
   test "to_s" do
-    assert_equal "var Project = {\n  find: function(id) {\n  }\n};\nvar Users = {\n  find: function(id) {\n  }\n};\n\n\n\ndocument.on('dom:loaded', function() {\n  $('search').focus();\n});\n\n//# sourceMappingURL=application.js-161f7edec524c6e94ab3b89924c4fb96d4552bb83b32d975c074b7fb9a84c454.map", @asset.to_s
+expected = <<-EOS
+var Project = {
+  find: function(id) {
+  }
+};
+var Users = {
+  find: function(id) {
+  }
+};
+
+
+
+document.on('dom:loaded', function() {
+  $('search').focus();
+});
+
+//# sourceMappingURL=application.js-95e519d4e0f0a5c4c7d24787ded990b0d027f7ad30b39f402c4c5e3196a41e8b.map
+EOS
+
+    assert_equal expected, @asset.to_s
   end
 
   def asset(logical_path, options = {})

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -1080,8 +1080,14 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
   end
 
   test "appends missing semicolons" do
-    assert_equal "var Bar\n;\n\n(function() {\n  var Foo\n})\n;\n",
-      asset("semicolons.js").to_s
+expected = <<-EOS
+var Bar;
+
+(function() {
+  var Foo
+});
+EOS
+    assert_equal expected, asset("semicolons.js").to_s
   end
 
   test 'keeps code in same line after multi-line comments' do

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -798,10 +798,12 @@ class TestEnvironment < Sprockets::TestCase
   end
 
   test "disabling default directive preprocessor" do
-    assert processor = @env.preprocessors['application/javascript'][0]
-    assert_kind_of Sprockets::DirectiveProcessor, processor
+    assert processors = @env.preprocessors['application/javascript']
+    processor = processors.detect {|p| p.is_a?(Sprockets::DirectiveProcessor) }
+
+    assert processor
     @env.unregister_preprocessor('application/javascript', processor)
-    assert_equal "// =require \"notfound\"\n;\n", @env["missing_require.js"].to_s
+    assert_equal "// =require \"notfound\";\n", @env["missing_require.js"].to_s
   end
 
   test "disabling processors by class name also disables processors which are instances of that class" do

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -610,7 +610,7 @@ class TestManifest < Sprockets::TestCase
     @env.register_exporter 'image/png',SlowExporter
     @env.register_exporter 'image/png',SlowExporter2
     Sprockets::Manifest.new(@env, @dir).compile('logo.png', 'troll.png')
-    assert_equal %w(0 0 0 0 1 1 1 1), SlowExporter.seq
+    refute_equal %w(0 1 0 1 0 1 0 1), SlowExporter.seq
   end
 
   test 'sequential exporting' do
@@ -642,7 +642,7 @@ class TestManifest < Sprockets::TestCase
     processor = SlowProcessor.new
     @env.register_postprocessor 'image/png', processor
     Sprockets::Manifest.new(@env, @dir).compile('logo.png', 'troll.png')
-    assert_equal %w(0 0 1 1), processor.seq
+    refute_equal %w(0 1 0 1), processor.seq
   end
 
   test 'sequential processing' do

--- a/test/test_source_map_utils.rb
+++ b/test/test_source_map_utils.rb
@@ -16,6 +16,8 @@ class TestSourceMapUtils < MiniTest::Test
       #   dup.instance_variable_defined?(:@a)    # => true
       def deep_dup
         dup
+      rescue TypeError # TypeError: can't dup Fixnum
+        self
       end
     end
 

--- a/test/test_source_map_utils.rb
+++ b/test/test_source_map_utils.rb
@@ -3,62 +3,10 @@ require 'minitest/autorun'
 require 'sprockets/source_map_utils'
 
 class TestSourceMapUtils < MiniTest::Test
-  module SprocketsDeepDup
-    refine Object do
-      # Returns a deep copy of object if it's duplicable. If it's
-      # not duplicable, returns +self+.
-      #
-      #   object = Object.new
-      #   dup    = object.deep_dup
-      #   dup.instance_variable_set(:@a, 1)
-      #
-      #   object.instance_variable_defined?(:@a) # => false
-      #   dup.instance_variable_defined?(:@a)    # => true
-      def deep_dup
-        dup
-      rescue TypeError # TypeError: can't dup Fixnum
-        self
-      end
-    end
 
-    refine Array do
-      # Returns a deep copy of array.
-      #
-      #   array = [1, [2, 3]]
-      #   dup   = array.deep_dup
-      #   dup[1][2] = 4
-      #
-      #   array[1][2] # => nil
-      #   dup[1][2]   # => 4
-      def deep_dup
-        map(&:deep_dup)
-      end
-    end
-
-    refine Hash do
-      # Returns a deep copy of hash.
-      #
-      #   hash = { a: { b: 'b' } }
-      #   dup  = hash.deep_dup
-      #   dup[:a][:c] = 'c'
-      #
-      #   hash[:a][:c] # => nil
-      #   dup[:a][:c]  # => "c"
-      def deep_dup
-        hash = dup
-        each_pair do |key, value|
-          if key.frozen? && ::String === key
-            hash[key] = value.deep_dup
-          else
-            hash.delete(key)
-            hash[key.deep_dup] = value.deep_dup
-          end
-        end
-        hash
-      end
-    end
+  def deep_dup(object)
+    Marshal.load( Marshal.dump(object) )
   end
-  using SprocketsDeepDup
 
   def test_map
     source_map = {
@@ -172,14 +120,14 @@ class TestSourceMapUtils < MiniTest::Test
       ]
     }
 
-    assert_equal map, Sprockets::SourceMapUtils.concat_source_maps(nil, map.deep_dup)
-    assert_equal map, Sprockets::SourceMapUtils.concat_source_maps(map.deep_dup, nil)
+    assert_equal map, Sprockets::SourceMapUtils.concat_source_maps(nil, deep_dup(map))
+    assert_equal map, Sprockets::SourceMapUtils.concat_source_maps(deep_dup(map), nil)
 
-    assert_equal index_map, Sprockets::SourceMapUtils.concat_source_maps(empty_map.deep_dup, map.dup)
+    assert_equal index_map, Sprockets::SourceMapUtils.concat_source_maps(deep_dup(empty_map), map.dup)
 
-    expected_index_map = index_map.deep_dup
+    expected_index_map = deep_dup(index_map)
     expected_index_map["sections"].first["map"].delete("x_sprockets_linecount")
-    assert_equal expected_index_map, Sprockets::SourceMapUtils.concat_source_maps(map.deep_dup, empty_map.deep_dup)
+    assert_equal expected_index_map, Sprockets::SourceMapUtils.concat_source_maps(deep_dup(map), deep_dup(empty_map))
   end
 
   def test_concat_source_maps
@@ -212,7 +160,7 @@ class TestSourceMapUtils < MiniTest::Test
       "x_sprockets_linecount" => 1
     }
 
-    combined = Sprockets::SourceMapUtils.concat_source_maps(abc_map.deep_dup, d_map.deep_dup)
+    combined = Sprockets::SourceMapUtils.concat_source_maps(deep_dup(abc_map), deep_dup(d_map))
     assert_equal [
       { source: 'a.js', generated: [1, 0], original: [1,  0] },
       { source: 'b.js', generated: [2, 0], original: [20, 0] },
@@ -220,7 +168,7 @@ class TestSourceMapUtils < MiniTest::Test
       { source: 'd.js', generated: [4, 0], original: [1,  0] }
     ], Sprockets::SourceMapUtils.decode_source_map(combined)[:mappings]
 
-    combined = Sprockets::SourceMapUtils.concat_source_maps(d_map.deep_dup, abc_map.deep_dup)
+    combined = Sprockets::SourceMapUtils.concat_source_maps(deep_dup(d_map), deep_dup(abc_map))
     assert_equal [
       { source: 'd.js', generated: [1, 0], original: [1,  0] },
       { source: 'a.js', generated: [2, 0], original: [1,  0] },

--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -19,6 +19,32 @@ class TestSourceMaps < Sprockets::TestCase
     map["sections"].reduce([]) { |r, s| r | s["map"]["sources"] }
   end
 
+  # Offset should be the line that the asset starts on minus one
+  test "correct offsets" do
+    asset = @env["multi-require.js"]
+    map   = asset.metadata[:map]
+
+    child         = @env["child.js"]
+    child_lines   = child.to_s.lines.length
+    child_section = map["sections"][0]
+    assert_equal 0, child_section["offset"]["line"]
+
+    coffee_main         = @env["coffee/main.js"]
+    coffee_main_lines   = coffee_main.to_s.lines.length
+    coffee_main_section = map["sections"][1]
+    assert_equal child_lines, coffee_main_section["offset"]["line"]
+
+    sub_a_js          = @env["sub/a.js"]
+    sub_a_js_lines    = sub_a_js.to_s.lines.length
+    sub_a_js_section  = map["sections"][2]
+
+    assert_equal coffee_main_lines + child_lines, sub_a_js_section["offset"]["line"]
+
+    plain_js         = @env["plain.js"]
+    plain_js_section = map["sections"][3]
+    assert_equal sub_a_js_lines + coffee_main_lines + child_lines, plain_js_section["offset"]["line"]
+  end
+
   test "builds a source map for js files" do
     asset = @env['child.js']
     map = asset.metadata[:map]

--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -37,7 +37,6 @@ class TestSourceMaps < Sprockets::TestCase
 
   test "builds a minified source map" do
     @env.js_compressor = Sprockets::UglifierCompressor.new
-    
 
     asset = @env['application.js']
     map = Sprockets::SourceMapUtils.decode_source_map(asset.metadata[:map])
@@ -103,7 +102,8 @@ class TestSourceMaps < Sprockets::TestCase
             "file"     => "coffee/main.coffee",
             "mappings" => "AACA;AAAA,MAAA,sDAAA;IAAA;;EAAA,MAAA,GAAW;;EACX,QAAA,GAAW;;EAGX,IAAgB,QAAhB;IAAA,MAAA,GAAS,CAAC,GAAV;;;EAGA,MAAA,GAAS,SAAC,CAAD;WAAO,CAAA,GAAI;EAAX;;EAGT,IAAA,GAAO,CAAC,CAAD,EAAI,CAAJ,EAAO,CAAP,EAAU,CAAV,EAAa,CAAb;;EAGP,IAAA,GACE;IAAA,IAAA,EAAQ,IAAI,CAAC,IAAb;IACA,MAAA,EAAQ,MADR;IAEA,IAAA,EAAQ,SAAC,CAAD;aAAO,CAAA,GAAI,MAAA,CAAO,CAAP;IAAX,CAFR;;;EAKF,IAAA,GAAO,SAAA;AACL,QAAA;IADM,uBAAQ;WACd,KAAA,CAAM,MAAN,EAAc,OAAd;EADK;;EAIP,IAAsB,8CAAtB;IAAA,KAAA,CAAM,YAAN,EAAA;;;EAGA,KAAA;;AAAS;SAAA,sCAAA;;mBAAA,IAAI,CAAC,IAAL,CAAU,GAAV;AAAA;;;AA1BT",
             "sources"  => ["main.source.coffee"],
-            "names"    => []
+            "names"    => [],
+            "x_sprockets_linecount"=>47
           }
         }
       ]
@@ -157,7 +157,8 @@ class TestSourceMaps < Sprockets::TestCase
             "file"     => "babel/main.es6",
             "mappings" => ";;;;;;;;;;AACA,IAAI,IAAI,GAAG,KAAK,CAAC,GAAG,CAAC,UAAA,CAAC;SAAI,CAAC,GAAG,CAAC;CAAA,CAAC,CAAC;AACjC,IAAI,IAAI,GAAG,KAAK,CAAC,GAAG,CAAC,UAAC,CAAC,EAAE,CAAC;SAAK,CAAC,GAAG,CAAC;CAAA,CAAC,CAAC;;IAEhC,WAAW;YAAX,WAAW;;AACJ,WADP,WAAW,CACH,QAAQ,EAAE,SAAS,EAAE;0BAD7B,WAAW;;AAEb,+BAFE,WAAW,6CAEP,QAAQ,EAAE,SAAS,EAAE;GAE5B;;eAJG,WAAW;;WAKT,gBAAC,MAAM,EAAE;AACb,iCANE,WAAW,wCAME;KAChB;;;WACmB,yBAAG;AACrB,aAAO,IAAI,KAAK,CAAC,OAAO,EAAE,CAAC;KAC5B;;;SAVG,WAAW;GAAS,KAAK,CAAC,IAAI;;AAapC,IAAI,SAAS,uBACV,MAAM,CAAC,QAAQ,0BAAG;MACb,GAAG,EAAM,GAAG,EAEV,IAAI;;;;AAFN,WAAG,GAAG,CAAC,EAAE,GAAG,GAAG,CAAC;;;AAEd,YAAI,GAAG,GAAG;;AACd,WAAG,GAAG,GAAG,CAAC;AACV,WAAG,IAAI,IAAI,CAAC;;eACN,GAAG;;;;;;;;;;;CAEZ,EACF,CAAA",
             "sources"  => ["main.source.es6"],
-            "names"    => []
+            "names"    => [],
+            "x_sprockets_linecount"=>66
           }
         }
       ]
@@ -216,7 +217,8 @@ class TestSourceMaps < Sprockets::TestCase
             "file"     => "sass/main.scss",
             "mappings" => "AACE,MAAG;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI;AAGlB,MAAG;EAAE,OAAO,EAAE,YAAY;AAE1B,KAAE;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI",
             "sources"  => ['main.source.scss'],
-            "names"    => []
+            "names"    => [],
+            "x_sprockets_linecount"=>10
           }
         }
       ]
@@ -260,7 +262,8 @@ class TestSourceMaps < Sprockets::TestCase
               "_imported.source.scss",
               "with-import.source.scss"
             ],
-            "names"    => []
+            "names"    => [],
+            "x_sprockets_linecount"=>5
           }
         }
       ]
@@ -294,7 +297,7 @@ class TestSourceMaps < Sprockets::TestCase
   test "source maps work with index alias" do
     asset = @env.find_asset("foo.js",  pipeline: :debug)
     mapUrl = asset.source.match(/^\/\/# sourceMappingURL=(.*)$/)[1]
-    assert_equal "foo/index.js-501c1acd99a6f760dd3ec4195ab25a3518f689fcf1ffc9be33f28e2f28712826.map", mapUrl
+    assert_equal "foo/index.js-008b5ccb5459dc75d7fd51bf5b1ac79fe54d05157d50586c16e558f33d28e9c4.map", mapUrl
 
     map = JSON.parse(@env.find_asset('foo/index.js.map').source)
     assert_equal [
@@ -323,7 +326,7 @@ class TestSourceMaps < Sprockets::TestCase
           s["offset"]["line"] += 1
         end
       end
-        
+
       File.open(filename, 'a') do |file|
         file.puts "console.log('newline');"
       end
@@ -378,7 +381,8 @@ class TestSasscSourceMaps < Sprockets::TestCase
             "file"     => "sass/main.scss",
             "mappings" => "AAAA,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GACjB;;AALH,AAOE,GAPC,CAOD,EAAE,CAAC;EAAE,OAAO,EAAE,YAAY,GAAK;;AAPjC,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GACtB",
             "sources"  => ["main.source.scss"],
-            "names"    => []
+            "names"    => [],
+            "x_sprockets_linecount"=>12
           }
         }
       ]
@@ -422,7 +426,8 @@ class TestSasscSourceMaps < Sprockets::TestCase
               "with-import.source.scss",
               "_imported.source.scss"
             ],
-            "names"    => []
+            "names"    => [],
+            "x_sprockets_linecount"=>5
           }
         }
       ]

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -93,12 +93,13 @@ class TestUtils < MiniTest::Test
   def test_concat_javascript_sources
     assert_equal "var foo;\n", apply_concat_javascript_sources("".freeze, "var foo;\n".freeze)
     assert_equal "\nvar foo;\n", apply_concat_javascript_sources("\n".freeze, "var foo;\n".freeze)
-    assert_equal " \nvar foo;\n", apply_concat_javascript_sources(" ".freeze, "var foo;\n".freeze)
-
     assert_equal "var foo;\nvar bar;\n", apply_concat_javascript_sources("var foo;\n".freeze, "var bar;\n".freeze)
-    assert_equal "var foo;\nvar bar;\n", apply_concat_javascript_sources("var foo".freeze, "var bar".freeze)
-    assert_equal "var foo;\nvar bar;\n", apply_concat_javascript_sources("var foo;".freeze, "var bar;".freeze)
-    assert_equal "var foo;\nvar bar;\n", apply_concat_javascript_sources("var foo".freeze, "var bar;".freeze)
+
+    assert_equal " var foo;\n", apply_concat_javascript_sources(" ".freeze, "var foo;\n".freeze)
+    assert_equal "var foo;var bar;", apply_concat_javascript_sources("var foo".freeze, "var bar".freeze)
+    assert_equal "var foo;var bar;", apply_concat_javascript_sources("var foo;".freeze, "var bar;".freeze)
+    assert_equal "var foo;var bar;", apply_concat_javascript_sources("var foo".freeze, "var bar;".freeze)
+    assert_equal "var foo;\nvar bar;", apply_concat_javascript_sources("var foo\n".freeze, "var bar;".freeze)
   end
 
   def apply_concat_javascript_sources(*args)


### PR DESCRIPTION
Sorry for the large PR, these issues all cropped up at the same time.

## Problem: Concat JS adds a newline after semi-colon

Solution: Don't add a newline. If one exists put semi-colon before newline

## Problem: Directive Processor adds newline between assets

This was done after the "Default Sourcemap" processor so it wasn't encoded in the asset's "map"

*Solution:* Move the default sourcemap processor to be last

## Problem: Default source map processor doesn't preserve source maps

*Solution:* Add the map back to the returned result

## Problem: Assets with sourcemap comment do not end in newline

*Solution:* Add newline after sourcemap comment

(Not required, but it makes things nicer)

## Problem: Concatenating Source Maps is broken

To concatenate 2 source maps you can use multiple "sections" and give each section an offset. To calculate the offset, you need to know the previous offset, and the length of the last generated file. The offset can be pulled from the last map. The size of the prior generated file was calculated using the number of semicolons in the "mappings" https://github.com/rails/sprockets/blob/341fed4f91e0dfd75f9740ee77885488db58aecd/lib/sprockets/source_map_utils.rb#L80

This behavior is not explicitly stated in the spec, but is implied and confirmed that it should work: https://groups.google.com/forum/#!topic/mozilla.dev.js-sourcemap/gp_ULp-h1fQ. However it appears that coffeescript generated sourcemaps do not always have the same number of semicolons as the generated files. I've opened an issue and with coffeescript https://github.com/jashkenas/coffeescript/issues/4786

*Solution:* To get around this, I've added an `x_sprockets_linecount` key to the sourcemaps that includes the line count of the generated file. This key is added in the `DefaultSourceMap` which all assets will be processed through.

The downside of this approach is this now means that the concat source map function will only work on files that have been passed through the `DefaultSourceMap` processor.

