### PR TITLE
Fix broken expansion of asset link paths

### DIFF
--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -115,6 +115,7 @@ module Sprockets
           asset[:load_path] = expand_from_root(asset[:load_path])
           asset[:filename]  = expand_from_root(asset[:filename])
           expand_key_from_hash(asset[:metadata], :included)
+          expand_key_from_hash(asset[:metadata], :links)
           expand_key_from_hash(asset[:metadata], :stubbed)
           expand_key_from_hash(asset[:metadata], :required)
           expand_key_from_hash(asset[:metadata], :to_load)


### PR DESCRIPTION
This fixes a regression from 36741c6 where a line was missed in the conversion.

See https://github.com/rails/sprockets/commit/36741c6ece811be881ba63fadae0c10f9aa77bd0#diff-dfbaed3e7b867e34b5441da43fc665e1L81 for the omitted line from the previous code.

Fixes #613.