### PR TITLE
Fix header casing compatibility with Rails 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprockets/blob/master/UPGRADING.md
 
 - Fix for precompile issues when multiple extensions map to the same MIME type (eg. `.jpeg` / `.jpg`). [#781](https://github.com/rails/sprockets/pull/781)
+- Fix compatibility with Rack 2 applications. [#790](https://github.com/rails/sprockets/pull/790)
 
 ## 4.2.0
 


### PR DESCRIPTION
Ref rails/rails#48874
Fixes rails/rails#47096 for Rails < 7.1

To support Rack 3, response headers in `Sprockets::Server` were all downcased. However, this has led to issues with Rack 2 applications (ex. Rails 7) since they still expect mixed case (ex. `Content-Type`) headers.

To ensure compatibility with both Rack 2 and Rack 3 applications, this commit makes the casing of the headers conditional on the Rack version. Rack itself provides constants to do this easily for most of the headers used (`Content-Type`, `Content-Length`, `Cache-Control`, and `ETag`) and the rest are added as constants under `Rack::Server`.

As an alternative to this, the responses could instead be wrapped using `Rack::Headers` (and `Rack::Utils::HeaderHash` in Rack 2), but making the header casing conditional seems better to me because it is relatively easier to implement and there will be less churn if/when Rack 2 support is eventually removed.