### PR TITLE
Raise error when two assets produce same path

### DIFF
--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -165,7 +165,12 @@ module Sprockets
       filenames            = []
       concurrent_exporters = []
 
+      assets_to_export = Concurrent::Array.new
       find(*args) do |asset|
+        assets_to_export << asset
+      end
+
+      assets_to_export.each do |asset|
         mtime = Time.now.iso8601
         files[asset.digest_path] = {
           'logical_path' => asset.logical_path,

--- a/test/fixtures/double/link_directory_manifest.js
+++ b/test/fixtures/double/link_directory_manifest.js
@@ -1,0 +1,1 @@
+//= link_directory ./stylesheets .css

--- a/test/fixtures/double/stylesheets/a.css
+++ b/test/fixtures/double/stylesheets/a.css
@@ -1,0 +1,1 @@
+body {color: red;}

--- a/test/fixtures/double/stylesheets/a.css.erb
+++ b/test/fixtures/double/stylesheets/a.css.erb
@@ -1,0 +1,1 @@
+body {color: blue;}

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -16,7 +16,7 @@ class TestManifest < Sprockets::TestCase
 
   def teardown
     FileUtils.remove_entry_secure(@dir) if File.exist?(@dir)
-    assert Dir["#{@dir}/*"].empty?
+    assert Dir["#{@dir}/*"].empty?, "Expected #{Dir["#{@dir}/*"]} to be empty but it was not"
   end
 
   test 'double rendering with link_directory raises an error' do

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -19,6 +19,17 @@ class TestManifest < Sprockets::TestCase
     assert Dir["#{@dir}/*"].empty?
   end
 
+  test 'double rendering with link_directory raises an error' do
+    config_manifest = 'link_directory_manifest.js'
+
+    @env.append_path(fixture_path('double'))
+    output_manifest_json = File.join(@dir, "manifest.json")
+    manifest = Sprockets::Manifest.new(@env, @dir, output_manifest_json)
+    assert_raises(Sprockets::DoubleLinkError) do
+      manifest.compile(config_manifest)
+    end
+  end
+
   test "specify full manifest filename" do
     directory = Dir::tmpdir
     filename  = File.join(directory, 'manifest.json')

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -28,7 +28,6 @@ class TestManifest < Sprockets::TestCase
     assert_raises(Sprockets::DoubleLinkError) do
       manifest.compile(config_manifest)
     end
-    FileUtils.remove_entry_secure("#{@dir}/stylesheets") if File.exist?("#{@dir}/stylesheets")
   end
 
   test "specify full manifest filename" do

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -28,6 +28,7 @@ class TestManifest < Sprockets::TestCase
     assert_raises(Sprockets::DoubleLinkError) do
       manifest.compile(config_manifest)
     end
+    FileUtils.remove_entry_secure("#{@dir}/stylesheets") if File.exist?("#{@dir}/stylesheets")
   end
 
   test "specify full manifest filename" do

--- a/test/test_path_utils.rb
+++ b/test/test_path_utils.rb
@@ -31,6 +31,7 @@ class TestPathUtils < MiniTest::Test
       "context",
       "default",
       "directives",
+      "double",
       "encoding",
       "errors",
       "index-assets",
@@ -44,7 +45,7 @@ class TestPathUtils < MiniTest::Test
       "source-maps",
       "symlink"
     ], entries(File.expand_path("../fixtures", __FILE__))
-    
+
     [ ['a', 'b'], ['a', 'b', '.', '..'] ].each do |dir_contents|
       Dir.stub :entries, dir_contents do
         assert_equal ['a', 'b'], entries(Dir.tmpdir)


### PR DESCRIPTION
When trying to generate assets we can have multiple files that generate the same end path. For example `.css` and `.css.erb` and `.scss` all generate a file with `.css` extension. When linking assets (telling sprockets to generate a new file) we can check for the condition that the same asset logical path has already been generated when that happens we should get an error like this:

```
Sprockets::DoubleLinkError: Multiple files with the same output path cannot be linked ("stylesheets/a.css")
In "/Users/rschneeman/Documents/projects/sprockets/test/fixtures/double/link_directory_manifest.js" these files were linked:
  - /Users/rschneeman/Documents/projects/sprockets/test/fixtures/double/stylesheets/a.css
  - /Users/rschneeman/Documents/projects/sprockets/test/fixtures/double/stylesheets/a.css.erb
```

This does not handle the case where individual assets are directly linked (versus using link_directory).