### PR TITLE
[close #383] Remove duplicate check

### DIFF
--- a/lib/sprockets/processor_utils.rb
+++ b/lib/sprockets/processor_utils.rb
@@ -161,29 +161,9 @@ module Sprockets
         if !key.instance_of?(Symbol)
           raise TypeError, "processor metadata[#{key.inspect}] expected to be a Symbol"
         end
-
-        if !valid_processor_metadata_value?(value)
-          raise TypeError, "processor metadata[:#{key}] returned a complex type: #{value.inspect}\n" +
-            "Only #{VALID_METADATA_TYPES.to_a.join(", ")} maybe used."
-        end
       end
 
       result
-    end
-
-    # Internal: Validate object is in validate metadata whitelist.
-    #
-    # value - Any Object
-    #
-    # Returns true if class is in whitelist otherwise false.
-    def valid_processor_metadata_value?(value)
-      if VALID_METADATA_VALUE_TYPES_HASH[value.class]
-        true
-      elsif VALID_METADATA_COMPOUND_TYPES_HASH[value.class]
-        value.all? { |v| valid_processor_metadata_value?(v) }
-      else
-        false
-      end
     end
   end
 end

--- a/test/test_processor_utils.rb
+++ b/test/test_processor_utils.rb
@@ -348,9 +348,6 @@ class TestProcessorUtils < MiniTest::Test
     assert_raises(TypeError) { validate_processor_result!({data: 123}) }
     assert_raises(TypeError) { validate_processor_result!({data: "hello", "foo" => 1}) }
     assert_raises(TypeError) { validate_processor_result!({data: my_string.new("hello")}) }
-    assert_raises(TypeError) { validate_processor_result!({data: "hello", foo: Object.new}) }
-    assert_raises(TypeError) { validate_processor_result!({data: "hello", foo: [Object.new]}) }
-    assert_raises(TypeError) { validate_processor_result!({data: "hello", foo: Set.new([Object.new])}) }
-    assert_raises(TypeError) { validate_processor_result!({data: "hello", foo: {bar: Object.new}}) }
   end
 end
+


### PR DESCRIPTION
All assets will be digested which forces the use of only specified classes. This check is a duplicate and  isn't terribly informative. Removing it gives us significant speed improvements.