### PR TITLE
Bump rake version 13.2 or higher to suppress ostruct warnings

### DIFF
--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "minitest", "~> 5.0"
   s.add_development_dependency "nokogiri", "~> 1.3"
   s.add_development_dependency "rack-test", "~> 2.0.0"
-  s.add_development_dependency "rake", "~> 12.0"
+  s.add_development_dependency "rake", "~> 13.2"
   s.add_development_dependency "sass", "~> 3.4"
   s.add_development_dependency "sassc", "~> 2.0"
   s.add_development_dependency "uglifier", ">= 2.3"


### PR DESCRIPTION
This commit bumps the required Rake version to suppress the following warnings:

```ruby
$ ruby -v
ruby 3.4.0dev (2024-10-21T16:48:53Z master 5131fb5dbe) +PRISM [x86_64-linux]
$ bundle exec rake 2>&1 |grep -i ostruct
ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
/home/yahonda/.rbenv/versions/trunk/lib/ruby/gems/3.4.0+0/gems/rake-12.3.3/lib/rake/rake_test_loader.rb:2: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
./home/yahonda/src/github.com/rails/sprockets/lib/rake/sprocketstask.rb:2: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```

- Rake v13.2.0 does not depend on OpenStruct https://github.com/ruby/rake/releases/tag/v13.2.0
https://github.com/ruby/rake/pull/545

- Ruby 3.4.0dev emits OpenStruct warnings https://bugs.ruby-lang.org/issues/20309
https://github.com/ruby/ruby/pull/10428