### PR TITLE
Fix: Path with spaces throws a bad URI(is not URI?) error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source "https://rubygems.org"
 gemspec
 
 gem "rack", github: 'rack/rack'
-
-gem 'pry', '~> 0.13.1'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 gemspec
 
 gem "rack", github: 'rack/rack'
+
+gem 'pry', '~> 0.13.1'

--- a/lib/sprockets/uri_utils.rb
+++ b/lib/sprockets/uri_utils.rb
@@ -54,8 +54,6 @@ module Sprockets
     #
     # Returns [scheme, host, path, query].
     def split_file_uri(uri)
-      # scheme, _, host, _, _, path, _, query, _ = URI.split(uri)
-
       # We need to ensure that the URI being split is always escaped
       scheme, _, host, _, _, path, _, query, _ = URI.split(escaped_uri(uri))
 

--- a/lib/sprockets/uri_utils.rb
+++ b/lib/sprockets/uri_utils.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'uri'
+require 'pry'
 
 module Sprockets
   # Internal: Asset URI related parsing utilities. Mixed into Environment.
@@ -43,6 +44,8 @@ module Sprockets
     #
     # Returns [scheme, host, path, query].
     def split_file_uri(uri)
+      # We need to parse out any potential spaces in the path
+      # uri = URI::Generic::DEFAULT_PARSER.escape(uri)
       scheme, _, host, _, _, path, _, query, _ = URI.split(uri)
 
       path = URI::Generic::DEFAULT_PARSER.unescape(path)

--- a/lib/sprockets/uri_utils.rb
+++ b/lib/sprockets/uri_utils.rb
@@ -38,15 +38,27 @@ module Sprockets
       URI::Generic.new(scheme, userinfo, host, port, registry, path, opaque, query, fragment).to_s
     end
 
+    # Escaped URI: Return URI regardless of whether the string is initially escaped.
+    #              If the initial URI is escaped, then that gets returned. If not, then it is escaped.
+    #
+    # uri - String uri
+    #
+    # Returns uri
+    def escaped_uri(uri)
+      return uri if uri == URI::Generic::DEFAULT_PARSER.escape(URI::Generic::DEFAULT_PARSER.unescape(uri))
+      URI::Generic::DEFAULT_PARSER.escape(uri)
+    end
+
     # Internal: Parse file: URI into component parts.
     #
     # uri - String uri
     #
     # Returns [scheme, host, path, query].
     def split_file_uri(uri)
-      # We need to parse out any potential spaces in the path
-      # uri = URI::Generic::DEFAULT_PARSER.escape(uri)
-      scheme, _, host, _, _, path, _, query, _ = URI.split(uri)
+      # scheme, _, host, _, _, path, _, query, _ = URI.split(uri)
+
+      # We need to ensure that the URI being split is always escaped
+      scheme, _, host, _, _, path, _, query, _ = URI.split(escaped_uri(uri))
 
       path = URI::Generic::DEFAULT_PARSER.unescape(path)
       path.force_encoding(Encoding::UTF_8)

--- a/lib/sprockets/uri_utils.rb
+++ b/lib/sprockets/uri_utils.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'uri'
-require 'pry'
 
 module Sprockets
   # Internal: Asset URI related parsing utilities. Mixed into Environment.

--- a/test/test_loader.rb
+++ b/test/test_loader.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'sprockets_test'
 require 'pathname'
-require 'pry'
 
 class TestLoader < Sprockets::TestCase
   def setup
@@ -51,8 +50,7 @@ class TestLoader < Sprockets::TestCase
   test 'load uri with index alias' do
     filename = fixture_path('default/coffee/index.js')
     index_alias = fixture_path('default/coffee.js')
