### PR TITLE
Added support for ERB in webmanifest files

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -180,6 +180,7 @@ module Sprockets
     application/ecmascript-6
     application/javascript
     application/json
+    application/manifest+json
     application/xml
     text/coffeescript
     text/css

--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -51,6 +51,7 @@ module Sprockets
   register_mime_type 'application/json', extensions: ['.json'], charset: :unicode
   register_mime_type 'application/ruby', extensions: ['.rb']
   register_mime_type 'application/xml', extensions: ['.xml']
+  register_mime_type 'application/manifest+json', extensions: ['.webmanifest']
   register_mime_type 'text/css', extensions: ['.css'], charset: :css
   register_mime_type 'text/html', extensions: ['.html', '.htm'], charset: :html
   register_mime_type 'text/plain', extensions: ['.txt', '.text']


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/Manifest for information on the standard.

This is in use already with previous versions of Sprockets - for instance, the package that Real Favicon Generator generates contains a .webmanifest.erb file. At present, this breaks on Sprockets 4. This PR addresses that.