### PR TITLE
Use character for #delete_prefix instead of RegEx

### DIFF
--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -391,7 +391,7 @@ class TestSasscSourceMaps < Sprockets::TestCase
     assert_equal "sass/main.css.map", asset.logical_path
     assert_equal "application/css-sourcemap+json", asset.content_type
     assert_equal [
-      "file:///#{ fixture_path('source-maps/sass/main.scss').delete_prefix(/\A\//, '') }?type=text/scss&pipeline=source"
+      "file:///#{ fixture_path('source-maps/sass/main.scss').delete_prefix('/') }?type=text/scss&pipeline=source"
     ], normalize_uris(asset.links)
 
     assert map = JSON.parse(asset.source)


### PR DESCRIPTION
This will make the pipeline green again so `4.0.2` can get released.

https://github.com/rails/sprockets/commit/53efbb87d15d5ee1ef40b31506ce38acc9868c1f changed a call from `sub` to `delete_prefix` but left the same `sub` parameters instead of switching to just using a single character.