### PR TITLE
[backport/v3.x] Make Sprockets::Utils.module_include thread safe on JRuby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**Master**
+
+* Make `Sprockets::Utils.module_include` thread safe on JRuby. [#760](https://github.com/rails/sprockets/pull/760)
+
 **3.7.2** (June 19, 2018)
 
 * Security release for [CVE-2018-3760](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3760).

--- a/lib/sprockets/utils.rb
+++ b/lib/sprockets/utils.rb
@@ -147,34 +147,39 @@ module Sprockets
       false
     end
 
+    MODULE_INCLUDE_MUTEX = Mutex.new
+    private_constant :MODULE_INCLUDE_MUTEX
+
     # Internal: Inject into target module for the duration of the block.
     #
     # mod - Module
     #
     # Returns result of block.
     def module_include(base, mod)
-      old_methods = {}
+      MODULE_INCLUDE_MUTEX.synchronize do
+        old_methods = {}
 
-      mod.instance_methods.each do |sym|
-        old_methods[sym] = base.instance_method(sym) if base.method_defined?(sym)
-      end
+        mod.instance_methods.each do |sym|
+          old_methods[sym] = base.instance_method(sym) if base.method_defined?(sym)
+        end
 
-      unless UNBOUND_METHODS_BIND_TO_ANY_OBJECT
-        base.send(:include, mod) unless base < mod
-      end
+        unless UNBOUND_METHODS_BIND_TO_ANY_OBJECT
+          base.send(:include, mod) unless base < mod
+        end
 
-      mod.instance_methods.each do |sym|
-        method = mod.instance_method(sym)
-        base.send(:define_method, sym, method)
-      end
+        mod.instance_methods.each do |sym|
+          method = mod.instance_method(sym)
+          base.send(:define_method, sym, method)
+        end
 
-      yield
-    ensure
-      mod.instance_methods.each do |sym|
-        base.send(:undef_method, sym) if base.method_defined?(sym)
-      end
-      old_methods.each do |sym, method|
-        base.send(:define_method, sym, method)
+        yield
+      ensure
+        mod.instance_methods.each do |sym|
+          base.send(:undef_method, sym) if base.method_defined?(sym)
+        end
+        old_methods.each do |sym, method|
+          base.send(:define_method, sym, method)
+        end
       end
     end
 


### PR DESCRIPTION
Backport/cherrypick of #759 to 3.x

Justification for requesting backport
- Backport seems relatively simple, as this code is large unchanged and `module_include` appears to be used in the same way on 3.x and 4.x
- The breaking changes in Sprockets 4 (`manifest.js` and friends) have made migration challenging for some folks (as well as the changes folks needed to get to Rails 6.0/6.1 to even unblock Sprockets upgrade)
- Some wrapping libraries such as Middleman appear to have some challenges with various combinations of sprockets/middleman/sass/sassc versions. Having this particular issue fixed on `3.x` sprockets allows some decoupling of these various upgrades without experiencing issues during live reloads as described in https://github.com/sass/sassc-rails/issues/114 (yes, `sassc` and `sassc-rails` are also deprecated, but bridging support to dart sass is available in https://github.com/ntkme/sassc-embedded-shim-ruby)
  - Use of `sass-embedded` as opposed to `sass-rails` appears to increase the chance of triggering the concurrency issue this addresses

If this isn't something that will be considered for release, please feel free to note and close this PR 🙏