### PR TITLE
Fix Minitest constant name in tests

### DIFF
--- a/test/sprockets_test.rb
+++ b/test/sprockets_test.rb
@@ -93,7 +93,7 @@ module Sprockets::TestDefinition
   end
 end
 
-class Sprockets::TestCase < MiniTest::Test
+class Sprockets::TestCase < Minitest::Test
   extend Sprockets::TestDefinition
 
   FIXTURE_ROOT = File.join(__dir__, "fixtures")

--- a/test/test_babel_processor.rb
+++ b/test/test_babel_processor.rb
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require 'sprockets/cache'
 require 'sprockets/babel_processor'
 
-class TestBabelProcessor < MiniTest::Test
+class TestBabelProcessor < Minitest::Test
   def setup
     @env = Sprockets::Environment.new
     @env.append_path File.expand_path("../fixtures", __FILE__)

--- a/test/test_cache_store.rb
+++ b/test/test_cache_store.rb
@@ -85,7 +85,7 @@ module CacheStoreTests
   end
 end
 
-class TestNullStore < MiniTest::Test
+class TestNullStore < Minitest::Test
   def setup
     @_store = Sprockets::Cache::NullStore.new
     @store = Sprockets::Cache.new(Sprockets::Cache::NullStore.new)
@@ -99,7 +99,7 @@ class TestNullStore < MiniTest::Test
   include CacheStoreNullTests
 end
 
-class TestMemoryStore < MiniTest::Test
+class TestMemoryStore < Minitest::Test
   def setup
     @_store = Sprockets::Cache::MemoryStore.new
     @store = Sprockets::Cache.new(@_store)
@@ -132,7 +132,7 @@ class TestMemoryStore < MiniTest::Test
   end
 end
 
-class TestZeroMemoryStore < MiniTest::Test
+class TestZeroMemoryStore < Minitest::Test
   def setup
     @_store = Sprockets::Cache::MemoryStore.new(0)
     @store = Sprockets::Cache.new(@_store)
@@ -145,7 +145,7 @@ class TestZeroMemoryStore < MiniTest::Test
   include CacheStoreNullTests
 end
 
-class TestFileStore < MiniTest::Test
+class TestFileStore < Minitest::Test
   def setup
     @root = Dir::mktmpdir "sprockets-file-store"
     @_store = Sprockets::Cache::FileStore.new(@root)
@@ -180,7 +180,7 @@ class TestFileStore < MiniTest::Test
   include CacheStoreTests
 end
 
-class TestZeroFileStore < MiniTest::Test
+class TestZeroFileStore < Minitest::Test
   def setup
     @tmpdir = Dir::mktmpdir "sprockets-file-store-zero"
     @_store = Sprockets::Cache::FileStore.new(@tmpdir, 0)

--- a/test/test_closure_compressor.rb
+++ b/test/test_closure_compressor.rb
@@ -3,7 +3,7 @@ require 'minitest/autorun'
 require 'sprockets/cache'
 require 'sprockets/closure_compressor'
 
