### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -44,5 +44,4 @@ Gem::Specification.new do |s|
   s.authors = ["Sam Stephenson", "Joshua Peek"]
   s.email = ["sstephenson@gmail.com", "josh@joshpeek.com"]
   s.homepage = "https://github.com/rails/sprockets"
-  s.rubyforge_project = "sprockets"
 end


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.