### PR TITLE
Fix cache key for coffee script processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 - Allow assets already fingerprinted to be served through `Sprockets::Server`
 - Do not fingerprint files that already contain a valid digest in their name
 - Remove remaining support for Ruby < 2.4.[#672](https://github.com/rails/sprockets/pull/672)
+- Fix cache key for coffee script processor to be dependent on the filename [#670](https://github.com/rails/sprockets/pull/670)
 
 ## 4.0.2
 

--- a/lib/sprockets/coffee_script_processor.rb
+++ b/lib/sprockets/coffee_script_processor.rb
@@ -20,7 +20,7 @@ module Sprockets
     def self.call(input)
       data = input[:data]
 
-      js, map = input[:cache].fetch([self.cache_key, data]) do
+      js, map = input[:cache].fetch([self.cache_key, data, input[:filename]]) do
         result = Autoload::CoffeeScript.compile(
           data,
           sourceMap: "v3",

--- a/test/test_coffee_script_processor.rb
+++ b/test/test_coffee_script_processor.rb
@@ -28,6 +28,26 @@ class TestCoffeeScriptProcessor < MiniTest::Test
     assert_equal ["squared.source.coffee"], result[:map]["sources"]
   end
 
+  def test_changing_map_sources_for_files_with_same_content
+    input = {
+      load_path: File.expand_path("../fixtures", __FILE__),
+      filename: File.expand_path("../fixtures/squared.coffee", __FILE__),
+      content_type: 'application/javascript',
+      environment: @env,
+      data: "square = (n) -> n * n",
+      name: 'squared',
+      cache: Sprockets::Cache.new,
+      metadata: { mapping: [] }
+    }
+    result = Sprockets::CoffeeScriptProcessor.call(input)
+    assert_equal ["squared.source.coffee"], result[:map]["sources"]
+
+    input[:filename] = File.expand_path("../fixtures/peterpan.coffee", __FILE__)
+
+    result = Sprockets::CoffeeScriptProcessor.call(input)
+    assert_equal ["peterpan.source.coffee"], result[:map]["sources"]
+  end
+
   def test_cache_key
     assert Sprockets::CoffeeScriptProcessor.cache_key
   end


### PR DESCRIPTION
The current implementation leads to a problem with the generation of the sourcemap. Two files with a different name but the same content (e.g. empty files) have different sourcemaps. But the current implementation returns the v3SourceMap of the first file for every subsequent call from the cache. So the commit changes the cache key to be dependent on the filename.