### PR TITLE
Avoid warnings

### DIFF
--- a/lib/sprockets/erb_processor.rb
+++ b/lib/sprockets/erb_processor.rb
@@ -18,7 +18,12 @@ class Sprockets::ERBProcessor
   end
 
   def call(input)
-    engine = ::ERB.new(input[:data], nil, '<>')
+    match = ERB.version.match(/\Aerb\.rb \[(?<version>[^ ]+) /)
+    if match && match[:version] >= "2.2.0" # Ruby 2.6+
+      engine = ::ERB.new(input[:data], trim_mode: '<>')
+    else
+      engine = ::ERB.new(input[:data], nil, '<>')
+    end
     engine.filename = input[:filename]
 
     context = input[:environment].context_class.new(input)

--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -40,7 +40,6 @@ class TestSourceMaps < Sprockets::TestCase
 
     assert_equal coffee_main_lines + child_lines, sub_a_js_section["offset"]["line"]
 
-    plain_js         = @env["plain.js"]
     plain_js_section = map["sections"][3]
     assert_equal sub_a_js_lines + coffee_main_lines + child_lines, plain_js_section["offset"]["line"]
   end


### PR DESCRIPTION
Two tweaks to avoid warnings from Ruby 2.5.1, and 2.6.0.

As no new feature is introduced I believe new tests are not needed.

And I suspect this does not justfiy a line in the CHANGELOG, but please do correct me if I'm mistaken.