### PR TITLE
Prevent revealing a sensitive info in an error message

### DIFF
--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -160,6 +160,7 @@ module Sprockets
     # Returns relative String path if subpath is a subpath of path, or nil if
     # subpath is outside of path.
     def split_subpath(path, subpath)
+      return nil if subpath.nil?
       return "" if path == subpath
       path = File.join(path, ''.freeze)
       if subpath.start_with?(path)


### PR DESCRIPTION
When assets are stored in a Cloudfront CDN, it's possible to misspell the assets path in browser on purpose and get an error message:

throw Error("NoMethodError: undefined method start_with?' for nil:NilClass\n (in /app/vendor/bundle/ruby/2.5.0/gems/sprockets-3.7.2/lib/sprockets/path_utils.rb:113:insplit_subpath')")

which is not desired