### PR TITLE
Enhancments to UPGRADING doc

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -45,7 +45,7 @@ When compiling assets with Sprockets, Sprockets needs to decide which top-level 
 
 If you are using sprockets prior to 4.0, Rails will compile `application.css`, `application.js`; and *any* files found in your assets directory(ies) that are _not_ recognized as JS or CSS, but do have a filename extension. That latter was meant to apply to all your images usually in `./app/assets/images/`, but could have targetted other files as well.
 
-If you wanted to specify additional assets to deliver that were not included by this logic, for instance for a marketing page iwht its own CSS, you might add something like this:
+If you wanted to specify additional assets to deliver that were not included by this logic, for instance for a marketing page with its own CSS, you might add something like this:
 
 
 ```ruby
@@ -65,7 +65,7 @@ The default `manifest.js` created by `rails new` for the past few Rails versions
 //= link_directory ../stylesheets .css
 ```
 
-This says to include the contents of all file found in the `./app/assets/images` directory or any subdirectories. And any files recognized as CSS directly at `./app/assets/stylesheets`  or as JS at `./app/assets/javascripts` (not including subdirectories). (The JS line is not generated in Rails 6.0.0 apps, since Rails 6.0 apps do not manage JS with sprockets).
+This says to include the contents of all file found in the `./app/assets/images` directory or any subdirectories. And any files recognized as CSS directly at `./app/assets/stylesheets`  or as JS at `./app/assets/javascripts` (not including subdirectories). (The JS line is not generated in Rails 6.0 apps, since Rails 6.0 apps do not manage JS with sprockets).
 
 Since the default logic for determining top-level targets changed, you might find some files that were currently compiled by sprockets for delivery to browser no longer are. You will have to edit the `manifest.js` to specify those files.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,10 +4,25 @@ Make sure that you're running the latest Sprockets 3 release. This document is a
 
 This upgrading guide touches on:
 
+- Upgrading as a Rails dependency
 - Source Maps
 - Manifest.js
 - ES6 support
 - Deprecated processor interface in 3.x is removed in 4.x
+
+## Upgrading as a Rails Dependency
+
+Your Rails app Gemfile may have a line requiring sass-rails 5.0:
+
+    gem 'sass-rails', '~> 5.0'
+    # or
+    gem 'sass-rails', '~> 5'
+
+These will prevent upgrade to sprockets 4, if you'd like to upgrade to sprockets 4 change to:
+
+    gem 'sass-rails', '>= 5'
+
+And then run `bundle update sass-rails sprockets` to get sass-rails 6.x and sprockets 4.x.
 
 ## Source Maps
 


### PR DESCRIPTION
After spending some time figuring out some things that were confusing me in upgrading to sprockets 4 in a Rails app, i wanted to contribute them back as an enhanced UPGRADING doc.  Primarily the "manifest" related stuff; also that it can be confusing why your Rails app dependency tree won't let you upgrade to sprockets 4. 

It's hard to keep this concise, there are a lot of... parts at play, that can interact in somewhat unexpected ways, depending on what versions of what you have. But I did my best to give people what they need to understand what's changing when they upgrade. 

* I may not have gotten everything _right_, so review is encouraged. 
* I wanted to point out that different handling of "manifest.js" related functionality _can_ break your app when you update to sprockets 4; it wasn't previously clear to reader what parts of this file are... well, not _exactly_ backwards compatibilities (in sprockets anyway), but "things that can stop working and break your app" and what parts weren't; I _think_ the "manifest.js"-related stuff are the _only_ ones that are, and I tried to explain how/why. 
* I wasn't sure what to _call_ the things referenced by `link` etc, I settled on "top-level targets", but if you can give me standard terminology I'm happy to use it. (Some Rails Guide docs refer to the files like `application.js` and `application.css` as "manifests" too, oh no we don't need _another_ thing called a "manifest" in sprockets-land!). 
* I wanted to tell people where to find more docs on link/link_directory/link_tree... but it wasn't clear to me where the canonical place to find those are, I guessed README?
  * I actually am confused about the args and meanings of args to link/link_directory/link_tree too, am still investigating it, and hope to submit enhanced docs for those too... I guess to the README, if that's where they are doc'd?