### PR TITLE
Attempt to have consistent behaviour for `require` directive in css and scss sources

### DIFF
--- a/lib/sprockets/directive_processor.rb
+++ b/lib/sprockets/directive_processor.rb
@@ -213,7 +213,8 @@ module Sprockets
       #     //= require "./bar"
       #
       def process_require_directive(path)
-        @required << resolve(path, accept: @content_type, pipeline: :self)
+        has_extname = File.extname(path) != ""
+        @required << resolve(path, accept: has_extname ? nil : @content_type, pipeline: :self)
       end
 
       # `require_self` causes the body of the current file to be inserted

--- a/lib/sprockets/transformers.rb
+++ b/lib/sprockets/transformers.rb
@@ -101,8 +101,13 @@ module Sprockets
         config[:inverted_transformers][type].each do |subtype|
           accepts.push([subtype, q * 0.8])
         end
+        config[:transformers][type].keys.each do |parent_type|
+          config[:inverted_transformers][parent_type].each do |subtype|
+            accepts.push([subtype, q * 0.6])
+          end
+        end
       end
-      accepts
+      accepts.uniq { |(type, _q)| type }
     end
 
     # Internal: Compose multiple transformer steps into a single processor


### PR DESCRIPTION
Also js and coffee and so forth.

When source file is scss and it contains
```
= require some_dependency.css
```
require tries to resolve it to `some_dependency.scss` and not `some_dependency.css` because `process_require_directive(path)` passes source file extension as only accepted extesion. This works for css and js because css/js expand to everything that can be compiled into these formats, which is not true for scss/coffee.

First commit solves this issue by not sending `accept` option so it's figured out down below from the extname.

Now if we don't specify extname and do just
```
= require some_dependency
```
require tries to resolve it to `some_dependency.scss` and not `some_dependency.css` because `resolve_logical_path` gets list of accepted extensions using `expand_transform_accepts`. The latter function gets formats that can be compiled to accepted format, and for scss it's just scss.

Second commit tries to add more formats using `config[:transformers][type]`, so for scss it would check scss per se and everything which compiles to `config[:transformers][:scss] == 'css'`

This is kinda dirty and breaks quite a lot of tests, so I request help here from someone more experienced with logic of the lib.

related to #647 