### PR TITLE
fix undefined order

### DIFF
--- a/lib/sprockets/manifest_utils.rb
+++ b/lib/sprockets/manifest_utils.rb
@@ -35,7 +35,7 @@ module Sprockets
     #
     # Returns String filename.
     def find_directory_manifest(dirname, logger = Logger.new($stderr))
-      entries = File.directory?(dirname) ? Dir.entries(dirname) : []
+      entries = File.directory?(dirname) ? Dir.entries(dirname).sort : []
       manifest_entries = entries.select { |e| e =~ MANIFEST_RE }
       if manifest_entries.length > 1
         logger.warn("Found multiple manifests: #{manifest_entries}. Choosing the first alphabetically: #{manifest_entries.first}")


### PR DESCRIPTION
Dir.entries actually does not guarantee order of the listed files

fixes
```
  1) Failure:
TestManifestUtils#test_warn_on_two [/home/travis/build/rails/sprockets/test/test_manifest_utils.rb:31]:

--- expected
+++ actual

@@ -1 +1 @@

-"/home/travis/build/rails/sprockets/test/fixtures/manifest_utils/with_two_manifests/.sprockets-manifest-00000000000000000000000000000000.json"

+"/home/travis/build/rails/sprockets/test/fixtures/manifest_utils/with_two_manifests/.sprockets-manifest-f4bf345974645583d284686ddfb7625e.json"
```