### PR TITLE
Remove sass implicit dependency

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -165,11 +165,11 @@ module Sprockets
   register_transformer 'application/javascript+function', 'application/javascript', JstProcessor
 
   # CSS processors
-  require 'sprockets/sass_processor'
+  require 'sprockets/sassc_processor'
   register_mime_type 'text/sass', extensions: ['.sass', '.css.sass']
   register_mime_type 'text/scss', extensions: ['.scss', '.css.scss']
-  register_transformer 'text/sass', 'text/css', SassProcessor
-  register_transformer 'text/scss', 'text/css', ScssProcessor
+  register_transformer 'text/sass', 'text/css', SasscProcessor
+  register_transformer 'text/scss', 'text/css', ScsscProcessor
   register_preprocessor 'text/sass', DirectiveProcessor.new(comments: ["//", ["/*", "*/"]])
   register_preprocessor 'text/scss', DirectiveProcessor.new(comments: ["//", ["/*", "*/"]])
   register_bundle_metadata_reducer 'text/css', :sass_dependencies, Set.new, :+

--- a/lib/sprockets/sassc_compressor.rb
+++ b/lib/sprockets/sassc_compressor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'sprockets/autoload'
 require 'sprockets/sass_compressor'
-require 'base64'
 
 module Sprockets
   class SasscCompressor < SassCompressor

--- a/lib/sprockets/sassc_compressor.rb
+++ b/lib/sprockets/sassc_compressor.rb
@@ -1,9 +1,32 @@
 # frozen_string_literal: true
 require 'sprockets/autoload'
-require 'sprockets/sass_compressor'
+require 'sprockets/source_map_utils'
 
 module Sprockets
