### PR TITLE
Drop base64 gem from dependency

### DIFF
--- a/lib/sprockets/encoding_utils.rb
+++ b/lib/sprockets/encoding_utils.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'base64'
 require 'stringio'
 require 'zlib'
 
@@ -71,7 +70,7 @@ module Sprockets
     #
     # Returns a encoded String
     def base64(str)
-      Base64.strict_encode64(str)
+      [str].pack("m0")
     end
 
 

--- a/test/fixtures/asset/sprite.css.erb
+++ b/test/fixtures/asset/sprite.css.erb
@@ -3,9 +3,8 @@
  */
 
 <%
-  require 'base64'
   path = File.expand_path("../POW.png", __FILE__)
-  data = Base64.encode64(File.open(path, "rb") { |f| f.read })
+  data = [File.open(path, "rb") { |f| f.read }].pack('m')
 %>
 .pow {
   background: url(data:image/png;base64,<%= data %>) no-repeat;

--- a/test/test_context.rb
+++ b/test/test_context.rb
@@ -47,8 +47,7 @@ class TestContext < Sprockets::TestCase
   test "extend context" do
     @env.context_class.class_eval do
       def datauri(path)
-        require 'base64'
-        Base64.encode64(File.open(path, "rb") { |f| f.read })
+        [File.open(path, "rb") { |f| f.read }].pack('m')
       end
     end
 
@@ -89,14 +88,13 @@ class TestCustomProcessor < Sprockets::TestCase
     assert_equal "var Foo = {};\n\nvar Bar = {};\n", @env['application.js'].to_s
   end
 
-  require 'base64'
   DataUriProcessor = proc do |input|
     env = input[:environment]
     data = input[:data]
     data.gsub(/url\(\"(.+?)\"\)/) do
       uri, _ = env.resolve($1)
       path, _ = env.parse_asset_uri(uri)
-      data = Base64.encode64(File.open(path, "rb") { |f| f.read })
+      data = [File.open(path, "rb") { |f| f.read }].pack('m')
       "url(data:image/png;base64,#{data})"
     end
   end
@@ -111,14 +109,12 @@ class TestCustomProcessor < Sprockets::TestCase
   end
 
   test "block custom processor" do
-    require 'base64'
-
     @env.register_preprocessor 'text/css' do |input|
       env = input[:environment]
       input[:data].gsub(/url\(\"(.+?)\"\)/) do
         uri, _ = env.resolve($1)
         path, _ = env.parse_asset_uri(uri)
-        data = Base64.encode64(File.open(path, "rb") { |f| f.read })
+        data = [File.open(path, "rb") { |f| f.read }].pack('m')
         "url(data:image/png;base64,#{data})"
       end
     end


### PR DESCRIPTION
This following warning is shown in test.
```
/Users/ryunosuke.sato/src/github.com/rails/sprockets/lib/sprockets/mime.rb:2: warning: base64 was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add base64 to your Gemfile or gemspec to silence this warning.
```

Instead of adding base64 to dependency, the usage of `Base64#strict_encode64` and `Base64#encode64` have replaced with `Array#pack`.

Also, this PR fixes CI for Ruby 3.4-dev.

Note: Similar PRs are here
- https://github.com/httprb/http/pull/778
- https://github.com/rubocop/rubocop/pull/12313
- https://github.com/rack/rack/pull/2110
- https://github.com/elastic/elasticsearch-ruby/pull/2295
- https://github.com/socketry/protocol-http/pull/51
- https://github.com/lautis/uglifier/pull/195