### PR TITLE
make sure `rake clobber_assets` and FileStore#clear work when cache dir doesn't exist

### DIFF
--- a/lib/sprockets/cache/file_store.rb
+++ b/lib/sprockets/cache/file_store.rb
@@ -137,8 +137,10 @@ module Sprockets
       #
       # Returns true
       def clear(options=nil)
-        root_dirs = Dir.entries(@root).reject { |f| (EXCLUDED_DIRS + GITKEEP_FILES).include?(f) }
-        FileUtils.rm_r(root_dirs.collect{ |f| File.join(@root, f) })
+        if File.exist?(@root)
+          root_dirs = Dir.entries(@root).reject { |f| (EXCLUDED_DIRS + GITKEEP_FILES).include?(f) }
+          FileUtils.rm_r(root_dirs.collect{ |f| File.join(@root, f) })
+        end
         true
       end
 

--- a/test/test_cache_store.rb
+++ b/test/test_cache_store.rb
@@ -170,6 +170,13 @@ class TestFileStore < MiniTest::Test
     refute @_store.get("corrupt")
   end
 
+  def test_clear_store_dir_not_exist
+    @cache_dir = File.join(Dir::tmpdir, 'sprockets')
+    refute File.exist?(@cache_dir)
+    @store = Sprockets::Cache::FileStore.new(@cache_dir)
+    assert @store.clear
+  end
+
   include CacheStoreTests
 end
 

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -672,4 +672,12 @@ class TestManifest < Sprockets::TestCase
     Sprockets::Manifest.new(@env, @dir).compile('logo.png', 'troll.png')
     assert_equal %w(0 1 0 1), processor.seq
   end
+
+  test 'clobber works when cache_dir not created' do
+    @cache_dir = File.join(Dir::tmpdir, 'sprockets')
+    refute File.exist?(@cache_dir)
+    @env.cache = Sprockets::Cache::FileStore.new(@cache_dir)
+    manifest = Sprockets::Manifest.new(@env, File.join(@dir, 'manifest.json'))
+    manifest.clobber
+  end
 end


### PR DESCRIPTION
This was exposed by the test suite for sprockets-rails.  See [here](https://travis-ci.org/rails/sprockets-rails/jobs/433120871) for an example of a failure.

Depending on the order the tests ran, they would sometimes pass, sometimes fail. I added a workaround on sprockets-rails at https://github.com/rails/sprockets-rails/pull/434/commits/977cc5f732a942169fb183460ba79af95392002f but this fixes the underlying issue.  After this or similar fix lands on sprockets, I will remove that workaround on sprockets-rails.