### PR TITLE
CI: Use continue-on-error w/ experimental: true [changelog skip]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,19 @@ on: [push, pull_request]
 jobs:
   tests:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ fromJSON(matrix.experimental) }}
+    name: ${{ matrix.ruby }}
     strategy:
       matrix:
+        experimental: [ false ]
         include:
           - { ruby: 2.5 }
           - { ruby: 2.6 }
           - { ruby: 2.7 }
-          - { ruby: 3.0 }
-          - { ruby: jruby, allow-failure: true }
-          - { ruby: jruby-head, allow-failure: true }
-          - { ruby: head, allow-failure: true }
+          - { ruby: "3.0" }
+          - { ruby: jruby, experimental: true }
+          - { ruby: jruby-head, experimental: true }
+          - { ruby: head, experimental: true }
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
           - { ruby: 2.5 }
           - { ruby: 2.6 }
           - { ruby: 2.7 }
-          - { ruby: "3.0" }
+          - { ruby: 3.0 }
           - { ruby: jruby, experimental: true }
           - { ruby: jruby-head, experimental: true }
           - { ruby: head, experimental: true }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,12 @@ on: [push, pull_request]
 jobs:
   tests:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ fromJSON(matrix.experimental) }}
+    continue-on-error: ${{ matrix.experimental }}
     name: ${{ matrix.ruby }}
     strategy:
       matrix:
-        experimental: [ false ]
+        fail-fast: [false]
+        experimental: [false]
         include:
           - { ruby: 2.5 }
           - { ruby: 2.6 }


### PR DESCRIPTION
Example taken from https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error

🛠️  This PR tries to fix the "allow_failures" settings migrated from Travis in a nearly-correct way.