-  class SasscCompressor < SassCompressor
+  # Public: Sass CSS minifier.
+  #
+  # To accept the default options
+  #
+  #     environment.register_bundle_processor 'text/css',
+  #       Sprockets::SasscCompressor
+  #
+  # Or to pass options to the Sass::Engine class.
+  #
+  #     environment.register_bundle_processor 'text/css',
+  #       Sprockets::SasscCompressor.new({ ... })
+  #
+  class SasscCompressor
+    # Public: Return singleton instance with default options.
+    #
+    # Returns SasscCompressor object.
+    def self.instance
+      @instance ||= new
+    end
+
+    def self.call(input)
+      instance.call(input)
+    end
+
     def initialize(options = {})
       @options = {
         syntax: :scss,

--- a/lib/sprockets/sassc_processor.rb
+++ b/lib/sprockets/sassc_processor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'sprockets/sass_processor'
 require 'sprockets/path_utils'
-require 'base64'
 
 module Sprockets
   class SasscProcessor < SassProcessor

--- a/lib/sprockets/sassc_processor.rb
+++ b/lib/sprockets/sassc_processor.rb
@@ -1,16 +1,49 @@
 # frozen_string_literal: true
-require 'sprockets/sass_processor'
-require 'sprockets/path_utils'
+require 'rack/utils'
+require 'sprockets/autoload'
+require 'sprockets/source_map_utils'
+require 'uri'
 
 module Sprockets
-  class SasscProcessor < SassProcessor
+  # Processor engine class for the SASS/SCSS compiler. Depends on the `sassc` gem.
+  #
+  # For more infomation see:
+  #
+  #   https://github.com/sass/sassc-ruby
+  #   https://github.com/sass/sassc-rails
+  #
+  class SasscProcessor
+
+    # Internal: Defines default sass syntax to use. Exposed so the ScsscProcessor
+    # may override it.
+    def self.syntax
+      :sass
+    end
+
+    # Public: Return singleton instance with default options.
+    #
+    # Returns SasscProcessor object.
+    def self.instance
+      @instance ||= new
+    end
+
+    def self.call(input)
+      instance.call(input)
+    end
+
+    def self.cache_key
+      instance.cache_key
+    end
+
+    attr_reader :cache_key
+
     def initialize(options = {}, &block)
       @cache_version = options[:cache_version]
       @cache_key = "#{self.class.name}:#{VERSION}:#{Autoload::SassC::VERSION}:#{@cache_version}".freeze
       @importer_class = options[:importer]
       @sass_config = options[:sass_config] || {}
       @functions = Module.new do
-        include SassProcessor::Functions
+        include Functions
         include options[:functions] if options[:functions]
         class_eval(&block) if block_given?
       end
@@ -41,6 +74,201 @@ module Sprockets
     end
 
     private
+
+    def merge_options(options)
+      defaults = @sass_config.dup
+
+      if load_paths = defaults.delete(:load_paths)
+        options[:load_paths] += load_paths
+      end
+
+      options.merge!(defaults)
+      options
+    end
+
+    # Public: Functions injected into Sass context during Sprockets evaluation.
+    #
+    # This module may be extended to add global functionality to all Sprockets
+    # Sass environments. Though, scoping your functions to just your environment
+    # is preferred.
+    #
+    # module Sprockets::SasscProcessor::Functions
+    #   def asset_path(path, options = {})
+    #   end
+    # end
+    #
+    module Functions
+      # Public: Generate a url for asset path.
+      #
+      # Default implementation is deprecated. Currently defaults to
+      # Context#asset_path.
+      #
+      # Will raise NotImplementedError in the future. Users should provide their
+      # own base implementation.
+      #
+      # Returns a SassC::Script::Value::String.
+      def asset_path(path, options = {})
+        path = path.value
+
+        path, _, query, fragment = URI.split(path)[5..8]
+        path     = sprockets_context.asset_path(path, options)
+        query    = "?#{query}" if query
+        fragment = "##{fragment}" if fragment
+
+        Autoload::SassC::Script::Value::String.new("#{path}#{query}#{fragment}", :string)
+      end
+
+      # Public: Generate a asset url() link.
+      #
+      # path - SassC::Script::Value::String URL path
+      #
+      # Returns a SassC::Script::Value::String.
+      def asset_url(path, options = {})
+        Autoload::SassC::Script::Value::String.new("url(#{asset_path(path, options).value})")
+      end
+
+      # Public: Generate url for image path.
+      #
+      # path - SassC::Script::Value::String URL path
+      #
+      # Returns a SassC::Script::Value::String.
+      def image_path(path)
+        asset_path(path, type: :image)
+      end
+
+      # Public: Generate a image url() link.
+      #
+      # path - SassC::Script::Value::String URL path
+      #
+      # Returns a SassC::Script::Value::String.
+      def image_url(path)
+        asset_url(path, type: :image)
+      end
+
+      # Public: Generate url for video path.
+      #
+      # path - SassC::Script::Value::String URL path
+      #
+      # Returns a SassC::Script::Value::String.
+      def video_path(path)
+        asset_path(path, type: :video)
+      end
+
+      # Public: Generate a video url() link.
+      #
+      # path - SassC::Script::Value::String URL path
+      #
+      # Returns a SassC::Script::Value::String.
+      def video_url(path)
+        asset_url(path, type: :video)
+      end
+
+      # Public: Generate url for audio path.
+      #
+      # path - SassC::Script::Value::String URL path
+      #
+      # Returns a SassC::Script::Value::String.
+      def audio_path(path)
+        asset_path(path, type: :audio)
+      end
+
+      # Public: Generate a audio url() link.
+      #
+      # path - SassC::Script::Value::String URL path
+      #
+      # Returns a SassC::Script::Value::String.
+      def audio_url(path)
+        asset_url(path, type: :audio)
+      end
+
+      # Public: Generate url for font path.
+      #
+      # path - SassC::Script::Value::String URL path
+      #
+      # Returns a SassC::Script::Value::String.
+      def font_path(path)
+        asset_path(path, type: :font)
+      end
+
+      # Public: Generate a font url() link.
+      #
+      # path - SassC::Script::Value::String URL path
+      #
+      # Returns a SassC::Script::Value::String.
+      def font_url(path)
+        asset_url(path, type: :font)
+      end
+
+      # Public: Generate url for javascript path.
+      #
+      # path - SassC::Script::Value::String URL path
+      #
+      # Returns a SassC::Script::Value::String.
+      def javascript_path(path)
+        asset_path(path, type: :javascript)
+      end
+
+      # Public: Generate a javascript url() link.
+      #
+      # path - SassC::Script::Value::String URL path
+      #
+      # Returns a SassC::Script::Value::String.
+      def javascript_url(path)
+        asset_url(path, type: :javascript)
+      end
+
+      # Public: Generate url for stylesheet path.
+      #
+      # path - SassC::Script::Value::String URL path
+      #
+      # Returns a SassC::Script::Value::String.
+      def stylesheet_path(path)
+        asset_path(path, type: :stylesheet)
+      end
+
+      # Public: Generate a stylesheet url() link.
+      #
+      # path - SassC::Script::Value::String URL path
+      #
+      # Returns a SassC::Script::Value::String.
+      def stylesheet_url(path)
+        asset_url(path, type: :stylesheet)
+      end
+
+      # Public: Generate a data URI for asset path.
+      #
+      # path - SassC::Script::Value::String logical asset path
+      #
+      # Returns a SassC::Script::Value::String.
+      def asset_data_url(path)
+        url = sprockets_context.asset_data_uri(path.value)
+        Autoload::SassC::Script::Value::String.new("url(" + url + ")")
+      end
+
+      protected
+        # Public: The Environment.
+        #
+        # Returns Sprockets::Environment.
+        def sprockets_environment
+          options[:sprockets][:environment]
+        end
+
+        # Public: Mutatable set of dependencies.
+        #
+        # Returns a Set.
+        def sprockets_dependencies
+          options[:sprockets][:dependencies]
+        end
+
+        # Deprecated: Get the Context instance. Use APIs on
+        # sprockets_environment or sprockets_dependencies directly.
+        #
+        # Returns a Context instance.
+        def sprockets_context
+          options[:sprockets][:context]
+        end
+
+    end
 
     def engine_options(input, context)
       merge_options({

--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -30,9 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rack-test", "~> 0.6"
   s.add_development_dependency "rake", "~> 12.0"
   s.add_development_dependency "sass", "~> 3.4"
-  unless RUBY_PLATFORM.include?('java')
-    s.add_development_dependency "sassc", ">= 1.12.1", "< 2.0"
-  end
+  s.add_development_dependency "sassc", "~> 2.0"
   s.add_development_dependency "uglifier", ">= 2.3"
   s.add_development_dependency "yui-compressor", "~> 0.12"
   unless RUBY_PLATFORM.include?('java')

--- a/test/test_sass.rb
+++ b/test/test_sass.rb
@@ -6,6 +6,9 @@ silence_warnings do
   require 'sass'
 end
 
+require 'sprockets/sass_processor'
+require 'sprockets/sass_compressor'
+
 class TestBaseSass < Sprockets::TestCase
   CACHE_PATH = File.expand_path("../../.sass-cache", __FILE__)
 
@@ -58,6 +61,8 @@ class TestSprocketsSass < TestBaseSass
       env.append_path(fixture_path('.'))
       env.append_path(fixture_path('compass'))
       env.append_path(fixture_path('octicons'))
+      env.register_transformer 'text/sass', 'text/css', Sprockets::SassProcessor.new
+      env.register_transformer 'text/scss', 'text/css', Sprockets::ScssProcessor.new
     end
   end
 

--- a/test/test_sassc.rb
+++ b/test/test_sassc.rb
@@ -2,7 +2,6 @@
 require 'sprockets_test'
 require 'shared_sass_tests'
 
-unless RUBY_PLATFORM.include?('java')
 silence_warnings do
   require 'sassc'
 end
@@ -131,5 +130,4 @@ class TestSasscFunctions < TestSprocketsSassc
   end
 
   include SharedSassTestFunctions
-end
 end

--- a/test/test_sassc.rb
+++ b/test/test_sassc.rb
@@ -43,12 +43,12 @@ end
 class TestNoSassFunctionSassC < TestBaseSassc
   module ::SassC::Script::Functions
     def javascript_path(path)
-      ::SassC::Script::String.new("/js/#{path.value}", :string)
+      ::SassC::Script::Value::String.new("/js/#{path.value}", :string)
     end
 
     module Compass
       def stylesheet_path(path)
-        ::SassC::Script::String.new("/css/#{path.value}", :string)
+        ::SassC::Script::Value::String.new("/css/#{path.value}", :string)
       end
     end
     include Compass

--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -240,10 +240,10 @@ class TestSourceMaps < Sprockets::TestCase
           "map"    => {
             "version"  => 3,
             "file"     => "sass/main.scss",
-            "mappings" => "AACE,MAAG;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI;AAGlB,MAAG;EAAE,OAAO,EAAE,YAAY;AAE1B,KAAE;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI",
+            "mappings" => "AAAA,AACE,GADC,CACD,EAAE,CAAC;EACD,MAAM,EAAE,CAAC;EACT,OAAO,EAAE,CAAC;EACV,UAAU,EAAE,IAAI,GACjB;;AALH,AAOE,GAPC,CAOD,EAAE,CAAC;EAAE,OAAO,EAAE,YAAY,GAAI;;AAPhC,AASE,GATC,CASD,CAAC,CAAC;EACA,OAAO,EAAE,KAAK;EACd,OAAO,EAAE,QAAQ;EACjB,eAAe,EAAE,IAAI,GACtB",
             "sources"  => ['main.source.scss'],
             "names"    => [],
-            "x_sprockets_linecount"=>10
+            "x_sprockets_linecount"=>12
           }
         }
       ]
@@ -282,10 +282,10 @@ class TestSourceMaps < Sprockets::TestCase
           "map"    => {
             "version"  => 3,
             "file"     => "sass/with-import.scss",
-            "mappings" => "AAAA,IAAK;EAAE,KAAK,EAAE,GAAG;;ACEjB,GAAI;EAAE,KAAK,EAAE,IAAI",
+            "mappings" => "ACAA,AAAA,IAAI,CAAC;EAAE,KAAK,EAAE,GAAG,GAAI;;ADErB,AAAA,GAAG,CAAC;EAAE,KAAK,EAAE,IAAI,GAAI",
             "sources"  => [
+              "with-import.source.scss",
               "_imported.source.scss",
-              "with-import.source.scss"
             ],
             "names"    => [],
             "x_sprockets_linecount"=>5


### PR DESCRIPTION
I tried to do with I think @guilleiguaran meant by https://github.com/rails/rails/pull/34884#issuecomment-451767789. Also changed the default ".sass" and ".scss" processors to be sassc instead of sass. Basically I copied the sass implementations and changed the `Sass` specific bits to use `SassC`.

I had to change a couple of tests to get it green, not sure if I need to change something in the implementation instead?