### PR TITLE
use stable sort

### DIFF
--- a/lib/sprockets/http_utils.rb
+++ b/lib/sprockets/http_utils.rb
@@ -92,7 +92,8 @@ module Sprockets
         end
       end
 
-      matches.sort_by! { |match, quality| -quality }
+      i = 0
+      matches.sort_by!{ |match, quality| [-quality, i += 1] }
       matches.map! { |match, quality| match }
       matches
     end

--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -248,11 +248,12 @@ module Sprockets
       asset_versions.each do |logical_path, versions|
         current = assets[logical_path]
 
+        i = 0
         versions.reject { |path, _|
           path == current
         }.sort_by { |_, attrs|
           # Sort by timestamp
-          Time.parse(attrs['mtime'])
+          [Time.parse(attrs['mtime']), i += 1]
         }.reverse.each_with_index.drop_while { |(_, attrs), index|
           _age = [0, Time.now - Time.parse(attrs['mtime'])].max
           # Keep if under age or within the count limit


### PR DESCRIPTION
stable sort isn't guaranteed in ruby, see https://bugs.ruby-lang.org/issues/1089

```
  1) Failure:
TestHTTPUtils#test_find_best_q_match [C:/projects/sprockets/test/test_http_utils.rb:83]:
Expected: "sdch"
  Actual: "gzip"
  2) Failure:
TestSprocketsSass#test_"track sass dependencies metadata" [C:/projects/sprockets/test/test_sass.rb:95]:
--- expected
+++ actual
@@ -1 +1 @@
-["C:/projects/sprockets/test/fixtures/sass/_rounded.scss", "C:/projects/sprockets/test/fixtures/sass/import_partial.sass"]
+["C:/projects/sprockets/test/fixtures/sass/_rounded.scss", "C:/projects/sprockets/test/fixtures/sass/import_partial.scss"]
  3) Failure:
TestManifest#test_"remove old backups(count)" [C:/projects/sprockets/test/test_manifest.rb:451]:
Expected false to be truthy.
  4) Failure:
TestSassFunctions#test_"track sass dependencies metadata" [C:/projects/sprockets/test/test_sass.rb:95]:
--- expected
+++ actual
@@ -1 +1 @@
-["C:/projects/sprockets/test/fixtures/sass/_rounded.scss", "C:/projects/sprockets/test/fixtures/sass/import_partial.sass"]
+["C:/projects/sprockets/test/fixtures/sass/_rounded.scss", "C:/projects/sprockets/test/fixtures/sass/import_partial.scss"]
  5) Failure:
TestTransformers#test_"resolve transform type for svg" [C:/projects/sprockets/test/test_transformers.rb:20]:
Expected: "image/svg+xml"
  Actual: "image/png"
  6) Failure:
TestResolve#test_"resolve accept type quality in paths" [C:/projects/sprockets/test/test_resolve.rb:152]:
--- expected
+++ actual
@@ -1 +1 @@
-"file:///C:/projects/sprockets/test/fixtures/resolve/javascripts/bar.js?type=application/javascript"
+"file:///C:/projects/sprockets/test/fixtures/resolve/javascripts/bar.css?type=text/css"
886 runs, 3899 assertions, 6 failures, 0 errors, 9 skips
```
the problem is if there're two extensions with the same priority, it may return results in a different order
```
[['image/svg+xml', 1.0], ['image/png', '1.0']].sort_by{|value, priority| priority} 
=> [['image/png', '1.0'], ['image/svg+xml', 1.0]]
```

unfortunatelly the fix has negative impact on performance
```
require 'benchmark/ips'

variants = [['csv', 1.0], ['xls', 1.0]]
variants2 = Array.new(100) { [rand(50).to_s, rand(50)] }

Benchmark.ips do |x|
  x.report('unstable') { variants.sort_by{|value, priority| priority} }
  x.report('stable') { i=0; variants.sort_by{|value, priority| [priority, i += 1]} }
  x.report('unstable2') { variants2.sort_by{|value, priority| priority} }
  x.report('stable2') { i=0; variants2.sort_by{|value, priority| [priority, i += 1]} }
end

Warming up --------------------------------------
            unstable    47.239k i/100ms
              stable    33.221k i/100ms
           unstable2     3.877k i/100ms
             stable2   493.000  i/100ms
Calculating -------------------------------------
            unstable    674.848k (± 4.6%) i/s -      3.401M in   5.053209s
              stable    405.792k (± 8.6%) i/s -      2.026M in   5.043886s
           unstable2     40.146k (± 2.0%) i/s -    201.604k in   5.023949s
             stable2      4.520k (±11.0%) i/s -     22.678k in   5.086251s
```