-class TestClosureCompressor < MiniTest::Test
+class TestClosureCompressor < Minitest::Test
   def test_compress_javascript
     input = {
       data: "function foo() {\n  return true;\n}",

--- a/test/test_coffee_script_processor.rb
+++ b/test/test_coffee_script_processor.rb
@@ -5,7 +5,7 @@ require 'sprockets/cache'
 require 'sprockets/coffee_script_processor'
 require 'sprockets/source_map_utils'
 
-class TestCoffeeScriptProcessor < MiniTest::Test
+class TestCoffeeScriptProcessor < Minitest::Test
   def setup
     @env = Sprockets::Environment.new
     @env.append_path File.expand_path("../fixtures", __FILE__)

--- a/test/test_digest_utils.rb
+++ b/test/test_digest_utils.rb
@@ -2,7 +2,7 @@
 require 'minitest/autorun'
 require 'sprockets/digest_utils'
 
-class TestDigestUtils < MiniTest::Test
+class TestDigestUtils < Minitest::Test
   include Sprockets::DigestUtils
 
   def test_detect_digest_class

--- a/test/test_eco_processor.rb
+++ b/test/test_eco_processor.rb
@@ -3,7 +3,7 @@ require 'minitest/autorun'
 require 'sprockets/cache'
 require 'sprockets/eco_processor'
 
-class TestEcoProcessor < MiniTest::Test
+class TestEcoProcessor < Minitest::Test
   def test_compile_eco_template_to_js
     input = {
       content_type: 'application/javascript',

--- a/test/test_ejs_processor.rb
+++ b/test/test_ejs_processor.rb
@@ -3,7 +3,7 @@ require 'minitest/autorun'
 require 'sprockets/cache'
 require 'sprockets/ejs_processor'
 
-class TestEjsProcessor < MiniTest::Test
+class TestEjsProcessor < Minitest::Test
   def test_compile_ejs_template_to_js
     input = {
       content_type: 'application/javascript',

--- a/test/test_encoding_utils.rb
+++ b/test/test_encoding_utils.rb
@@ -3,7 +3,7 @@
 require 'minitest/autorun'
 require 'sprockets/encoding_utils'
 
-class TestDigestUtils < MiniTest::Test
+class TestDigestUtils < Minitest::Test
   include Sprockets::EncodingUtils
 
   def test_deflate

--- a/test/test_erb_processor.rb
+++ b/test/test_erb_processor.rb
@@ -5,7 +5,7 @@ require 'sprockets/cache'
 require 'sprockets/erb_processor'
 require 'sass'
 
-class TestERBProcessor < MiniTest::Test
+class TestERBProcessor < Minitest::Test
 
   def uri_path(path)
     path = '/' + path if path[1] == ':' # Windows path / drive letter

--- a/test/test_http_utils.rb
+++ b/test/test_http_utils.rb
@@ -2,7 +2,7 @@
 require 'minitest/autorun'
 require 'sprockets/http_utils'
 
-class TestHTTPUtils < MiniTest::Test
+class TestHTTPUtils < Minitest::Test
   include Sprockets::HTTPUtils
 
   def test_match_mime_type

--- a/test/test_jsminc_compressor.rb
+++ b/test/test_jsminc_compressor.rb
@@ -4,7 +4,7 @@ require 'sprockets/cache'
 unless RUBY_PLATFORM.include?('java')
   require 'sprockets/jsminc_compressor'
 
-  class TestJSMincCompressor < MiniTest::Test
+  class TestJSMincCompressor < Minitest::Test
 
     def test_compress_javascript
       input = {

--- a/test/test_jst_processor.rb
+++ b/test/test_jst_processor.rb
@@ -3,7 +3,7 @@ require 'minitest/autorun'
 require 'sprockets/cache'
 require 'sprockets/jst_processor'
 
-class TestJstProcessor < MiniTest::Test
+class TestJstProcessor < Minitest::Test
   def test_export_js_template_in_JST
     input = {
       name: 'users/show',

--- a/test/test_manifest_utils.rb
+++ b/test/test_manifest_utils.rb
@@ -3,7 +3,7 @@ require 'minitest/autorun'
 require 'sprockets/manifest_utils'
 require 'logger'
 
-class TestManifestUtils < MiniTest::Test
+class TestManifestUtils < Minitest::Test
   include Sprockets::ManifestUtils
 
   def test_generate_manifest_path

--- a/test/test_path_dependency_utils.rb
+++ b/test/test_path_dependency_utils.rb
@@ -2,7 +2,7 @@
 require 'minitest/autorun'
 require 'sprockets/path_dependency_utils'
 
-class TestPathDependencyUtils < MiniTest::Test
+class TestPathDependencyUtils < Minitest::Test
   include Sprockets::PathDependencyUtils
 
   def test_entries_with_dependencies

--- a/test/test_path_digest_utils.rb
+++ b/test/test_path_digest_utils.rb
@@ -2,7 +2,7 @@
 require 'minitest/autorun'
 require 'sprockets/path_digest_utils'
 
-class TestPathDigestUtils < MiniTest::Test
+class TestPathDigestUtils < Minitest::Test
   include Sprockets::PathDigestUtils
 
   def test_file_stat_digest

--- a/test/test_path_utils.rb
+++ b/test/test_path_utils.rb
@@ -2,7 +2,7 @@
 require 'minitest/autorun'
 require 'sprockets/path_utils'
 
-class TestPathUtils < MiniTest::Test
+class TestPathUtils < Minitest::Test
   include Sprockets::PathUtils
 
   DOSISH = File::ALT_SEPARATOR != nil

--- a/test/test_processor_utils.rb
+++ b/test/test_processor_utils.rb
@@ -37,7 +37,7 @@ class TestCallingProcessors < Sprockets::TestCase
   end
 end
 
-class TestProcessorUtils < MiniTest::Test
+class TestProcessorUtils < Minitest::Test
   include Sprockets::ProcessorUtils
 
   class Processor

--- a/test/test_require.rb
+++ b/test/test_require.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'minitest/autorun'
 
-class TestRequire < MiniTest::Test
+class TestRequire < Minitest::Test
   parallelize_me!
 
   ROOT = File.expand_path("../..", __FILE__)

--- a/test/test_source_map_utils.rb
+++ b/test/test_source_map_utils.rb
@@ -2,7 +2,7 @@
 require 'minitest/autorun'
 require 'sprockets/source_map_utils'
 
-class TestSourceMapUtils < MiniTest::Test
+class TestSourceMapUtils < Minitest::Test
 
   def deep_dup(object)
     Marshal.load( Marshal.dump(object) )

--- a/test/test_uglifier_compressor.rb
+++ b/test/test_uglifier_compressor.rb
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require 'sprockets/cache'
 require 'sprockets/uglifier_compressor'
 
-class TestUglifierCompressor < MiniTest::Test
+class TestUglifierCompressor < Minitest::Test
   def setup
     @env = Sprockets::Environment.new
     @env.append_path File.expand_path("../fixtures", __FILE__)

--- a/test/test_uri_utils.rb
+++ b/test/test_uri_utils.rb
@@ -2,7 +2,7 @@
 require 'minitest/autorun'
 require 'sprockets/uri_utils'
 
-class TestURIUtils < MiniTest::Test
+class TestURIUtils < Minitest::Test
   include Sprockets::URIUtils
 
   DOSISH = File::ALT_SEPARATOR != nil

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -2,7 +2,7 @@
 require 'minitest/autorun'
 require 'sprockets/utils'
 
-class TestUtils < MiniTest::Test
+class TestUtils < Minitest::Test
   include Sprockets::Utils
 
   def test_duplicable

--- a/test/test_yui_compressor.rb
+++ b/test/test_yui_compressor.rb
@@ -3,7 +3,7 @@ require 'minitest/autorun'
 require 'sprockets/cache'
 require 'sprockets/yui_compressor'
 
-class TestYUICompressor < MiniTest::Test
+class TestYUICompressor < Minitest::Test
   def test_compress_javascript
     input = {
       content_type: 'application/javascript',


### PR DESCRIPTION
Minitest 5.19.0 removed the "ancient MiniTest compatibility layer" that aliased `Minitest` as `MiniTest`. CI runs without a lock file so tests are failing due to this new release.

This commit renames all of the tests to the correct `Minitest` constant