### PR TITLE
Prefer setup-ruby's built in bundler-cache feature over actions/cache

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -11,18 +11,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/cache@v2
-      with:
-        path: /home/runner/bundle
-        key: bundle-use-ruby-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: bundle-use-ruby-gems-
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Bundle install
-      run: |
-        gem install bundler -v 2.1.4
-        bundle config path /home/runner/bundle
-        bundle install
+        bundler-cache: true
     - name: Run linter
       run: bundle exec rubocop --parallel


### PR DESCRIPTION
this fixes the following warning:
"Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/cache@v2."