### PR TITLE
[Bug Fix] x_sprockets_linecount missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 ## Master
 
 - Fix for Ruby 2.7 keyword arguments warning in `base.rb`. [#660](https://github.com/rails/sprockets/pull/660)
+- Fix for when `x_sprockets_linecount` is missing from a source map.
+
 
 ## 4.0.0
 

--- a/lib/sprockets/source_map_utils.rb
+++ b/lib/sprockets/source_map_utils.rb
@@ -78,7 +78,7 @@ module Sprockets
       offset = 0
       if a["sections"].count != 0 && !a["sections"].last["map"]["mappings"].empty?
         last_line_count = a["sections"].last["map"].delete("x_sprockets_linecount")
-        offset += last_line_count
+        offset += last_line_count || 1
 
         last_offset = a["sections"].last["offset"]["line"]
         offset += last_offset


### PR DESCRIPTION
When I attempted to upgrade an application to sprockets 4.0 I hit the bug described by https://github.com/rails/sprockets/issues/657#issuecomment-566231862. The application is in a private github repo so I can't link it here. 

After a bit of digging it appears that this might be related to https://github.com/rails/sprockets/commit/033c6b693b2cd6e0a61735f781409d35c57b1f7e. 

I've added a test and what I believe is a fix. Though I'm not sure if `last_line_count  || 1` should be `last_line_count || 0` or if this is actually the wrong place to put the fix.


cc: @byroot  