### PR TITLE
Make environment version affect digest of assets with no preprocessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 
 - Fix for Ruby 2.7 keyword arguments warning in `base.rb`. [#660](https://github.com/rails/sprockets/pull/660)
 - Fix for when `x_sprockets_linecount` is missing from a source map.
+- Changing the version now busts the digest of assets with no preprocessor (eg. images) [#680](https://github.com/rails/sprockets/pull/680)
 
 
 ## 4.0.0

--- a/lib/sprockets/loader.rb
+++ b/lib/sprockets/loader.rb
@@ -200,7 +200,7 @@ module Sprockets
         else
           dependencies << build_file_digest_uri(unloaded.filename)
           metadata = {
-            digest: file_digest(unloaded.filename),
+            digest: digest(self.version + file_digest(unloaded.filename)),
             length: self.stat(unloaded.filename).size,
             dependencies: dependencies
           }

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -188,7 +188,7 @@ class BinaryStaticAssetTest < Sprockets::TestCase
   end
 
   test "digest path" do
-    assert_equal "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png",
+    assert_equal "POW-807d145b64b285d67ade03dcea1b193440650f62d1296a42deddcefcfa5ec6c6.png",
       @asset.digest_path
   end
 
@@ -209,19 +209,19 @@ class BinaryStaticAssetTest < Sprockets::TestCase
   end
 
   test "source digest" do
-    assert_equal [29, 162, 229, 157, 247, 93, 51, 216, 183, 76, 61, 113, 254, 237, 230, 152, 242, 3, 241, 54, 81, 44, 186, 171, 32, 198, 138, 91, 222, 189, 88, 0], @asset.digest.bytes.to_a
+    assert_equal [128, 125, 20, 91, 100, 178, 133, 214, 122, 222, 3, 220, 234, 27, 25, 52, 64, 101, 15, 98, 209, 41, 106, 66, 222, 221, 206, 252, 250, 94, 198, 198], @asset.digest.bytes.to_a
   end
 
   test "source hexdigest" do
-    assert_equal "1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800", @asset.hexdigest
+    assert_equal "807d145b64b285d67ade03dcea1b193440650f62d1296a42deddcefcfa5ec6c6", @asset.hexdigest
   end
 
   test "source base64digest" do
-    assert_equal "HaLlnfddM9i3TD1x/u3mmPID8TZRLLqrIMaKW969WAA=", @asset.base64digest
+    assert_equal "gH0UW2SyhdZ63gPc6hsZNEBlD2LRKWpC3t3O/PpexsY=", @asset.base64digest
   end
 
   test "integrity" do
-    assert_equal "sha256-HaLlnfddM9i3TD1x/u3mmPID8TZRLLqrIMaKW969WAA=", @asset.integrity
+    assert_equal "sha256-gH0UW2SyhdZ63gPc6hsZNEBlD2LRKWpC3t3O/PpexsY=", @asset.integrity
   end
 
   test "asset is fresh if its mtime is changed but its contents is the same" do
@@ -299,7 +299,7 @@ class SourceAssetTest < Sprockets::TestCase
   end
 
   test "digest path" do
-    assert_equal "application.source-6ae801e02813bf209a84a89b8c5b5edf5eb770ca9e4253c56834c08a2fc5dbea.js",
+    assert_equal "application.source-403cc6173410e12cc40dbd17c89311d491e12ae1bf1434d18e71b82f4aca8d23.js",
       @asset.digest_path
   end
 
@@ -312,19 +312,19 @@ class SourceAssetTest < Sprockets::TestCase
   end
 
   test "source digest" do
-    assert_equal [106, 232, 1, 224, 40, 19, 191, 32, 154, 132, 168, 155, 140, 91, 94, 223, 94, 183, 112, 202, 158, 66, 83, 197, 104, 52, 192, 138, 47, 197, 219, 234], @asset.digest.bytes.to_a
+    assert_equal [64, 60, 198, 23, 52, 16, 225, 44, 196, 13, 189, 23, 200, 147, 17, 212, 145, 225, 42, 225, 191, 20, 52, 209, 142, 113, 184, 47, 74, 202, 141, 35], @asset.digest.bytes.to_a
   end
 
   test "source hexdigest" do
-    assert_equal "6ae801e02813bf209a84a89b8c5b5edf5eb770ca9e4253c56834c08a2fc5dbea", @asset.hexdigest
+    assert_equal "403cc6173410e12cc40dbd17c89311d491e12ae1bf1434d18e71b82f4aca8d23", @asset.hexdigest
   end
 
   test "source base64digest" do
-    assert_equal "augB4CgTvyCahKibjFte3163cMqeQlPFaDTAii/F2+o=", @asset.base64digest
+    assert_equal "QDzGFzQQ4SzEDb0XyJMR1JHhKuG/FDTRjnG4L0rKjSM=", @asset.base64digest
   end
 
   test "integrity" do
-    assert_equal "sha256-augB4CgTvyCahKibjFte3163cMqeQlPFaDTAii/F2+o=", @asset.integrity
+    assert_equal "sha256-QDzGFzQQ4SzEDb0XyJMR1JHhKuG/FDTRjnG4L0rKjSM=", @asset.integrity
   end
 
   test "to_s" do
@@ -885,7 +885,7 @@ class BundledAssetTest < Sprockets::TestCase
 
 define("application.js", "application-955b2dddd0d1449b1c617124b83b46300edadec06d561104f7f6165241b31a94.js")
 define("application.css", "application-46d50149c56fc370805f53c29f79b89a52d4cc479eeebcdc8db84ab116d7ab1a.css")
-define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png");
+define("POW.png", "POW-807d145b64b285d67ade03dcea1b193440650f62d1296a42deddcefcfa5ec6c6.png");
     EOS
     assert_equal [
       "file://#{fixture_path_for_uri("asset/POW.png")}?type=image/png&id=xxx",
@@ -903,7 +903,7 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
 
 define("application.js", "application-955b2dddd0d1449b1c617124b83b46300edadec06d561104f7f6165241b31a94.js")
 define("application.css", "application-46d50149c56fc370805f53c29f79b89a52d4cc479eeebcdc8db84ab116d7ab1a.css")
-define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png");
+define("POW.png", "POW-807d145b64b285d67ade03dcea1b193440650f62d1296a42deddcefcfa5ec6c6.png");
     EOS
 
     assert_equal [
@@ -985,7 +985,7 @@ define("POW.png", "POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bd
     assert asset = asset("link/asset_uri.css")
     assert_equal <<-EOS, asset.to_s
 .logo {
-  background: url(POW-1da2e59df75d33d8b74c3d71feede698f203f136512cbaab20c68a5bdebd5800.png);
+  background: url(POW-807d145b64b285d67ade03dcea1b193440650f62d1296a42deddcefcfa5ec6c6.png);
 }
     EOS
     assert_equal [

--- a/test/test_environment.rb
+++ b/test/test_environment.rb
@@ -720,10 +720,16 @@ class TestEnvironment < Sprockets::TestCase
     assert_equal 2, asset.metadata[:selector_count]
   end
 
-  test "changing version changes the digest of the asset" do
+  test "changing version changes the digest of the asset (with preprocessor)" do
     old_asset_digest = @env["gallery.js"].hexdigest
     @env.version = 'v2'
     assert old_asset_digest != @env["gallery.js"].hexdigest
+  end
+
+  test "changing version changes the digest of the asset (no preprocessor)" do
+    old_asset_digest = @env["blank.gif"].hexdigest
+    @env.version = 'v2'
+    assert old_asset_digest != @env["blank.gif"].hexdigest
   end
 
   test "bundled asset is stale if its mtime is updated or deleted" do


### PR DESCRIPTION
Disclaimer: I did this pretty quickly with no prior knowledge of Sprockets internals.

I followed the logic of #404 and created an equivalent test in `test_environment.rb` using `"blank.gif"` instead of `"gallery.js"`, which was failing. Then I realized that PR clearly covered the `if processors.any?` branch only and not the `else`. I implemented what seemed to be the closest and most inoffensive change (doesn’t affect the implementation of `file_digest` or similar), which got my test to pass. Then I blindly fixed the failing tests in `test_asset.rb`, and here we are.