### PR TITLE
Add extra mimetypes.

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -72,10 +72,14 @@ module Sprockets
   register_mime_type 'audio/aiff', extensions: ['.aiff']
   register_mime_type 'audio/mpeg', extensions: ['.mp3', '.mp2', '.m2a', '.m3a']
   register_mime_type 'application/ogg', extensions: ['.ogx']
+  register_mime_type 'audio/ogg', extensions: ['.ogg', '.oga']
   register_mime_type 'audio/midi', extensions: ['.midi', '.mid']
   register_mime_type 'video/avi', extensions: ['.avi']
   register_mime_type 'audio/wave', extensions: ['.wav', '.wave']
   register_mime_type 'video/mp4', extensions: ['.mp4', '.m4v']
+  register_mime_type 'audio/aac', extensions: ['.aac']
+  register_mime_type 'audio/mp4', extensions: ['.m4a']
+  register_mime_type 'audio/flac', extensions: ['.flac']
 
   # Common font types
   register_mime_type 'application/vnd.ms-fontobject', extensions: ['.eot']


### PR DESCRIPTION
* Adds `audio/mp4` -> `.m4a`
* Adds `audio/ogg` -> `.ogg`, `.oga`
* Adds `audio/flac` -> `.flac`
* Adds `audio/aac` ->` ,aac`

The upcoming release of Jekyll-Assets will support `<audio>` and `<video>`. As such, upon our testing we noticed that there are a few mime-types missing from the list that we would like to support for people. This adds support for extra mime-types, common mime-types we use, and would like to support without extra code inside of Jekyll-Assets, we find that we often encode in `aac`, and `m4a`, we also find that a lot of Linux users still like `ogg`, and personally when I do stuff, it's always in `flac`.