### PR TITLE
Ensure compatibility with esbuilds' base32 digests

### DIFF
--- a/lib/sprockets/digest_utils.rb
+++ b/lib/sprockets/digest_utils.rb
@@ -185,7 +185,7 @@ module Sprockets
     #
     # Returns true if the name contains a digest like string and .digested before the extension
     def already_digested?(name)
-      return name =~ /-([0-9a-f]{7,128})\.digested/
+      return name =~ /-([0-9a-zA-Z]{7,128})\.digested/
     end
 
     private

--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -299,7 +299,7 @@ module Sprockets
       #     # => "0aa2105d29558f3eb790d411d7d8fb66"
       #
       def path_fingerprint(path)
-        path[/-([0-9a-f]{7,128})\.[^.]+\z/, 1]
+        path[/-([0-9a-zA-Z]{7,128})\.[^.]+\z/, 1]
       end
   end
 end

--- a/test/fixtures/server/app/javascripts/esbuild-TQDC3LZV.digested.js
+++ b/test/fixtures/server/app/javascripts/esbuild-TQDC3LZV.digested.js
@@ -1,0 +1,1 @@
+console.log("I was hashed by esbuild!");

--- a/test/test_asset.rb
+++ b/test/test_asset.rb
@@ -1145,6 +1145,18 @@ class PreDigestedAssetTest < Sprockets::TestCase
     FileUtils.rm(digested) if File.exist?(digested)
   end
 
+  test "digest base32 path" do
+    path     = File.expand_path("test/fixtures/asset/application")
+    original = "#{path}.js"
+    digested = "#{path}-TQDC3LZV.digested.js"
+    FileUtils.cp(original, digested)
+
+    assert_equal "application-TQDC3LZV.digested.js",
+      asset("application-TQDC3LZV.digested.js").digest_path
+  ensure
+    FileUtils.rm(digested) if File.exist?(digested)
+  end
+
   def asset(logical_path, options = {})
     @env.find_asset(logical_path, **{pipeline: @pipeline}.merge(options))
   end

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -139,6 +139,16 @@ class TestServer < Sprockets::TestCase
     assert_equal 'edabfd0f1ac5fcdae82cc7d92d1c52abb671797a3948fa9040aec1db8e61c327', digest
   end
 
+  test "200 response for prehashed esbuild asset with etag digest by sprockets" do
+    get "/assets/esbuild-TQDC3LZV.digested.js"
+    assert_equal 200, last_response.status
+
+    etag = last_response.headers['ETag']
+    digest = etag[/"(.+)"/, 1]
+
+    assert_equal '3ebac3dc00b383de6cbdfa470d105f5a9f22708fb72c63db917ad37f288ac708', digest
+  end
+
   test "ok response with fingerprint and if-nonematch etags don't match" do
     get "/assets/application.js"
     assert_equal 200, last_response.status
@@ -308,7 +318,7 @@ class TestServer < Sprockets::TestCase
 
     sandbox filename do
       get "/assets/tree.js"
-      assert_equal %[var foo;\n\n(function() {\n  application.boot();\n})();\nvar bar;\nconsole.log("I was already hashed!");\nvar japanese = \"日本語\";\n], last_response.body
+      assert_equal %[var foo;\n\n(function() {\n  application.boot();\n})();\nvar bar;\nconsole.log(\"I was hashed by esbuild!\");\nconsole.log("I was already hashed!");\nvar japanese = \"日本語\";\n], last_response.body
 
       File.open(filename, "w") do |f|
         f.write "var baz;\n"
@@ -319,7 +329,7 @@ class TestServer < Sprockets::TestCase
       File.utime(mtime, mtime, path)
 
       get "/assets/tree.js"
-      assert_equal %[var foo;\n\n(function() {\n  application.boot();\n})();\nvar bar;\nvar baz;\nconsole.log("I was already hashed!");\nvar japanese = \"日本語\";\n], last_response.body
+      assert_equal %[var foo;\n\n(function() {\n  application.boot();\n})();\nvar bar;\nvar baz;\nconsole.log(\"I was hashed by esbuild!\");\nconsole.log("I was already hashed!");\nvar japanese = \"日本語\";\n], last_response.body
     end
   end
 


### PR DESCRIPTION
esbuild hashes using base32, so we can configure it to produce files like `application-TQDC3LZV.digested.js`, but we need the digest patterns to accept this. That requires changing the digest matching pattern from `/-([0-9a-f]{7,128})\.[^.]+\z/` to `/-([0-9a-zA-Z]{7,128})\.[^.]+\z/`.