### PR TITLE
Test #614

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 
 ## Master
 
+## 4.0.0.beta10
+
+- Fix YACB (Yet Another Caching Bug) [Fix broken expansion of asset link paths](https://github.com/rails/sprockets/pull/614)
+
 ## 4.0.0.beta9
 
 - Minimum Ruby version for Sprockets 4 is now 2.5+ which matches minimum ruby verision of Rails [#604]

--- a/lib/sprockets/version.rb
+++ b/lib/sprockets/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Sprockets
-  VERSION = "4.0.0.beta9"
+  VERSION = "4.0.0.beta10"
 end


### PR DESCRIPTION
We have a test that ensures that values in the cache are never stored as absolute values, however, we had no tests ensuring that values being "expanded" from the cache are all absolute values. That's what this test does.

Before https://github.com/rails/sprockets/pull/614/commits/872b4b265bbf295c3270b3a906de9c99371c206c it failed, with that commit it passes.