### PR TITLE
Fix `Sprockets::Base#unescape` to avoid unexpected change landed in 3.7.4

### DIFF
--- a/lib/sprockets/legacy.rb
+++ b/lib/sprockets/legacy.rb
@@ -155,7 +155,7 @@ module Sprockets
       end
 
       def unescape(str)
-        URIUtils::URI_PARSER.unescape(str)
+        str = URIUtils::URI_PARSER.unescape(str)
         str.force_encoding(Encoding.default_internal) if Encoding.default_internal
         str
       end


### PR DESCRIPTION
384bf452fdbf994a5b80c7cfc55009c98b7e6b76 breaks `Sprockets::Base#unescape`.

The following code has been changed between 3.7.3 and 3.7.4.
``` console
$ ruby -I ./lib -r sprockets -e 'p [Sprockets::VERSION, Sprockets::Environment.new.send(:unescape, "%")]'
```

```
["3.7.3", "%"]
["3.7.4", "%25"]
```

This commit changes back to the behavior of 3.7.3.

This method is not covered by auto-mated tests.
I'm not sure this method is supported officially or not.
Could you tell me we should add specs for this method.