### PR TITLE
Use concurrent-ruby's new Promises API

### DIFF
--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.executables = ["sprockets"]
 
   s.add_dependency "rack",            ">= 2.2.4", "< 4"
-  s.add_dependency "concurrent-ruby", "~> 1.0"
+  s.add_dependency "concurrent-ruby", "~> 1.1"
   s.add_dependency "logger"
 
   s.add_development_dependency "m", ">= 0"


### PR DESCRIPTION
This PR updates `Sprockets::Manifest` to use concurrent-ruby's new [Promises API](https://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/Promises.html) which was added in [v1.1](https://github.com/olivier-thatch/concurrent-ruby/blob/master/CHANGELOG.md#release-v110pre1-edge-v040pre1-15-aug-2018).

The new Promises framework is less prone to deadlocks. As a result, this PR should fix #640.
