### PR TITLE
Remove all references to MD5, for FIPS compliance

### DIFF
--- a/lib/sprockets/configuration.rb
+++ b/lib/sprockets/configuration.rb
@@ -59,9 +59,9 @@ module Sprockets
 
     # Deprecated: Assign a `Digest` implementation class. This maybe any Ruby
     # `Digest::` implementation such as `Digest::SHA256` or
-    # `Digest::MD5`.
+    # `Digest::SHA512`.
     #
-    #     environment.digest_class = Digest::MD5
+    #     environment.digest_class = Digest::SHA512
     #
     def digest_class=(klass)
       self.config = config.merge(digest_class: klass).freeze

--- a/lib/sprockets/digest_utils.rb
+++ b/lib/sprockets/digest_utils.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'digest/md5'
 require 'digest/sha1'
 require 'digest/sha2'
 require 'set'
@@ -19,7 +18,6 @@ module Sprockets
 
     # Internal: Maps digest bytesize to the digest class.
     DIGEST_SIZES = {
-      16 => Digest::MD5,
       20 => Digest::SHA1,
       32 => Digest::SHA256,
       48 => Digest::SHA384,

--- a/test/test_digest_utils.rb
+++ b/test/test_digest_utils.rb
@@ -6,13 +6,11 @@ class TestDigestUtils < MiniTest::Test
   include Sprockets::DigestUtils
 
   def test_detect_digest_class
-    md5    = Digest::MD5.new.digest
     sha1   = Digest::SHA1.new.digest
     sha256 = Digest::SHA256.new.digest
     sha512 = Digest::SHA512.new.digest
 
     refute detect_digest_class("0000")
-    assert_equal Digest::MD5, detect_digest_class(md5)
     assert_equal Digest::SHA1, detect_digest_class(sha1)
     assert_equal Digest::SHA256, detect_digest_class(sha256)
     assert_equal Digest::SHA512, detect_digest_class(sha512)


### PR DESCRIPTION
See https://github.com/rails/sprockets/issues/499