### PR TITLE
Fix asset integrity not compliant with Subresource integrity RFC:

### DIFF
--- a/lib/sprockets/asset.rb
+++ b/lib/sprockets/asset.rb
@@ -123,9 +123,14 @@ module Sprockets
       metadata[:digest]
     end
 
+    # Private: Return the version of the environment where the asset was generated.
+    def environment_version
+      metadata[:environment_version]
+    end
+
     # Public: Returns String hexdigest of source.
     def hexdigest
-      DigestUtils.pack_hexdigest(digest)
+      DigestUtils.pack_hexdigest(environment_version + digest)
     end
 
     # Pubic: ETag String of Asset.

--- a/lib/sprockets/exporters/base.rb
+++ b/lib/sprockets/exporters/base.rb
@@ -69,4 +69,3 @@ module Sprockets
     end
   end
 end
-

--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -195,14 +195,16 @@ module Sprockets
           source = result.delete(:data)
           metadata = result
           metadata[:charset] = source.encoding.name.downcase unless metadata.key?(:charset)
-          metadata[:digest]  = digest(self.version + source)
+          metadata[:digest]  = digest(source)
           metadata[:length]  = source.bytesize
+          metadata[:environment_version] = self.version
         else
           dependencies << build_file_digest_uri(unloaded.filename)
           metadata = {
             digest: file_digest(unloaded.filename),
             length: self.stat(unloaded.filename).size,
-            dependencies: dependencies
+            dependencies: dependencies,
+            environment_version: self.version,
           }
         end
 

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -435,6 +435,12 @@ class BundledAssetTest < Sprockets::TestCase
       @asset.digest_path
   end
 
+  test "environment version" do
+    @env.version = "v1"
+
+    assert_equal "v1", @env['application.js'].environment_version
+  end
+
   test "content type" do
     assert_equal "application/javascript", @asset.content_type
   end

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -720,6 +720,12 @@ class TestEnvironment < Sprockets::TestCase
     assert_equal 2, asset.metadata[:selector_count]
   end
 
+  test "changing version changes the digest_path of the asset" do
+    old_asset_digest = @env["gallery.js"].digest_path
+    @env.version = 'v2'
+    assert old_asset_digest != @env["gallery.js"].digest_path
+  end
+
   test "changing version changes the digest of the asset" do
     old_asset_digest = @env["gallery.js"].hexdigest
     @env.version = 'v2'

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -86,6 +86,7 @@ class TestManifest < Sprockets::TestCase
   end
 
   test "compile asset" do
+    @env.version = '1.1.2'
     manifest = Sprockets::Manifest.new(@env, File.join(@dir, 'manifest.json'))
 
     digest_path = @env['application.js'].digest_path
@@ -325,6 +326,29 @@ class TestManifest < Sprockets::TestCase
     assert_equal main_digest_path, data['assets']['explore-link.js']
     assert_equal dep_digest_path, data['assets']['gallery-link.js']
     assert_equal subdep_digest_path, data['assets']['gallery.js']
+  end
+
+  test "recompile asset when environment version is changed" do
+    manifest = Sprockets::Manifest.new(@env, File.join(@dir, 'manifest.json'))
+
+    digest_path = @env['application.js'].digest_path
+    filename = fixture_path('default/application.coffee')
+
+    sandbox filename do
+      assert !File.exist?("#{@dir}/#{digest_path}"), Dir["#{@dir}/*"].inspect
+
+      manifest.compile('application.js')
+
+      assert File.exist?("#{@dir}/manifest.json")
+      assert File.exist?("#{@dir}/#{digest_path}")
+
+      @env.version = '1.1.3'
+      new_digest_path = @env['application.js'].digest_path
+
+      assert !File.exist?("#{@dir}/#{new_digest_path}"), Dir["#{@dir}/*"].inspect
+      manifest.compile('application.js')
+      assert File.exist?("#{@dir}/#{new_digest_path}")
+    end
   end
 
   test "recompile asset" do

--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -345,7 +345,7 @@ class TestSourceMaps < Sprockets::TestCase
     filename = fixture_path('source-maps/sub/a.js')
     sandbox filename do
       expected = JSON.parse(@env.find_asset('sub/directory.js.map').source).tap do |map|
-        index = map["sections"].find_index { |s| /sub\/a\.js$/ =~ s["map"]["file"] }
+        index = map["sections"].find_index { |s| s["map"]["file"].end_with?('sub/a.js') }
         map["sections"][index]["map"]["mappings"] << ";AACA"
         map["sections"][(index+1)..-1].each do |s|
           s["offset"]["line"] += 1


### PR DESCRIPTION
Fix asset integrity not compliant with Subresource integrity RFC:

Few years ago, in 64fadf908, a change was introduced and modified the
digest of an asset. The returned value was the result of computing the
asset's content AND the sprockets environment version.
This fix was made in order to properly bust the asset cache when
the sprockets environment version was modified.

As a result of this change, the `Asset#digest` which is used to look
for the asset's integrity doesn't comply with the RFC as the returned
value should be hash representing the asset's content only.

More detail in #555

Based on feedbacks, I have reverted the change that modifies the
`Asset#digest` to remain a pure function of the digest.
I however modified the `digest_path` so that the hash represents the
sprockets environment version AND the asset's content.

The main difference in the manifest is that the digest_path is no
longer the same as the digest

Before
```json
{"files":{"application-a2f9b346fff9b3e6ea8e29c613dd3b0abdec1207fb111ca10acfb249ac5ace1c.js":{digest":"a2f9b346fff9b3e6ea8e29c613dd3b0abdec1207fb111ca10acfb249ac5ace1c"}}
```

After
```json
{"files":{"application-dsadsad91984391rfasfasf87f8asfasfdasd81dsjqisdasds87dasdas.js":{digest":"a2f9b346fff9b3e6ea8e29c613dd3b0abdec1207fb111ca10acfb249ac5ace1c"}}
```

Co-authored-by: Yuri S. <fudoshiki.ari@gmail.com>

cc/ @rafaelfranca @airhorns @casperisfine @etiennebarrie