### PR TITLE
Suggest registering transformer OR engine in guides, not both at the same time

### DIFF
--- a/guides/extending_sprockets.md
+++ b/guides/extending_sprockets.md
@@ -425,9 +425,7 @@ In Sprockets 2 and 3 the way you registered a processor was via `register_engine
 if env.respond_to?(:register_transformer)
   env.register_mime_type 'text/css', extensions: ['.css'], charset: :css
   env.register_preprocessor 'text/css', MySprocketsExtension
-end
-
-if env.respond_to?(:register_engine)
+elsif env.respond_to?(:register_engine)
   args = ['.css', MySprocketsExtension]
   args << { mime_type: 'text/css', silence_deprecation: true } if Sprockets::VERSION.start_with?("3")
   env.register_engine(*args)


### PR DESCRIPTION
It may actually cause some troubles, like high memory consumption if both transformer and engine are registered for some extensions.
See https://github.com/slim-template/slim-rails/pull/132

This change suggests to favour `register_transformer` if it is supported.

cc: @schneems , re: https://github.com/rails/sprockets/issues/462#issuecomment-345302829