### PR TITLE
Improve detection of files already digested

### DIFF
--- a/lib/sprockets/digest_utils.rb
+++ b/lib/sprockets/digest_utils.rb
@@ -183,13 +183,9 @@ module Sprockets
     #
     # name - The name of the asset
     #
-    # Returns true if the name contains a digest recognized by one of the valid digest classes
+    # Returns true if the name contains a digest like string and .digested before the extension
     def already_digested?(name)
-      return if name.nil?
-
-      if hexdigest = name.scan(/[a-fA-F0-9]+\z/).last
-        detect_digest_class(unpack_hexdigest(hexdigest))
-      end
+      return name =~ /-([0-9a-f]{7,128})\.digested/
     end
 
     private

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -1136,13 +1136,13 @@ class PreDigestedAssetTest < Sprockets::TestCase
   test "digest path" do
     path     = File.expand_path("test/fixtures/asset/application")
     original = "#{path}.js"
-    digested = "#{path}-d41d8cd98f00b204e9800998ecf8427e.js"
+    digested = "#{path}-d41d8cd98f00b204e9800998ecf8427e.digested.js"
     FileUtils.cp(original, digested)
 
-    assert_equal "application-d41d8cd98f00b204e9800998ecf8427e.js",
-      asset("application-d41d8cd98f00b204e9800998ecf8427e.js").digest_path
+    assert_equal "application-d41d8cd98f00b204e9800998ecf8427e.digested.js",
+      asset("application-d41d8cd98f00b204e9800998ecf8427e.digested.js").digest_path
   ensure
-    FileUtils.rm(digested) if File.exists?(digested)
+    FileUtils.rm(digested) if File.exist?(digested)
   end
 
   def asset(logical_path, options = {})

--- a/test/test_digest_utils.rb
+++ b/test/test_digest_utils.rb
@@ -97,14 +97,10 @@ class TestDigestUtils < MiniTest::Test
 
   def test_already_digested
     refute already_digested?(nil)
-    refute already_digested?("application-d41d8cd98f00b204e9800998ecf8427z")
-    refute already_digested?("application-d41d8cd98f00b204e9800998ecf8427ef")
-    refute already_digested?("application-d41d8cd98f00b204e9800998ecf8427e-")
+    refute already_digested?("application-abc123.digested")
+    refute already_digested?("application-abcd1234")
 
-    assert already_digested?("application-" + Digest::MD5.new.hexdigest)
-    assert already_digested?("application-" + Digest::SHA1.new.hexdigest)
-    assert already_digested?("application-" + Digest::SHA256.new.hexdigest)
-    assert already_digested?("application-" + Digest::SHA384.new.hexdigest)
-    assert already_digested?("application-" + Digest::SHA512.new.hexdigest)
+    assert already_digested?("application-abcd1234.digested")
+    assert already_digested?("application-abcd1234.digested.map")
   end
 end


### PR DESCRIPTION
As indicated in https://github.com/rails/propshaft/pull/10, the current auto detection of digests in the filename is causing false positives. So we are changing it to require the `.digested` word after the digest.

To keep parity with Propshaft, and make this compatible with esbuild (which does not use any of sprockets digest algorithms), I've relaxed the regex and removed the digest class detection