### PR TITLE
backport: Deprecate safe_level of `ERB.new` in Ruby 2.6

### DIFF
--- a/lib/sprockets/erb_processor.rb
+++ b/lib/sprockets/erb_processor.rb
@@ -18,7 +18,13 @@ module Sprockets
     end
 
     def call(input)
-      engine = ::ERB.new(input[:data], nil, '<>')
+      match = ERB.version.match(/\Aerb\.rb \[(?<version>[^ ]+) /)
+      if match && match[:version] >= "2.2.0" # Ruby 2.6+
+        engine = ::ERB.new(input[:data], trim_mode: '<>')
+      else
+        engine = ::ERB.new(input[:data], nil, '<>')
+      end
+
       context = input[:environment].context_class.new(input)
       klass = (class << context; self; end)
       klass.class_eval(&@block) if @block


### PR DESCRIPTION
Original commit: 37a87ba0969d9c08e0e5d05271c7d2e6ba8aa817

We see the warnings in Rails CI for 2.6, as in:

https://travis-ci.org/rails/rails/jobs/397080951#L1194-L1199
https://travis-ci.org/rails/rails/jobs/397080951#L1209-L1216
https://travis-ci.org/rails/rails/jobs/397080951#L2238-L2239