### PR TITLE
Get rid off undefined method `start_with?' for nil:NilClass error

### DIFF
--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -162,7 +162,7 @@ module Sprockets
     def split_subpath(path, subpath)
       return "" if path == subpath
       path = File.join(path, ''.freeze)
-      if subpath.start_with?(path)
+      if subpath and subpath.start_with?(path)
         subpath[path.length..-1]
       else
         nil

--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -162,7 +162,7 @@ module Sprockets
     def split_subpath(path, subpath)
       return "" if path == subpath
       path = File.join(path, ''.freeze)
-      if subpath and subpath.start_with?(path)
+      if subpath&.start_with?(path)
         subpath[path.length..-1]
       else
         nil

--- a/test/test_path_utils.rb
+++ b/test/test_path_utils.rb
@@ -109,6 +109,8 @@ class TestPathUtils < MiniTest::Test
     subpath = File.expand_path("../fixtures/default/app/application.js", __FILE__)
     assert_equal "app/application.js", split_subpath(path, subpath)
 
+    assert_equal nil, split_subpath(path, nil)
+
     subpath = File.expand_path("../fixtures/default", __FILE__)
     assert_equal "", split_subpath(path, subpath)
 


### PR DESCRIPTION
I had following error when using sprockets (v. 4) with jekyll (ver 4.1). 

```
Traceback (most recent call last):
	29: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:324:in `block in create_worker'
	28: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:324:in `catch'
	27: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:325:in `block (2 levels) in create_worker'
	26: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:325:in `loop'
	25: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:342:in `block (3 levels) in create_worker'
	24: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:353:in `run_task'
	23: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/promise.rb:563:in `block in realize'
	22: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/executor/safe_task_executor.rb:19:in `execute'
	21: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:41:in `synchronize'
	20: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:41:in `synchronize'
	19: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/synchronization/mutex_lockable_object.rb:41:in `block in synchronize'
	18: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/executor/safe_task_executor.rb:24:in `block in execute'
	17: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/promise.rb:533:in `block in on_fulfill'
	16: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/sprockets-4.0.1/lib/sprockets/manifest.rb:198:in `block (3 levels) in compile'
	15: from /Users/dakolech/.rvm/gems/ruby-2.7.0/bundler/gems/jekyll-assets-7ac3a1fde304/lib/jekyll/assets/plugins/srcmap/writer.rb:23:in `call'
	14: from /Users/dakolech/.rvm/gems/ruby-2.7.0/bundler/gems/jekyll-assets-7ac3a1fde304/lib/jekyll/assets/plugins/srcmap/writer.rb:150:in `write_src!'
	13: from /Users/dakolech/.rvm/gems/ruby-2.7.0/bundler/gems/jekyll-assets-7ac3a1fde304/lib/jekyll/assets/plugins/srcmap/writer.rb:150:in `each'
	12: from /Users/dakolech/.rvm/gems/ruby-2.7.0/bundler/gems/jekyll-assets-7ac3a1fde304/lib/jekyll/assets/plugins/srcmap/writer.rb:151:in `block in write_src!'
	11: from /Users/dakolech/.rvm/gems/ruby-2.7.0/bundler/gems/jekyll-assets-7ac3a1fde304/lib/jekyll/assets/env.rb:60:in `find_asset'
	10: from /Users/dakolech/.rvm/gems/ruby-2.7.0/bundler/gems/jekyll-assets-7ac3a1fde304/lib/jekyll/assets/logger.rb:22:in `with_timed_logging'
	 9: from /Users/dakolech/.rvm/gems/ruby-2.7.0/bundler/gems/jekyll-assets-7ac3a1fde304/lib/jekyll/assets/env.rb:61:in `block in find_asset'
	 8: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/sprockets-4.0.1/lib/sprockets/environment.rb:31:in `find_asset'
	 7: from /Users/dakolech/.rvm/gems/ruby-2.7.0/bundler/gems/jekyll-assets-7ac3a1fde304/lib/jekyll/assets/patches/cached_environment.rb:37:in `block (2 levels) in <module:CachedEnvironment>'
	 6: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/sprockets-4.0.1/lib/sprockets/base.rb:79:in `find_asset'
	 5: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/sprockets-4.0.1/lib/sprockets/resolve.rb:32:in `resolve'
	 4: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/sprockets-4.0.1/lib/sprockets/resolve.rb:122:in `resolve_relative_path'
	 3: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/sprockets-4.0.1/lib/sprockets/path_utils.rb:179:in `paths_split'
	 2: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/sprockets-4.0.1/lib/sprockets/path_utils.rb:179:in `each'
	 1: from /Users/dakolech/.rvm/gems/ruby-2.7.0/gems/sprockets-4.0.1/lib/sprockets/path_utils.rb:180:in `block in paths_split'
/Users/dakolech/.rvm/gems/ruby-2.7.0/gems/sprockets-4.0.1/lib/sprockets/path_utils.rb:165:in `split_subpath': undefined method `start_with?' for nil:NilClass (NoMethodError)
```