### PR TITLE
Drop support for Ruby 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 ## Master
 
 - Fix for Ruby 2.7 keyword arguments warning in `base.rb`. [#660](https://github.com/rails/sprockets/pull/660)
+- Remove remaining support for Ruby < 2.4.[#672](https://github.com/rails/sprockets/pull/672)
 
 ## 4.0.0
 

--- a/lib/sprockets/digest_utils.rb
+++ b/lib/sprockets/digest_utils.rb
@@ -68,18 +68,8 @@ module Sprockets
       Encoding => ->(val, digest) {
         digest << 'Encoding'.freeze
         digest << val.name
-      },
+      }
     }
-    if 0.class != Integer # Ruby < 2.4
-      ADD_VALUE_TO_DIGEST[Fixnum] = ->(val, digest) {
-        digest << 'Integer'.freeze
-        digest << val.to_s
-      }
-      ADD_VALUE_TO_DIGEST[Bignum] = ->(val, digest) {
-        digest << 'Integer'.freeze
-        digest << val.to_s
-      }
-    end
 
     ADD_VALUE_TO_DIGEST.compare_by_identity.rehash
 

--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -291,7 +291,7 @@ module Sprockets
       # Internal: Retrieves an asset based on its digest
       #
       # unloaded - An UnloadedAsset
-      # limit    - A Integer which sets the maximum number of versions of "histories"
+      # limit    - An Integer which sets the maximum number of versions of "histories"
       #            stored in the cache
       #
       # This method attempts to retrieve the last `limit` number of histories of an asset

--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -289,7 +289,7 @@ module Sprockets
       # Internal: Retrieves an asset based on its digest
       #
       # unloaded - An UnloadedAsset
-      # limit    - A Fixnum which sets the maximum number of versions of "histories"
+      # limit    - A Integer which sets the maximum number of versions of "histories"
       #            stored in the cache
       #
       # This method attempts to retrieve the last `limit` number of histories of an asset

--- a/lib/sprockets/processor_utils.rb
+++ b/lib/sprockets/processor_utils.rb
@@ -118,8 +118,9 @@ module Sprockets
       Symbol,
       TrueClass,
       FalseClass,
-      NilClass
-    ] + (0.class == Integer ? [Integer] : [Bignum, Fixnum])).freeze
+      NilClass,
+      Integer
+    ]).freeze
 
     # Internal: Set of all nested compound metadata types that can nest values.
     VALID_METADATA_COMPOUND_TYPES = Set.new([


### PR DESCRIPTION
Fixnum and Bignum were unified into Integer since Ruby 2.4 and now are deprecated, even [Ruby 2.4 is now EOL](https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/) and is not supported since https://github.com/rails/sprockets/pull/604.