### PR TITLE
Fix .sprockets-manifest and gzip reproducibility issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 
 - Add support for Rack 3.0. Headers set by sprockets will now be lower case. [#758](https://github.com/rails/sprockets/pull/758)
 - Make `Sprockets::Utils.module_include` thread safe on JRuby. [#759](https://github.com/rails/sprockets/pull/759)
+- Improve reproducibility [#761](https://github.com/rails/sprockets/pull/761)
 
 ## 4.1.0
 

--- a/lib/sprockets/manifest_utils.rb
+++ b/lib/sprockets/manifest_utils.rb
@@ -9,21 +9,6 @@ module Sprockets
 
     MANIFEST_RE = /^\.sprockets-manifest-[0-9a-f]{32}.json$/
 
-    # Public: Generate a new random manifest path.
-    #
-    # Manifests are not intended to be accessed publicly, but typically live
-    # alongside public assets for convenience. To avoid being served, the
-    # filename is prefixed with a "." which is usually hidden by web servers
-    # like Apache. To help in other environments that may not control this,
-    # a random hex string is appended to the filename to prevent people from
-    # guessing the location. If directory indexes are enabled on the server,
-    # all bets are off.
-    #
-    # Return String path.
-    def generate_manifest_path
-      ".sprockets-manifest-#{SecureRandom.hex(16)}.json"
-    end
-
     # Public: Find or pick a new manifest filename for target build directory.
     #
     # dirname - String dirname
@@ -33,7 +18,7 @@ module Sprockets
     #     find_directory_manifest("/app/public/assets")
     #     # => "/app/public/assets/.sprockets-manifest-abc123.json"
     #
-    # Returns String filename.
+    # Returns String filename or nil if it cannot find one.
     def find_directory_manifest(dirname, logger = Logger.new($stderr))
       entries = File.directory?(dirname) ? Dir.entries(dirname) : []
       manifest_entries = entries.select { |e| e =~ MANIFEST_RE }
@@ -41,7 +26,8 @@ module Sprockets
         manifest_entries.sort!
         logger.warn("Found multiple manifests: #{manifest_entries}. Choosing the first alphabetically: #{manifest_entries.first}")
       end
-      entry = manifest_entries.first || generate_manifest_path
+      entry = manifest_entries.first
+      return nil if entry.nil?
       File.join(dirname, entry)
     end
   end

--- a/lib/sprockets/utils/gzip.rb
+++ b/lib/sprockets/utils/gzip.rb
@@ -12,7 +12,7 @@ module Sprockets
       module ZlibArchiver
         def self.call(file, source, mtime)
           gz = Zlib::GzipWriter.new(file, Zlib::BEST_COMPRESSION)
-          gz.mtime = mtime
+          gz.mtime = 1 # for reproducibility
           gz.write(source)
           gz.close
 

--- a/test/test_manifest.rb
+++ b/test/test_manifest.rb
@@ -50,11 +50,10 @@ class TestManifest < Sprockets::TestCase
     assert_equal filename, manifest.path
   end
 
-  test "specify manifest directory yields random .sprockets-manifest-*.json" do
+  test "specify manifest directory reproducible .sprockets-manifest-*.json" do
     manifest = Sprockets::Manifest.new(@env, @dir)
 
     assert_equal @dir, manifest.directory
-    assert_match(/^\.sprockets-manifest-[a-f0-9]{32}.json/, File.basename(manifest.filename))
 
     manifest.save
     assert_match(/^\.sprockets-manifest-[a-f0-9]{32}.json/, File.basename(manifest.filename))

--- a/test/test_manifest_utils.rb
+++ b/test/test_manifest_utils.rb
@@ -6,8 +6,10 @@ require 'logger'
 class TestManifestUtils < MiniTest::Test
   include Sprockets::ManifestUtils
 
-  def test_generate_manifest_path
-    assert_match(MANIFEST_RE, generate_manifest_path)
+  def test_returns_no_manifest_nil
+    root = File.expand_path("../fixtures/manifest_utils", __FILE__)
+    assert_equal nil,
+      find_directory_manifest("#{root}/")
   end
 
   def test_find_directory_manifest


### PR DESCRIPTION
When building Rails assets with Nix, I found they are almost completely reproducible save the manifest file, and the gzipped files. This commit fixes those issues. For more information about why it is good for a build to be reproducible see:

https://reproducible-builds.org/

Here are the reproducibility issues and how they were fixed:

1. .sprckets-manifest contained the time when the assets were generated. Instead use timestamp 1.
2. gzip encoded the file mtime in the archive, which is not reproducible. Instead use timestamp 1.
3. .sprockets-manifest generating a random path for this file is not reproducible. Instead use the file's data to generate a digest.

Fixes #707 