### PR TITLE
fix: set application/css-sourcemap+json default charset to unicode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 - Add support for Rack 3.0. Headers set by sprockets will now be lower case. [#758](https://github.com/rails/sprockets/pull/758)
 - Make `Sprockets::Utils.module_include` thread safe on JRuby. [#759](https://github.com/rails/sprockets/pull/759)
 
+## 4.1.1
+
+- Fix `Sprockets::Server` to return response headers to be compatible with Rack::Lint 2.0.
+
 ## 4.1.0
 
 - Allow age to be altered in asset:clean rake task.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprockets/blob/master/UPGRADING.md
 
 - Fix for precompile issues when multiple extensions map to the same MIME type (eg. `.jpeg` / `.jpg`). [#781](https://github.com/rails/sprockets/pull/781)
+- Fix `application/css-sourcemap+json` charset [#764](https://github.com/rails/sprockets/pull/764)
 
 ## 4.2.0
 

--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -91,7 +91,7 @@ module Sprockets
 
   require 'sprockets/source_map_processor'
   register_mime_type 'application/js-sourcemap+json', extensions: ['.js.map'], charset: :unicode
-  register_mime_type 'application/css-sourcemap+json', extensions: ['.css.map']
+  register_mime_type 'application/css-sourcemap+json', extensions: ['.css.map'], charset: :unicode
   register_transformer 'application/javascript', 'application/js-sourcemap+json', SourceMapProcessor
   register_transformer 'text/css', 'application/css-sourcemap+json', SourceMapProcessor
 

--- a/test/test_source_maps.rb
+++ b/test/test_source_maps.rb
@@ -60,7 +60,7 @@ class TestSourceMaps < Sprockets::TestCase
     ], get_sources(map)
   end
 
-  test "reads the data transcoded to UTF-8" do
+  test "reads js data transcoded to UTF-8" do
     processor = Proc.new do |input|
       assert_equal Encoding::UTF_8, input[:data].encoding
       { data: input[:data] }
@@ -69,6 +69,17 @@ class TestSourceMaps < Sprockets::TestCase
     assert asset = @env.find_asset('plain.js', pipeline: :debug)
   ensure
     @env.unregister_preprocessor('application/javascript', processor)
+  end
+
+  test "reads css data transcoded to UTF-8" do
+    processor = Proc.new do |input|
+      assert_equal Encoding::UTF_8, input[:data].encoding
+      { data: input[:data] }
+    end
+    @env.register_processor('text/css', processor)
+    assert asset = @env.find_asset('sass/precompiled/main.css', pipeline: :debug)
+  ensure
+    @env.unregister_preprocessor('text/css', processor)
   end
 
   test "builds a minified source map" do


### PR DESCRIPTION
After a Sprockets 4.x upgrade the CSS sourcemaps seemed to be assuming ASCII-8BIT and causing errors within the asset pipeline for SCSS which contained Unicode chars due to corruption going through the pipeline.

After a bit of digging, it seemed that was caused by an equivalent issue to #669 except for SCSS with Unicode in it  (`Encoding::UndefinedConversionError at "\xC3" from ASCII-8BIT to UTF-8`). This is an issue only when `debug: true` is enabled for an asset and thus with sourcemap generation enabled.

In #669 (`4.1.0`) the default charset for JS sourcemaps was corrected to UTF-8. However the default charset for `application/css+sourcemap+json` is still currently ending up as `ASCII-8BIT`, even when source has a non-ASCII character in it. For consistency and correctness, it seems that these should also be assumed to be Unicode.

This PR also reinstates the changelog for the previously-released [`4.1.1`](https://github.com/rails/sprockets/releases/tag/v4.1.1) which seemed to have been (accidentally?) removed in https://github.com/rails/sprockets/commit/17d77237f60aa0c2c339e414b2efd3a658a872e7 This was rather confusing when reading the changelog.