### PR TITLE
Fixes for Ruby 2.7 keyword arguments warnings

### DIFF
--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -75,8 +75,8 @@ module Sprockets
     end
 
     # Find asset by logical path or expanded path.
-    def find_asset(*args)
-      uri, _ = resolve(*args)
+    def find_asset(*args, **options)
+      uri, _ = resolve(*args, **options)
       if uri
         load(uri)
       end

--- a/lib/sprockets/environment.rb
+++ b/lib/sprockets/environment.rb
@@ -27,8 +27,8 @@ module Sprockets
     end
     alias_method :index, :cached
 
-    def find_asset(*args)
-      cached.find_asset(*args)
+    def find_asset(*args, **options)
+      cached.find_asset(*args, **options)
     end
 
     def find_asset!(*args)

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -332,7 +332,7 @@ class SourceAssetTest < Sprockets::TestCase
   end
 
   def asset(logical_path, options = {})
-    @env.find_asset(logical_path, {pipeline: @pipeline}.merge(options))
+    @env.find_asset(logical_path, **{pipeline: @pipeline}.merge(options))
   end
 end
 
@@ -403,7 +403,7 @@ class ProcessedAssetTest < Sprockets::TestCase
   end
 
   def asset(logical_path, options = {})
-    @env.find_asset(logical_path, {pipeline: @pipeline}.merge(options))
+    @env.find_asset(logical_path, **{pipeline: @pipeline}.merge(options))
   end
 end
 
@@ -1110,7 +1110,7 @@ EOS
   end
 
   def asset(logical_path, options = {})
-    @env.find_asset(logical_path, {pipeline: @pipeline}.merge(options))
+    @env.find_asset(logical_path, **{pipeline: @pipeline}.merge(options))
   end
 
   def read(logical_path)
@@ -1245,7 +1245,7 @@ class AssetLogicalPathTest < Sprockets::TestCase
     filename = fixture_path("paths/#{path}")
     assert File.exist?(filename), "#{filename} does not exist"
     silence_warnings do
-      assert asset = @env.find_asset(filename, options), "couldn't find asset: #{filename}"
+      assert asset = @env.find_asset(filename, **options), "couldn't find asset: #{filename}"
       asset.logical_path
     end
   end
@@ -1308,7 +1308,7 @@ class AssetContentTypeTest < Sprockets::TestCase
     filename = fixture_path("paths/#{path}")
     assert File.exist?(filename), "#{filename} does not exist"
     silence_warnings do
-      assert asset = @env.find_asset(filename, options), "couldn't find asset: #{filename}"
+      assert asset = @env.find_asset(filename, **options), "couldn't find asset: #{filename}"
       asset.content_type
     end
   end

--- a/test/test_resolve.rb
+++ b/test/test_resolve.rb
@@ -262,8 +262,8 @@ class TestResolve < Sprockets::TestCase
     assert_match(/#{ random_path }/, error.message)
   end
 
-  def resolve(path, options = {})
-    uri, _ = @env.resolve(path, options)
+  def resolve(path, **options)
+    uri, _ = @env.resolve(path, **options)
     uri
   end
 end

--- a/test/test_resolve.rb
+++ b/test/test_resolve.rb
@@ -255,7 +255,7 @@ class TestResolve < Sprockets::TestCase
     @env.append_path(random_path)
 
     error = assert_raises(Sprockets::FileNotFound) do
-      uri, _ = @env.resolve!("thisfiledoesnotexistandshouldraiseerrors", {})
+      uri, _ = @env.resolve!("thisfiledoesnotexistandshouldraiseerrors", **{})
       uri
     end
 


### PR DESCRIPTION
This PR updates the code base to be Ruby 3.0 compatible.

After a very long discussion at https://bugs.ruby-lang.org/issues/14183, the Ruby core team finally decided to introduce a slight incompatibility to keyword arguments from Ruby 3.0, i.e. complete separation of keyword arguments literal from Hash literal.

With that, current Ruby master warns when a Hash object was passed in as keyword arguments.

```
$ ruby -ve 'def f(x: nil) p x; end; hash = {x: 1}; f(hash)'
ruby 2.7.0dev (2019-09-14T20:57:39Z master 1edcfd6107) [x86_64-darwin18]
-e:1: warning: The last argument is used as the keyword parameter
-e:1: warning: for `f' defined here
```

To eliminate this warning, we need to prefix a "double splat" (`**`) in order to avoid ambiguity.

```
$ ruby -ve 'def f(x: nil) p x;end; hash = {x: 1}; f(**hash)'
ruby 2.7.0dev (2019-09-14T20:57:39Z master 1edcfd6107) [x86_64-darwin18]
1
```

Also, calling `super` between methods with "last hash argument" and methods with kwargs would warn.

```
$ ruby -ve 'class A; def f(**opts) p opts; end; end; class B < A; def f(opts = {}) super; end; end; B.new.f'
ruby 2.7.0dev (2019-09-14T20:57:39Z master 1edcfd6107) [x86_64-darwin18]
-e:1: warning: The last argument is used as the keyword parameter
-e:1: warning: for `f' defined here
```

This PR includes fixes for these Ruby 2.7 warnings (this ensures that this code works with Ruby 3.0) without breaking compatibility with Ruby < 2.7.