### PR TITLE
ignore Errno::EACCES on Windows

### DIFF
--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -359,7 +359,10 @@ module Sprockets
         yield f
       end
 
-      File.rename(tmpname, filename)
+      begin
+        File.rename(tmpname, filename)
+      rescue Errno::EACCES
+      end
     ensure
       File.delete(tmpname) if File.exist?(tmpname)
     end


### PR DESCRIPTION
if concurrent exporting is enabled, it could happen that two assets produce the same cache file.

Windows IO is more strict about accessing files that're already in use.