### PR TITLE
Tighten fingerprint detection regex to only accept hexadecimal.

### DIFF
--- a/lib/sprockets/server.rb
+++ b/lib/sprockets/server.rb
@@ -309,7 +309,7 @@ module Sprockets
       #     # => "0aa2105d29558f3eb790d411d7d8fb66"
       #
       def path_fingerprint(path)
-        path[/-([0-9a-zA-Z]{7,128})\.[^.]+\z/, 1]
+        path[/-([0-9a-f]{7,128})\.[^.]+\z/, 1]
       end
   end
 end


### PR DESCRIPTION
Simple fix for https://github.com/rails/sprockets/issues/749

Unless, of course, some fingerprints are not hexadecimal? Is that even a thing? If it is, do we want to support it?