### PR TITLE
Sort manifest entries alphabetically before choosing one

### DIFF
--- a/lib/sprockets/manifest_utils.rb
+++ b/lib/sprockets/manifest_utils.rb
@@ -38,6 +38,7 @@ module Sprockets
       entries = File.directory?(dirname) ? Dir.entries(dirname) : []
       manifest_entries = entries.select { |e| e =~ MANIFEST_RE }
       if manifest_entries.length > 1
+        manifest_entries.sort!
         logger.warn("Found multiple manifests: #{manifest_entries}. Choosing the first alphabetically: #{manifest_entries.first}")
       end
       entry = manifest_entries.first || generate_manifest_path


### PR DESCRIPTION
`Dir.entries` does not always alphabetically sort the results. Its order is OS dependent.

This patch actually sorts the entries as the warning message implies, and probably fixes the current CI failure. https://travis-ci.org/rails/sprockets/builds/583105082