-    # binding.pry
-    assert asset = @env.load("file://#{uri_path(filename)}?type=application/javascript&index_alias=#{Rack::Utils.escape(index_alias)}")
+    assert asset = @env.load("file://#{uri_path(filename)}?type=application/javascript&index_alias=#{index_alias}")
     assert_equal filename, asset.filename, asset.inspect
     assert_equal 'coffee.js', asset.logical_path, asset.inspect
     assert_equal fixture_path('default'), asset.to_hash[:load_path], asset.inspect

--- a/test/test_loader.rb
+++ b/test/test_loader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'sprockets_test'
 require 'pathname'
+require 'pry'
 
 class TestLoader < Sprockets::TestCase
   def setup
@@ -50,6 +51,7 @@ class TestLoader < Sprockets::TestCase
   test 'load uri with index alias' do
     filename = fixture_path('default/coffee/index.js')
     index_alias = fixture_path('default/coffee.js')
+    # binding.pry
     assert asset = @env.load("file://#{uri_path(filename)}?type=application/javascript&index_alias=#{Rack::Utils.escape(index_alias)}")
     assert_equal filename, asset.filename, asset.inspect
     assert_equal 'coffee.js', asset.logical_path, asset.inspect

--- a/test/test_uri_utils.rb
+++ b/test/test_uri_utils.rb
@@ -45,7 +45,6 @@ class TestURIUtils < MiniTest::Test
     parts = split_file_uri("file:///etc/fstab")
     assert_equal ['file', nil, '/etc/fstab', nil], parts
 
-    # binding.pry
     parts = split_file_uri("file:///usr/local/bin/ruby%20on%20rails")
     assert_equal ['file', nil, '/usr/local/bin/ruby on rails', nil], parts
 

--- a/test/test_uri_utils.rb
+++ b/test/test_uri_utils.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'minitest/autorun'
 require 'sprockets/uri_utils'
+require 'pry'
 
 class TestURIUtils < MiniTest::Test
   include Sprockets::URIUtils
@@ -35,12 +36,16 @@ class TestURIUtils < MiniTest::Test
   end
 
   def test_split_file_uri
+    parts = split_file_uri("file:///usr/Company Name Dropbox/local/bin/myapp/assets")
+    assert_equal ['file', nil, '/usr/Company Name Dropbox/local/bin/myapp/assets', nil], parts
+
     parts = split_file_uri("file://localhost/etc/fstab")
     assert_equal ['file', 'localhost', '/etc/fstab', nil], parts
 
     parts = split_file_uri("file:///etc/fstab")
     assert_equal ['file', nil, '/etc/fstab', nil], parts
 
+    # binding.pry
     parts = split_file_uri("file:///usr/local/bin/ruby%20on%20rails")
     assert_equal ['file', nil, '/usr/local/bin/ruby on rails', nil], parts
 

--- a/test/test_uri_utils.rb
+++ b/test/test_uri_utils.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'minitest/autorun'
 require 'sprockets/uri_utils'
-require 'pry'
 
 class TestURIUtils < MiniTest::Test
   include Sprockets::URIUtils


### PR DESCRIPTION
This PR fixes the issues described in [this issue](https://github.com/rails/sprockets/issues/687) and in [this comment](https://github.com/rails/sprockets/issues/96#issuecomment-653684209).

### Expected behavior

When a Rails or Sprockets project is placed in a directory with spaces in the folder names in the path, it shouldn't throw any errors. It should just escape the path name and work like normal.

### Actual behavior

Once you put your project in a folder that has spaces in the path name, it throws the following error:

```
bad URI(is not URI?): "file-digest:///Users/username/Company Name Dropbox/User Name/ProjectName/myapp/app/assets/config/bootstrap"`
```

### System configuration

- Sprockets 4.0.2 (also been able to replicate it in 3.7.2)
- Ruby 2.7.1 (also been able to replicate it in 2.5.1)
- Rails 6.0.3.2 (also been able to replicate it in 5.2.4.3)

===========

This issue surfaced once I upgraded my Dropbox account (which my Rails project is in) from a personal account (with no spaces in the name of the Dropbox folder) to a business account that has spaces -- which I couldn't control.