### PR TITLE
Include more information in sprockets upgrade docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 
 - Fix for Ruby 2.7 keyword arguments warning in `base.rb`. [#660](https://github.com/rails/sprockets/pull/660)
 - Fix for when `x_sprockets_linecount` is missing from a source map.
+- Documentation updates
 
 
 ## 4.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ git push origin my-feature-branch
 
 #### Make a Pull Request
 
-Go to https://github.com/contributor/sprockets and select your feature branch. Click the 'Pull Request' button and fill out the form. Pull requests are usually reviewed within a few days.
+Go to https://github.com/rails/sprockets/network/members and select your feature branch. Click the 'Pull Request' button and fill out the form. Pull requests are usually reviewed within a few days.
 
 #### Rebase
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -55,7 +55,7 @@ config.assets.precompile += ["marketing.css"]
 
 If you are using Sprockets 4, Rails changes its default logic for determining top-level targets.  It will now use _only_ a file at `./app/assets/config/manifest.js` for specifying top-level targets; this file may already exist in your Rails app (although Rails only starts automatically using it once you are using sprockets 4), if not you should create it.
 
-The `manifest.js` file is meant to specify which files to use as a top-level target using sprockets methods `link`, `link_directory`, and `link_tree`.
+The `manifest.js` file is meant to specify which files to use as a top-level target using sprockets methods [`link`](README.md#link), [`link_directory`](README.md#link_directory), and [link_tree](README.md#link_tree).
 
 The default `manifest.js` created by `rails new` for the past few Rails versions looks like:
 
@@ -69,9 +69,9 @@ This is meant to include the contents of all files found in the `./app/assets/im
 
 Since the default logic for determining top-level targets changed, you might find some files that were currently compiled by sprockets for delivery to browser no longer are. You will have to edit the `manifest.js` to specify those files.
 
-You may also find that some files that were *not* previously compiled as top-level targets are now. For instance, if your existing app has any js files directly at `./app/assets/javascripts` or css/scss files `./app/assets/stylesheets`, Rails with Sprockets 4 will now compile them as top-level targets. Since they were not previously treated as such, you probably don't mean them to be; if they are .scss partials referencing variables meant to be defined in other files, it may even result in an error message that looks like `Undefined variable: $some_variable`.
+You may also find that some files that were *not* previously compiled as top-level targets are now. For instance, if your existing app has any js files directly at `./app/assets/javascripts/` or css/scss files `./app/assets/stylesheets/`, Rails with Sprockets 4 will now compile them as top-level targets. Since they were not previously treated as such, you probably don't mean them to be; if they are .scss partials referencing variables meant to be defined in other files, it may even result in an error message that looks like `Undefined variable: $some_variable`.
 
-To correct this, you can move these files to some _subdirectory_ of `./app/assets/stylesheets` or `javascripts`; or you can change the `manifest.js` to be more like how Rails with Sprockets 3 works, linking only the specific `application` files as top-level targets:
+To correct this, you can move these files to some _subdirectory_ of `./app/assets/stylesheets/` or `./app/assets/javascripts/`; or you can change the `manifest.js` to be more like how Rails with Sprockets 3 works, linking only the specific `application` files as top-level targets:
 
 ```js
 //= link_tree ../images
@@ -88,7 +88,15 @@ Now you'll be able to use a `<%= stylesheet_link_tag "application" %>` or `<%= s
 
 If you have additional non-standard files you need to be top-level targets, instead of using `config.assets.precompile`, you can use `link`, `link_directory`, and `link_tree` directives in the `manifest.js`.
 
-Existing `config.assets.precompile` settings will still work for string values (although it is discouraged), but if you were previously using regexp or proc values, they won't work at all with Sprockets 4, and if you try you'll get an exception raised that looks like `NoMethodError: undefined method 'start_with?'`
+Existing `config.assets.precompile` settings will still work for string values. While this is discouraged, any logical instructions will need to remain, for example:
+
+```ruby
+if Rails.env.development?
+  Rails.application.config.assets.precompile += %w(development-only-file.css)
+end
+```
+
+However, if you were previously using regexp or proc values, they won't work at all with Sprockets 4, and if you try you'll get an exception raised that looks like `NoMethodError: undefined method 'start_with?'`. 
 
 Some assets will be compiled as top-level assets when they are referenced from inside of another asset. For example, the `asset_url` erb helper will automatically link assets:
 


### PR DESCRIPTION
Some additions while I was working on the Sprockets 4.0 upgrade

1. Include links to README explaining more about link, link_tree and link_directory methods
2. Added trailing `/` to highlight the directory structure for files that will be included as top-level targets
3. Addition of when you might need to leave `Rails.application.config.assets.precompile` configs, instead of moving them to `manifest.js`