### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ In production you should generate your assets to a directory on disk and serve t
 On Rails you can generate assets by running:
 
 ```term
-$ RAIlS_ENV=production rake assets:precompile
+$ RAILS_ENV=production rake assets:precompile
 ```
 
 In development Rails will serve assets from `Sprockets::Server`.


### PR DESCRIPTION
RAILS_ENV have a typo.
I have not created an entry in CHANGELOG as it seems a really minor fix.