### PR TITLE
manifest mtime reproducibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprockets/blob/master/UPGRADING.md
 
 - Add support for Rack 3.0. Headers set by sprockets will now be lower case. [#758](https://github.com/rails/sprockets/pull/758)
+- Stop encoding compiled asset modifcation time into sprockets-manifest for reproducibility [#763](https://github.com/rails/sprockets/pull/763)
 - Make `Sprockets::Utils.module_include` thread safe on JRuby. [#759](https://github.com/rails/sprockets/pull/759)
 
 ## 4.1.0

--- a/lib/sprockets/manifest.rb
+++ b/lib/sprockets/manifest.rb
@@ -97,12 +97,12 @@ module Sprockets
     #
     #   Fingerprint path (String):
     #     logical_path: Logical path (String)
-    #     mtime: ISO8601 mtime (String)
+    #     mtime: ISO8601 mtime (String) always "1970-01-01T00:00:01+00:00"
     #     digest: Base64 hex digest (String)
     #
     #  { "application-2e8e9a7c6b0aafa0c9bdeec90ea30213.js" =>
     #      { 'logical_path' => "application.js",
-    #        'mtime' => "2011-12-13T21:47:08-06:00",
+    #        'mtime' => "1970-01-01T00:00:01+00:00",
     #        'digest' => "2e8e9a7c6b0aafa0c9bdeec90ea30213" } }
     #
     def files
@@ -172,7 +172,7 @@ module Sprockets
       end
 
       assets_to_export.each do |asset|
-        mtime = Time.now.iso8601
+        mtime = Time.at(1).utc.to_datetime.iso8601 # for reproducibility
         files[asset.digest_path] = {
           'logical_path' => asset.logical_path,
           'mtime'        => mtime,


### PR DESCRIPTION
When building Rails assets with Nix, I found they are almost completely reproducible. This commit fixes one of the issues. For more information about why it is good for a build to be reproducible see:

https://reproducible-builds.org/

This stops encoding the asset compilation time (something that is not reproducible) into the manifest.

fixes #707 