### PR TITLE
add missing require delegate [changelog skip]

### DIFF
--- a/lib/sprockets/context.rb
+++ b/lib/sprockets/context.rb
@@ -2,6 +2,7 @@
 require 'rack/utils'
 require 'set'
 require 'sprockets/errors'
+require 'delegate'
 
 module Sprockets
   # They are typically accessed by ERB templates. You can mix in custom helpers


### PR DESCRIPTION
fixes ```NameError: uninitialized constant Sprockets::Context::SimpleDelegator```