### PR TITLE
Fix storing absolute path in cache (again)

### DIFF
--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -81,6 +81,8 @@ module Sprockets
           asset[:metadata][:links].map!             { |uri| expand_from_root(uri) } if asset[:metadata][:links]
           asset[:metadata][:stubbed].map!           { |uri| expand_from_root(uri) } if asset[:metadata][:stubbed]
           asset[:metadata][:required].map!          { |uri| expand_from_root(uri) } if asset[:metadata][:required]
+          asset[:metadata][:to_load].map!           { |uri| expand_from_root(uri) } if asset[:metadata][:to_load]
+          asset[:metadata][:to_link].map!           { |uri| expand_from_root(uri) } if asset[:metadata][:to_link]
           asset[:metadata][:dependencies].map!      { |uri| uri.start_with?("file-digest://") ? expand_from_root(uri) : uri } if asset[:metadata][:dependencies]
 
           asset[:metadata].each_key do |k|
@@ -140,7 +142,6 @@ module Sprockets
 
         # Read into memory and process if theres a processor pipeline
         if processors.any?
-
           result = call_processors(processors, {
             environment: self,
             cache: self.cache,
@@ -222,6 +223,16 @@ module Sprockets
           if cached_asset[:metadata][:required] && !cached_asset[:metadata][:required].empty?
             cached_asset[:metadata][:required] = cached_asset[:metadata][:required].dup
             cached_asset[:metadata][:required].map! { |uri| compress_from_root(uri) }
+          end
+
+          if cached_asset[:metadata][:to_load] && !cached_asset[:metadata][:to_load].empty?
+            cached_asset[:metadata][:to_load] = cached_asset[:metadata][:to_load].dup
+            cached_asset[:metadata][:to_load].map! { |uri| compress_from_root(uri) }
+          end
+
+          if cached_asset[:metadata][:to_link] && !cached_asset[:metadata][:to_link].empty?
+            cached_asset[:metadata][:to_link] = cached_asset[:metadata][:to_link].dup
+            cached_asset[:metadata][:to_link].map! { |uri| compress_from_root(uri) }
           end
 
           if cached_asset[:metadata][:dependencies] && !cached_asset[:metadata][:dependencies].empty?

--- a/test/test_caching.rb
+++ b/test/test_caching.rb
@@ -429,6 +429,21 @@ class TestFileStoreCaching < Sprockets::TestCase
     end
   end
 
+  test "no absolute paths are stored in the cache by accident" do
+    environment = Sprockets::Environment.new(fixture_path('default')) do |env|
+      env.append_path(".")
+      env.cache = @cache
+    end
+    cache = environment.cache
+    def cache.set(key, value, local = false)
+      if value.to_s =~ /#{Dir.pwd}/
+        raise "Expected '#{value}' to not contain absolute path '#{Dir.pwd}' but did"
+      end
+    end
+
+    environment['schneems.js']
+  end
+
   test "no absolute paths are retuned from cache" do
     env1 = Sprockets::Environment.new(fixture_path('default')) do |env|
       env.append_path(".")


### PR DESCRIPTION
Introduced in #441 the `to_load` and `to_link` sets are used to store assets that will be loaded or linked. At the time of implementation it was thought that the key was removed in the Bundle processor before being stored in the cache. Unfortunately this is not the case as Sprockets pipelines are confusing and the Bundle processor gets called in the “self” pipeline which does not get called until after the “default” pipeline produces an asset that is stored to the cache.

This PR fixes this issue by forcing the path into a relative path before being put in the cache, and then expanding from relative path after reading from cache.

I also added a test that should catch if __any__ absolute values make their way into the cache, not just in the keys that we specify.