### PR TITLE
Ensure asset source is utf-8 encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Get upgrade notes from Sprockets 3.x to 4.x at https://github.com/rails/sprockets/blob/master/UPGRADING.md
 
+- Ensure asset source is always UTF-8 encoded.
+
 ## 4.2.1
 
 - Fix for precompile issues when multiple extensions map to the same MIME type (eg. `.jpeg` / `.jpg`). [#781](https://github.com/rails/sprockets/pull/781)

--- a/lib/sprockets/asset.rb
+++ b/lib/sprockets/asset.rb
@@ -98,7 +98,8 @@ module Sprockets
         @source
       else
         # File is read everytime to avoid memory bloat of large binary files
-        File.binread(filename)
+        file = File.binread(filename)
+        file.encoding == Encoding::BINARY ? file : file.force_encoding('utf-8')
       end
     end
 


### PR DESCRIPTION
This is a modest fix for the issue mentioned here #498.