### PR TITLE
Adds additional condition to PathUtils#split_subpath to avoid undefined error method for 'start_with?'

### DIFF
--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -162,7 +162,7 @@ module Sprockets
     def split_subpath(path, subpath)
       return "" if path == subpath
       path = File.join(path, ''.freeze)
-      if subpath.start_with?(path)
+      if !subpath.nil? && subpath.start_with?(path)
         subpath[path.length..-1]
       else
         nil


### PR DESCRIPTION
I've run into an undefined error method for 'start_with?' on line 60 of lib/sprockets/path_utils.rb. While running rspec I've received about 80 failures mentioning this error. I found that I could avoid the error with an additional condition that checks whether or not the `subpath` argument is present.

By no means am I sure this is the proper solution, but this is working for our application at the moment.