### PR TITLE
Make Sprockets::Utils.module_include thread safe on JRuby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprockets/blob/master/UPGRADING.md
 
 - Add support for Rack 3.0. Headers set by sprockets will now be lower case. [#758](https://github.com/rails/sprockets/pull/758)
+- Make `Sprockets::Utils.module_include` thread safe on JRuby. [#759](https://github.com/rails/sprockets/pull/759)
 
 ## 4.1.0
 


### PR DESCRIPTION
This PR fixes https://github.com/sass/sassc-rails/issues/114.

See https://github.com/ntkme/sassc-embedded-shim-ruby/issues/23#issuecomment-1247633775 for a minimum reproduction.

Note: In my limited testing I cannot reproduce it with MRI, likely due to its global interpreter lock. However, on JRuby the problem is very easy to reproduce.