### PR TITLE
[close #573] Stable sort to get windows CI green

### DIFF
--- a/lib/sprockets/http_utils.rb
+++ b/lib/sprockets/http_utils.rb
@@ -86,14 +86,16 @@ module Sprockets
         raise TypeError, "unknown q_values type: #{q_values.class}"
       end
 
+      i = 0
       q_values.each do |accepted, quality|
         if match = available.find { |option| matcher.call(option, accepted) }
-          matches << [match, quality]
+          i += 1
+          matches << [-quality, i, match]
         end
       end
 
-      matches.sort_by! { |match, quality| -quality }
-      matches.map! { |match, quality| match }
+      matches.sort!
+      matches.map! { |_, _, match| match }
       matches
     end
 

--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   unless RUBY_PLATFORM.include?('java')
     s.add_development_dependency "jsminc", "~> 1.1"
   end
+  s.add_development_dependency "timecop", "~> 0.9.1"
   s.add_development_dependency "minitest", "~> 5.0"
   s.add_development_dependency "nokogiri", "~> 1.3"
   s.add_development_dependency "rack-test", "~> 0.6"

--- a/test/sprockets_test.rb
+++ b/test/sprockets_test.rb
@@ -3,6 +3,7 @@ require "minitest/autorun"
 require "sprockets"
 require "sprockets/environment"
 require "fileutils"
+require "timecop"
 
 old_verbose, $VERBOSE = $VERBOSE, false
 Encoding.default_external = 'UTF-8'

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -422,24 +422,27 @@ class TestManifest < Sprockets::TestCase
       manifest.compile('application.js')
       assert File.exist?("#{@dir}/#{digest_path}")
 
+      Timecop.travel(Time.now + 1)
       File.open(filename, 'w') { |f| f.write "a;" }
-      mtime = Time.now + 1
+      mtime = Time.now
       File.utime(mtime, mtime, filename)
       new_digest_path1 = @env['application.js'].digest_path
 
       manifest.compile('application.js')
       assert File.exist?("#{@dir}/#{new_digest_path1}")
 
+      Timecop.travel(Time.now + 1)
       File.open(filename, 'w') { |f| f.write "b;" }
-      mtime = Time.now + 2
+      mtime = Time.now
       File.utime(mtime, mtime, filename)
       new_digest_path2 = @env['application.js'].digest_path
 
       manifest.compile('application.js')
       assert File.exist?("#{@dir}/#{new_digest_path2}")
 
+      Timecop.travel(Time.now + 1)
       File.open(filename, 'w') { |f| f.write "c;" }
-      mtime = Time.now + 3
+      mtime = Time.now
       File.utime(mtime, mtime, filename)
       new_digest_path3 = @env['application.js'].digest_path
 
@@ -460,6 +463,8 @@ class TestManifest < Sprockets::TestCase
       assert data['files'][new_digest_path3]
       assert_equal new_digest_path3, data['assets']['application.js']
     end
+  ensure
+    Timecop.return
   end
 
   test "test manifest does not exist" do


### PR DESCRIPTION

This is an alternative implementation to https://github.com/rails/sprockets/pull/573. The proposed method of fixing this issue, actually makes the code faster:

Benchmark script https://gist.github.com/schneems/1c4e7bcd2a0457665a467dfbe68840c5

Result:


```
Warming up --------------------------------------
                 old    12.736k i/100ms
      proposed array    14.927k i/100ms
Calculating -------------------------------------
                 old    131.024k (± 4.8%) i/s -    662.272k in   5.067206s
      proposed array    155.329k (± 2.6%) i/s -    776.204k in   5.000518s

Comparison:
      proposed array:   155328.7 i/s
                 old:   131024.2 i/s - 1.19x  slower
```


I think `sort_by!` is slower than plain `sort!`, by moving to the different method (and not really incurring much cost to store the extra index information), we can make the solution both correct, and faster.