### PR TITLE
Better ERB keyword argument check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 
 ## Master
 
+- Better detect the ERB version to avoid deprecation warnings. [#719](https://github.com/rails/sprockets/pull/719)
 - Allow assets already fingerprinted to be served through `Sprockets::Server`
 - Do not fingerprint files that already contain a valid digest in their name
 - Remove remaining support for Ruby < 2.4.[#672](https://github.com/rails/sprockets/pull/672)

--- a/lib/sprockets/erb_processor.rb
+++ b/lib/sprockets/erb_processor.rb
@@ -18,8 +18,7 @@ class Sprockets::ERBProcessor
   end
 
   def call(input)
-    match = ERB.version.match(/\Aerb\.rb \[(?<version>[^ ]+) /)
-    if match && match[:version] >= "2.2.0" # Ruby 2.6+
+    if keyword_constructor? # Ruby 2.6+
       engine = ::ERB.new(input[:data], trim_mode: '<>')
     else
       engine = ::ERB.new(input[:data], nil, '<>')
@@ -33,5 +32,12 @@ class Sprockets::ERBProcessor
 
     data = engine.result(context.instance_eval('binding'))
     context.metadata.merge(data: data)
+  end
+
+  private
+
+  def keyword_constructor?
+    return @keyword_constructor if defined? @keyword_constructor
+    @keyword_constructor = ::ERB.instance_method(:initialize).parameters.include?([:key, :trim_mode])
   end
 end


### PR DESCRIPTION
Later on later versions `ERB.version` has no prefix:

```
$ ruby -v
ruby 3.1.0dev (2021-10-06T06:42:37Z master d53493715c) [x86_64-darwin20]
$ ruby -rerb -e 'p ERB.version'
"2.2.3"
```

So It's better to check what the method parameters are like.