### PR TITLE
(Sprockets 3) Reduce retained memory for compute_extname_map

### DIFF
--- a/lib/sprockets/resolve.rb
+++ b/lib/sprockets/resolve.rb
@@ -202,7 +202,7 @@ module Sprockets
 
         if extname
           path = path.chomp(extname)
-          type, engines, pipeline = value.values_at(:type, :engines, :pipeline)
+          type, engines, pipeline = value
         end
 
         return path, type, engines, pipeline


### PR DESCRIPTION
This change only affects Sprockets 3. Currenlty master is on version 4 so I'm not sure changes to only 3.x branch is accepted or not. Since version 4 is still beta and rails release are still locked to sprocket < 4, I think changes related to only improving version 3 should be accepted

```
Before
Total allocated: 24154640 bytes (227383 objects)
Total retained:  14660632 bytes (127924 objects)

After
Total allocated: 14798384 bytes (157380 objects)
Total retained:  5944672 bytes (72057 objects)
```

Explanation

1. extname_map's values are now stored as Array rather than Hash.
	ObjectSpace.memsize_of({type: 1, engine: [], pipeline: 3}) #=> 192
	ObjectSpace.memsize_of([1, [], 3]) #=> 40

2. Eliminate duplicate array(extname_map's values and engine_extnames)
	i. extname_map's values are 60-70% uniq
	ii.Previously engine_extname's permutation was executed (pipelines.size + 1)*(mime_exts.size + 1) (During Benchmark 4*41)times

I've tested the new extname_map against old extname_map.

Script(You will need to add old implementation with old_compute_extname_map method name):

```
require 'sprockets'
require 'memory_profiler'

graph = nil
old_graph = nil
puts "----==="*20
puts 'NEW'
MemoryProfiler.report{graph = Sprockets.send(:compute_extname_map)}.pretty_print(detailed_report: false, allocated_strings: 0, retained_strings: 0)
p graph.size
p graph.values.uniq.size
p graph.values.uniq(&:__id__).size


puts "----==="*20
puts 'OLD'

MemoryProfiler.report{old_graph = Sprockets.send(:old_compute_extname_map)}.pretty_print(detailed_report: false, allocated_strings: 0, retained_strings: 0)
p old_graph.size
p old_graph.values.uniq.size
p old_graph.values.uniq(&:__id__).size


puts "----==="*20
old_graph.each do |key, old_val|
  val = graph[key]
  old_val = old_val.values_at(:type, :engines, :pipeline)
  puts "'#{key}' => #{val.inspect} , #{old_val.inspect}" unless val == old_val
end
```

NOTE: Allocated Memory can be further reduced (additional ~80K object for above result) by changing the way key is generated. I've not changed the key generation because it won't be a clean change and I wanted to strictly focus on retained memory in this PR