### PR TITLE
Lowercase  all response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprockets/blob/master/UPGRADING.md
 
+## Master
+
+- Fix `Sprockets::Server` to return lower-cased response headers to comply with Rack::Lint 3.0. [#744](https://github.com/rails/sprockets/pull/744)
+
 ## 4.0.3
 
 - Fix `Manifest#find` yielding from a Promise causing issue on Ruby 3.1.0-dev. [#720](https://github.com/rails/sprockets/pull/720)

--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -148,39 +148,39 @@ module Sprockets
       # Returns a 400 Forbidden response tuple
       def bad_request_response(env)
         if head_request?(env)
-          [ 400, { "Content-Type" => "text/plain", "Content-Length" => "0" }, [] ]
+          [ 400, { "content-type" => "text/plain", "content-length" => "0" }, [] ]
         else
-          [ 400, { "Content-Type" => "text/plain", "Content-Length" => "11" }, [ "Bad Request" ] ]
+          [ 400, { "content-type" => "text/plain", "content-length" => "11" }, [ "Bad Request" ] ]
         end
       end
 
       # Returns a 403 Forbidden response tuple
       def forbidden_response(env)
         if head_request?(env)
-          [ 403, { "Content-Type" => "text/plain", "Content-Length" => "0" }, [] ]
+          [ 403, { "content-type" => "text/plain", "content-length" => "0" }, [] ]
         else
-          [ 403, { "Content-Type" => "text/plain", "Content-Length" => "9" }, [ "Forbidden" ] ]
+          [ 403, { "content-type" => "text/plain", "content-length" => "9" }, [ "Forbidden" ] ]
         end
       end
 
       # Returns a 404 Not Found response tuple
       def not_found_response(env)
         if head_request?(env)
-          [ 404, { "Content-Type" => "text/plain", "Content-Length" => "0", "X-Cascade" => "pass" }, [] ]
+          [ 404, { "content-type" => "text/plain", "content-length" => "0", "x-cascade" => "pass" }, [] ]
         else
-          [ 404, { "Content-Type" => "text/plain", "Content-Length" => "9", "X-Cascade" => "pass" }, [ "Not found" ] ]
+          [ 404, { "content-type" => "text/plain", "content-length" => "9", "x-cascade" => "pass" }, [ "Not found" ] ]
         end
       end
 
       def method_not_allowed_response
-        [ 405, { "Content-Type" => "text/plain", "Content-Length" => "18" }, [ "Method Not Allowed" ] ]
+        [ 405, { "content-type" => "text/plain", "content-length" => "18" }, [ "Method Not Allowed" ] ]
       end
 
       def precondition_failed_response(env)
         if head_request?(env)
-          [ 412, { "Content-Type" => "text/plain", "Content-Length" => "0", "X-Cascade" => "pass" }, [] ]
+          [ 412, { "content-type" => "text/plain", "content-length" => "0", "x-cascade" => "pass" }, [] ]
         else
-          [ 412, { "Content-Type" => "text/plain", "Content-Length" => "19", "X-Cascade" => "pass" }, [ "Precondition Failed" ] ]
+          [ 412, { "content-type" => "text/plain", "content-length" => "19", "x-cascade" => "pass" }, [ "Precondition Failed" ] ]
         end
       end
 
@@ -189,7 +189,7 @@ module Sprockets
       def javascript_exception_response(exception)
         err  = "#{exception.class.name}: #{exception.message}\n  (in #{exception.backtrace[0]})"
         body = "throw Error(#{err.inspect})"
-        [ 200, { "Content-Type" => "application/javascript", "Content-Length" => body.bytesize.to_s }, [ body ] ]
+        [ 200, { "content-type" => "application/javascript", "content-length" => body.bytesize.to_s }, [ body ] ]
       end
 
       # Returns a CSS response that hides all elements on the page and
@@ -242,7 +242,7 @@ module Sprockets
           }
         CSS
 
-        [ 200, { "Content-Type" => "text/css; charset=utf-8", "Content-Length" => body.bytesize.to_s }, [ body ] ]
+        [ 200, { "content-type" => "text/css; charset=utf-8", "content-length" => body.bytesize.to_s }, [ body ] ]
       end
 
       # Escape special characters for use inside a CSS content("...") string
@@ -258,18 +258,18 @@ module Sprockets
         headers = {}
 
         # Set caching headers
-        headers["Cache-Control"] = +"public"
-        headers["ETag"]          = %("#{etag}")
+        headers["cache-control"] = +"public"
+        headers["etag"]          = %("#{etag}")
 
         # If the request url contains a fingerprint, set a long
         # expires on the response
         if path_fingerprint(env["PATH_INFO"])
-          headers["Cache-Control"] << ", max-age=31536000, immutable"
+          headers["cache-control"] << ", max-age=31536000, immutable"
 
         # Otherwise set `must-revalidate` since the asset could be modified.
         else
-          headers["Cache-Control"] << ", must-revalidate"
-          headers["Vary"] = "Accept-Encoding"
+          headers["cache-control"] << ", must-revalidate"
+          headers["vary"] = "Accept-Encoding"
         end
 
         headers
@@ -279,7 +279,7 @@ module Sprockets
         headers = {}
 
         # Set content length header
-        headers["Content-Length"] = length.to_s
+        headers["content-length"] = length.to_s
 
         # Set content type header
         if type = asset.content_type
@@ -287,7 +287,7 @@ module Sprockets
           if type.start_with?("text/") && asset.charset
             type += "; charset=#{asset.charset}"
           end
-          headers["Content-Type"] = type
+          headers["content-type"] = type
         end
 
         headers.merge(cache_headers(env, asset.etag))

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -36,15 +36,15 @@ class TestServer < Sprockets::TestCase
   test "serve single source file" do
     get "/assets/foo.js"
     assert_equal 200, last_response.status
-    assert_equal "9", last_response.headers['Content-Length']
-    assert_equal "Accept-Encoding", last_response.headers['Vary']
+    assert_equal "9", last_response.headers['content-length']
+    assert_equal "Accept-Encoding", last_response.headers['vary']
     assert_equal "var foo;\n", last_response.body
   end
 
   test "serve single self file" do
     get "/assets/foo.self.js"
     assert_equal 200, last_response.status
-    assert_equal "9", last_response.headers['Content-Length']
+    assert_equal "9", last_response.headers['content-length']
     assert_equal "var foo;\n", last_response.body
   end
 
@@ -64,15 +64,15 @@ class TestServer < Sprockets::TestCase
     assert_equal 200, last_response.status
     assert_equal "\n(function() {\n  application.boot();\n})();\n",
       last_response.body
-    assert_equal "43", last_response.headers['Content-Length']
+    assert_equal "43", last_response.headers['content-length']
   end
 
   test "serve source with content type headers" do
     get "/assets/application.js"
-    assert_equal "application/javascript", last_response.headers['Content-Type']
+    assert_equal "application/javascript", last_response.headers['content-type']
 
     get "/assets/bootstrap.css"
-    assert_equal "text/css; charset=utf-8", last_response.headers['Content-Type']
+    assert_equal "text/css; charset=utf-8", last_response.headers['content-type']
   end
 
   test "serve source with etag headers" do
@@ -80,14 +80,14 @@ class TestServer < Sprockets::TestCase
 
     get "/assets/application.js"
     assert_equal "\"#{digest}\"",
-      last_response.headers['ETag']
+      last_response.headers['etag']
   end
 
   test "not modified partial response when if-none-match etags match" do
     get "/assets/application.js"
     assert_equal 200, last_response.status
     etag, cache_control, expires, vary = last_response.headers.values_at(
-      'ETag', 'Cache-Control', 'Expires', 'Vary'
+      'etag', 'cache-control', 'Expires', 'vary'
     )
 
     assert_nil expires
@@ -97,14 +97,14 @@ class TestServer < Sprockets::TestCase
     assert_equal 304, last_response.status
 
     # Allow 304 headers
-    assert_equal cache_control, last_response.headers['Cache-Control']
-    assert_equal etag, last_response.headers['ETag']
+    assert_equal cache_control, last_response.headers['cache-control']
+    assert_equal etag, last_response.headers['etag']
     assert_nil last_response.headers['Expires']
-    assert_equal vary, last_response.headers['Vary']
+    assert_equal vary, last_response.headers['vary']
 
     # Disallowed 304 headers
-    refute last_response.headers['Content-Type']
-    refute last_response.headers['Content-Length']
+    refute last_response.headers['content-type']
+    refute last_response.headers['content-length']
     refute last_response.headers['Content-Encoding']
   end
 
@@ -113,15 +113,15 @@ class TestServer < Sprockets::TestCase
       'HTTP_IF_NONE_MATCH' => "nope"
 
     assert_equal 200, last_response.status
-    assert_equal '"b452c9ae1d5c8d9246653e0d93bc83abce0ee09ef725c0f0a29a41269c217b83"', last_response.headers['ETag']
-    assert_equal '52', last_response.headers['Content-Length']
+    assert_equal '"b452c9ae1d5c8d9246653e0d93bc83abce0ee09ef725c0f0a29a41269c217b83"', last_response.headers['etag']
+    assert_equal '52', last_response.headers['content-length']
   end
 
   test "not modified partial response with fingerprint and if-none-match etags match" do
     get "/assets/application.js"
     assert_equal 200, last_response.status
 
-    etag   = last_response.headers['ETag']
+    etag   = last_response.headers['etag']
     digest = etag[/"(.+)"/, 1]
 
     get "/assets/application-#{digest}.js", {},
@@ -133,7 +133,7 @@ class TestServer < Sprockets::TestCase
     get "/assets/prehashed-988881adc9fc3655077dc2d4d757d480b5ea0e11.js"
     assert_equal 200, last_response.status
 
-    etag = last_response.headers['ETag']
+    etag = last_response.headers['etag']
     digest = etag[/"(.+)"/, 1]
 
     assert_equal 'edabfd0f1ac5fcdae82cc7d92d1c52abb671797a3948fa9040aec1db8e61c327', digest
@@ -143,7 +143,7 @@ class TestServer < Sprockets::TestCase
     get "/assets/application.js"
     assert_equal 200, last_response.status
 
-    etag   = last_response.headers['ETag']
+    etag   = last_response.headers['etag']
     digest = etag[/"(.+)"/, 1]
 
     get "/assets/application-#{digest}.js", {},
@@ -167,7 +167,7 @@ class TestServer < Sprockets::TestCase
     get "/assets/application.js"
     assert_equal 200, last_response.status
 
-    etag = last_response.headers['ETag']
+    etag = last_response.headers['etag']
 
     get "/assets/application-0000000000000000000000000000000000000000.js", {},
       'HTTP_IF_NONE_MATCH' => etag
@@ -177,14 +177,14 @@ class TestServer < Sprockets::TestCase
   test "ok partial response when if-match etags match" do
     get "/assets/application.js"
     assert_equal 200, last_response.status
-    etag = last_response.headers['ETag']
+    etag = last_response.headers['etag']
 
     get "/assets/application.js", {},
       'HTTP_IF_MATCH' => etag
 
     assert_equal 200, last_response.status
-    assert_equal '"b452c9ae1d5c8d9246653e0d93bc83abce0ee09ef725c0f0a29a41269c217b83"', last_response.headers['ETag']
-    assert_equal '52', last_response.headers['Content-Length']
+    assert_equal '"b452c9ae1d5c8d9246653e0d93bc83abce0ee09ef725c0f0a29a41269c217b83"', last_response.headers['etag']
+    assert_equal '52', last_response.headers['content-length']
   end
 
   test "precondition failed with if-match is a mismatch" do
@@ -192,7 +192,7 @@ class TestServer < Sprockets::TestCase
       'HTTP_IF_MATCH' => '"000"'
     assert_equal 412, last_response.status
 
-    refute last_response.headers['ETag']
+    refute last_response.headers['etag']
   end
 
   test "not found with if-match" do
@@ -215,23 +215,23 @@ class TestServer < Sprockets::TestCase
 
   test "fingerprint digest sets expiration to the future" do
     get "/assets/application.js"
-    digest = last_response.headers['ETag'][/"(.+)"/, 1]
+    digest = last_response.headers['etag'][/"(.+)"/, 1]
 
     get "/assets/application-#{digest}.js"
     assert_equal 200, last_response.status
-    assert_match %r{max-age}, last_response.headers['Cache-Control']
-    assert_match %r{immutable}, last_response.headers['Cache-Control']
+    assert_match %r{max-age}, last_response.headers['cache-control']
+    assert_match %r{immutable}, last_response.headers['cache-control']
   end
 
   test "fingerprint digest of file self" do
     get "/assets/application.self.js"
-    digest = last_response.headers['ETag'][/"(.+)"/, 1]
+    digest = last_response.headers['etag'][/"(.+)"/, 1]
 
     get "/assets/application.self-#{digest}.js"
     assert_equal 200, last_response.status
     assert_equal "\n(function() {\n  application.boot();\n})();\n", last_response.body
-    assert_equal "43", last_response.headers['Content-Length']
-    assert_match %r{max-age}, last_response.headers['Cache-Control']
+    assert_equal "43", last_response.headers['content-length']
+    assert_match %r{max-age}, last_response.headers['cache-control']
   end
 
   test "bad fingerprint digest returns a 404" do
@@ -240,14 +240,14 @@ class TestServer < Sprockets::TestCase
 
     head "/assets/application-0000000000000000000000000000000000000000.js"
     assert_equal 404, last_response.status
-    assert_equal "0", last_response.headers['Content-Length']
+    assert_equal "0", last_response.headers['content-length']
     assert_equal "", last_response.body
   end
 
   test "missing source" do
     get "/assets/none.js"
     assert_equal 404, last_response.status
-    assert_equal "pass", last_response.headers['X-Cascade']
+    assert_equal "pass", last_response.headers['x-cascade']
   end
 
   test "re-throw JS exceptions in the browser" do
@@ -292,7 +292,7 @@ class TestServer < Sprockets::TestCase
 
     head "/assets/.-0000000./etc/passwd"
     assert_equal 403, last_response.status
-    assert_equal "0", last_response.headers['Content-Length']
+    assert_equal "0", last_response.headers['content-length']
     assert_equal "", last_response.body
   end
 
@@ -326,7 +326,7 @@ class TestServer < Sprockets::TestCase
   test "serving static assets" do
     get "/assets/logo.png"
     assert_equal 200, last_response.status
-    assert_equal "image/png", last_response.headers['Content-Type']
+    assert_equal "image/png", last_response.headers['content-type']
     refute last_response.headers['Content-Encoding']
     assert_equal File.binread(fixture_path("server/app/images/logo.png")), last_response.body
   end
@@ -337,8 +337,8 @@ class TestServer < Sprockets::TestCase
 
     head "/assets/foo.js"
     assert_equal 200, last_response.status
-    assert_equal "application/javascript", last_response.headers['Content-Type']
-    assert_equal "0", last_response.headers['Content-Length']
+    assert_equal "application/javascript", last_response.headers['content-type']
+    assert_equal "0", last_response.headers['content-length']
     assert_equal "", last_response.body
 
     post "/assets/foo.js"


### PR DESCRIPTION
Rack::Lint requires all response headers to be lower-cased since https://github.com/rack/rack/commit/472e12f5b6505cc2fdd3b5e529b616b3a2d5fbf8, and the CI here is failing due to that change. So here are fixes on Sprockets::Server to comply with the Rack::Lint change and make the CI green again.

See https://github.com/rack/rack/issues/1592 for more details.

/cc @ioquatix @jeremyevans