### PR TITLE
Update assets.rb typo in comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprocket
 
 - Add support for Rack 3.0. Headers set by sprockets will now be lower case. [#758](https://github.com/rails/sprockets/pull/758)
 - Make `Sprockets::Utils.module_include` thread safe on JRuby. [#759](https://github.com/rails/sprockets/pull/759)
+- Fix typo in `asset.rb` file. [#768](https://github.com/rails/sprockets/pull/768) 
 
 ## 4.1.0
 

--- a/lib/sprockets/asset.rb
+++ b/lib/sprockets/asset.rb
@@ -137,7 +137,7 @@ module Sprockets
       DigestUtils.pack_hexdigest(digest)
     end
 
-    # Pubic: ETag String of Asset.
+    # Public: ETag String of Asset.
     def etag
       version = environment_version
 


### PR DESCRIPTION
Saw a bad typo while checking the `asset.rb` file in a comment and this PR fixes this.
Thanks!