### PR TITLE
TypeError Regexp#match?(nil) in Ruby Head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 
 ## Master
 
+- Fixes for Ruby 2.7 match with nil raises an exception [#646] (https://github.com/rails/sprockets/pull/646)
+
 ## 4.0.0
 
 - Fixes for Ruby 2.7 keyword arguments warnings [#625](https://github.com/rails/sprockets/pull/625)

--- a/lib/sprockets/http_utils.rb
+++ b/lib/sprockets/http_utils.rb
@@ -59,7 +59,7 @@ module Sprockets
       values.to_s.split(/\s*,\s*/).map do |part|
         value, parameters = part.split(/\s*;\s*/, 2)
         quality = 1.0
-        if md = /\Aq=([\d.]+)/.match(parameters)
+        if parameters && (md = /\Aq=([\d.]+)/.match(parameters))
           quality = md[1].to_f
         end
         [value, quality]


### PR DESCRIPTION
ruby/ruby@2a22a6b

Regexp#match?(nil) raises an exception.

https://github.com/rails/rails/pull/37504