### PR TITLE
Fix deprecation warning for Ruby 2.7 in base.rb.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 
 ## Master
 
+- Fix for Ruby 2.7 keyword arguments warning in `base.rb`. [#660](https://github.com/rails/sprockets/pull/660)
+
 ## 4.0.0
 
 - Fixes for Ruby 2.7 keyword arguments warnings [#625](https://github.com/rails/sprockets/pull/625)

--- a/lib/sprockets/base.rb
+++ b/lib/sprockets/base.rb
@@ -115,8 +115,8 @@ module Sprockets
     #
     #     environment['application.js']
     #
-    def [](*args)
-      find_asset(*args)
+    def [](*args, **options)
+      find_asset(*args, **options)
     end
 
     # Find asset by logical path or expanded path.


### PR DESCRIPTION
Resolves #659. This causes a new deprecation warning in sprockets-rails, but I'm opening a PR in sprockets-rails to fix that next.