### PR TITLE
Improve serving of prehashed assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 
 ## Master
 
+- Allow assets already fingerprinted to be served through `Sprockets::Server`
 - Do not fingerprint files that already contain a valid digest in their name
 - Remove remaining support for Ruby < 2.4.[#672](https://github.com/rails/sprockets/pull/672)
 

--- a/test/fixtures/server/app/javascripts/prehashed-988881adc9fc3655077dc2d4d757d480b5ea0e11.js
+++ b/test/fixtures/server/app/javascripts/prehashed-988881adc9fc3655077dc2d4d757d480b5ea0e11.js
@@ -1,0 +1,1 @@
+console.log("I was already hashed!");

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -129,6 +129,16 @@ class TestServer < Sprockets::TestCase
     assert_equal 304, last_response.status
   end
 
+  test "200 response for prehashed asset with etag digest by sprockets" do
+    get "/assets/prehashed-988881adc9fc3655077dc2d4d757d480b5ea0e11.js"
+    assert_equal 200, last_response.status
+
+    etag = last_response.headers['ETag']
+    digest = etag[/"(.+)"/, 1]
+
+    assert_equal 'edabfd0f1ac5fcdae82cc7d92d1c52abb671797a3948fa9040aec1db8e61c327', digest
+  end
+
   test "ok response with fingerprint and if-nonematch etags don't match" do
     get "/assets/application.js"
     assert_equal 200, last_response.status
@@ -298,7 +308,7 @@ class TestServer < Sprockets::TestCase
 
     sandbox filename do
       get "/assets/tree.js"
-      assert_equal "var foo;\n\n(function() {\n  application.boot();\n})();\nvar bar;\nvar japanese = \"日本語\";\n", last_response.body
+      assert_equal %[var foo;\n\n(function() {\n  application.boot();\n})();\nvar bar;\nconsole.log("I was already hashed!");\nvar japanese = \"日本語\";\n], last_response.body
 
       File.open(filename, "w") do |f|
         f.write "var baz;\n"
@@ -309,7 +319,7 @@ class TestServer < Sprockets::TestCase
       File.utime(mtime, mtime, path)
 
       get "/assets/tree.js"
-      assert_equal "var foo;\n\n(function() {\n  application.boot();\n})();\nvar bar;\nvar baz;\nvar japanese = \"日本語\";\n", last_response.body
+      assert_equal %[var foo;\n\n(function() {\n  application.boot();\n})();\nvar bar;\nvar baz;\nconsole.log("I was already hashed!");\nvar japanese = \"日本語\";\n], last_response.body
     end
   end
 


### PR DESCRIPTION
See https://github.com/rails/jsbundling-rails/pull/21 and https://github.com/rails/jsbundling-rails/issues/15 for motivation. Also builds on the work in https://github.com/rails/sprockets/pull/714.

Given an already digested asset `chunk-9ad2e0aa4f0e481dfc8eaa4dc850eab8.js`, we want to make sure that Sprockets can serve this file.

There are currently two problems that needs to be resolved:

1. `Sprockets::Server` will currently try to lookup `chunk.js` when accessing `chunk-9ad2e0aa4f0e481dfc8eaa4dc850eab8.js`
2. `Sprockets::Server` expects ETags of assets and digests to be the same, but that cannot be predicted as the hashing algorithm and version configured in the Rails application will not match whatever configuration the upstream build process used to digest the file.

- `Sprockets::Server` is now changed so that if it fails to find `chunk.js`, it will instead try and load `chunk-9ad2e0aa4f0e481dfc8eaa4dc850eab8.js`.
- When this code path is triggered, the `fingerprint` will be hijacked and replaced by `Asset#etag` so the ETag header behavior is consistent with other assets served by sprockets.