### PR TITLE
Minimum Ruby version is 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,8 @@
+require: rubocop-performance
 AllCops:
   DisabledByDefault: true
   DisplayCopNames: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
 
 Performance:
   Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ before_script: "unset _JAVA_OPTIONS"
 before_install: gem install bundler -v '<2'
 
 rvm:
-  - 2.3.8
-  - 2.4.5
   - 2.5.3
   - 2.6.0
   - jruby-9.2.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 
 ## Master
 
+- Minimum Ruby version for Sprockets 4 is now 2.5+ which matches minimum ruby verision of Rails [#604]
+
 ## 4.0.0.beta8
 
 - Security release for [CVE-2018-3760](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3760)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,14 +16,8 @@ before_test:
 test_script:
   - bundle exec rake
 
-matrix:
-  allow_failures:
-    - RUBY_VERSION: 25-x64
-    - RUBY_VERSION: 24-x64
-
 environment:
   matrix:
+    - RUBY_VERSION: 26-x64
     - RUBY_VERSION: 25-x64
-    - RUBY_VERSION: 24-x64
-    - RUBY_VERSION: 23-x64
 

--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -86,7 +86,7 @@ module Sprockets
           asset[:metadata][:dependencies].map!      { |uri| uri.start_with?("file-digest://") ? expand_from_root(uri) : uri } if asset[:metadata][:dependencies]
 
           asset[:metadata].each_key do |k|
-            next unless k.to_s.end_with?('_dependencies')
+            next unless k.match?(/_dependencies\z/) # rubocop:disable Performance/EndWith
             asset[:metadata][k].map! { |uri| expand_from_root(uri) }
           end
         end
@@ -244,7 +244,7 @@ module Sprockets
 
           # compress all _dependencies in metadata like `sass_dependencies`
           cached_asset[:metadata].each do |key, value|
-            next unless key.to_s.end_with?('_dependencies')
+            next unless key.match?(/_dependencies\z/) # rubocop:disable Performance/EndWith
             cached_asset[:metadata][key] = value.dup
             cached_asset[:metadata][key].map! {|uri| compress_from_root(uri) }
           end

--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -98,7 +98,7 @@ module Sprockets
     #
     # Returns true if path is relative, otherwise false.
     def relative_path?(path)
-      path =~ /^\.\.?($|#{SEPARATOR_PATTERN})/ ? true : false
+      path.match?(/^\.\.?($|#{SEPARATOR_PATTERN})/) ? true : false
     end
 
     # Public: Get relative path from `start` to `dest`.

--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -36,9 +36,9 @@ Gem::Specification.new do |s|
   unless RUBY_PLATFORM.include?('java')
     s.add_development_dependency "zopfli", "~> 0.0.4"
   end
-  s.add_development_dependency "rubocop", "~> 0.63"
+  s.add_development_dependency "rubocop-performance", "~> 1.3"
 
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.authors = ["Sam Stephenson", "Joshua Peek"]
   s.email = ["sstephenson@gmail.com", "josh@joshpeek.com"]

--- a/test/test_caching.rb
+++ b/test/test_caching.rb
@@ -436,7 +436,7 @@ class TestFileStoreCaching < Sprockets::TestCase
     end
     cache = environment.cache
     def cache.set(key, value, local = false)
-      if value.to_s =~ /#{Dir.pwd}/
+      if value.to_s.match?(/#{Dir.pwd}/)
         raise "Expected '#{value}' to not contain absolute path '#{Dir.pwd}' but did"
       end
     end


### PR DESCRIPTION
Ruby 2.3 is EOL and is no longer supported by Ruby Core. 2.4 will be EOL in 6 months when 2.7 comes out. This also allows us to match Ruby versions with Rails 6.