### PR TITLE
update sassc

### DIFF
--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rack-test", "~> 0.6"
   s.add_development_dependency "rake", "~> 10.0"
   s.add_development_dependency "sass", "~> 3.4"
-  s.add_development_dependency "sassc", ">= 1.10.1", "< 2.0"
+  s.add_development_dependency "sassc", ">= 1.12.1", "< 2.0"
   s.add_development_dependency "uglifier", ">= 2.3"
   s.add_development_dependency "yui-compressor", "~> 0.12"
   s.add_development_dependency "zopfli", "~> 0.0.4"

--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -404,7 +404,7 @@ class TestSasscSourceMaps < Sprockets::TestCase
           "map"    => {
             "version"  => 3,
             "file"     => "sass/main.scss",
-            "mappings" => "AAAA,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GACjB;;AALH,AAOE,GAPC,CAOD,EAAE,CAAC;EAAE,OAAO,EAAE,YAAY,GAAK;;AAPjC,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GACtB",
+            "mappings" => "AAAA,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GACjB;;AALH,AAOE,GAPC,CAOD,EAAE,CAAC;EAAE,OAAO,EAAE,YAAY,GAAI;;AAPhC,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GACtB",
             "sources"  => ["main.source.scss"],
             "names"    => [],
             "x_sprockets_linecount"=>12
@@ -446,7 +446,7 @@ class TestSasscSourceMaps < Sprockets::TestCase
           "map"    => {
             "version"  => 3,
             "file"     => "sass/with-import.scss",
-            "mappings" => "ACAA,AAAA,IAAI,CAAC;EAAE,KAAK,EAAE,GAAG,GAAK;;ADEtB,AAAA,GAAG,CAAC;EAAE,KAAK,EAAE,IAAI,GAAK",
+            "mappings" => "ACAA,AAAA,IAAI,CAAC;EAAE,KAAK,EAAE,GAAG,GAAI;;ADErB,AAAA,GAAG,CAAC;EAAE,KAAK,EAAE,IAAI,GAAI",
             "sources"  => [
               "with-import.source.scss",
               "_imported.source.scss"


### PR DESCRIPTION
```
  1) Failure:
TestSasscSourceMaps#test_"compile scss source map with imported dependencies" [C:/projects/sprockets/test/test_source_maps.rb:440]:
--- expected
+++ actual
@@ -1 +1 @@
-{"version"=>3, "file"=>"sass/with-import.scss", "sections"=>[{"offset"=>{"line"=>0, "column"=>0}, "map"=>{"version"=>3, "file"=>"sass/with-import.scss", "mappings"=>"ACAA,AAAA,IAAI,CAAC;EAAE,KAAK,EAAE,GAAG,GAAK;;ADEtB,AAAA,GAAG,CAAC;EAAE,KAAK,EAAE,IAAI,GAAK", "sources"=>["with-import.source.scss", "_imported.source.scss"], "names"=>[], "x_sprockets_linecount"=>5}}]}
+{"version"=>3, "file"=>"sass/with-import.scss", "sections"=>[{"offset"=>{"line"=>0, "column"=>0}, "map"=>{"version"=>3, "file"=>"sass/with-import.scss", "mappings"=>"ACAA,AAAA,IAAI,CAAC;EAAE,KAAK,EAAE,GAAG,GAAI;;ADErB,AAAA,GAAG,CAAC;EAAE,KAAK,EAAE,IAAI,GAAI", "sources"=>["with-import.source.scss", "_imported.source.scss"], "names"=>[], "x_sprockets_linecount"=>5}}]}


  2) Failure:
TestSasscSourceMaps#test_"compile scss source map" [C:/projects/sprockets/test/test_source_maps.rb:398]:
--- expected
+++ actual
@@ -1 +1 @@
-{"version"=>3, "file"=>"sass/main.scss", "sections"=>[{"offset"=>{"line"=>0, "column"=>0}, "map"=>{"version"=>3, "file"=>"sass/main.scss", "mappings"=>"AAAA,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GACjB;;AALH,AAOE,GAPC,CAOD,EAAE,CAAC;EAAE,OAAO,EAAE,YAAY,GAAK;;AAPjC,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GACtB", "sources"=>["main.source.scss"], "names"=>[], "x_sprockets_linecount"=>12}}]}
+{"version"=>3, "file"=>"sass/main.scss", "sections"=>[{"offset"=>{"line"=>0, "column"=>0}, "map"=>{"version"=>3, "file"=>"sass/main.scss", "mappings"=>"AAAA,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GACjB;;AALH,AAOE,GAPC,CAOD,EAAE,CAAC;EAAE,OAAO,EAAE,YAAY,GAAI;;AAPhC,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GACtB", "sources"=>["main.source.scss"], "names"=>[], "x_sprockets_linecount"=>12}}]}
```