### PR TITLE
Address `warning: URI::RFC3986_PARSER` warnings against ruby 3.4.0dev

### DIFF
--- a/lib/sprockets/uri_utils.rb
+++ b/lib/sprockets/uri_utils.rb
@@ -21,6 +21,9 @@ module Sprockets
   module URIUtils
     extend self
 
+    URI_PARSER = defined?(URI::RFC2396_PARSER) ? URI::RFC2396_PARSER : URI::Generic::DEFAULT_PARSER
+    private_constant :URI_PARSER
+
     # Internal: Parse URI into component parts.
     #
     # uri - String uri
@@ -45,7 +48,7 @@ module Sprockets
     def split_file_uri(uri)
       scheme, _, host, _, _, path, _, query, _ = URI.split(uri)
 
-      path = URI::Generic::DEFAULT_PARSER.unescape(path)
+      path = URI_PARSER.unescape(path)
       path.force_encoding(Encoding::UTF_8)
 
       # Hack for parsing Windows "/C:/Users/IEUser" paths
@@ -63,7 +66,7 @@ module Sprockets
       str = +"#{scheme}://"
       str << host if host
       path = "/#{path}" unless path.start_with?("/".freeze)
-      str << URI::Generic::DEFAULT_PARSER.escape(path)
+      str << URI_PARSER.escape(path)
       str << "?#{query}" if query
       str
     end
@@ -162,7 +165,7 @@ module Sprockets
         when Integer
           query << "#{key}=#{value}"
         when String, Symbol
-          query << "#{key}=#{URI::Generic::DEFAULT_PARSER.escape(value.to_s)}"
+          query << "#{key}=#{URI_PARSER.escape(value.to_s)}"
         when TrueClass
           query << "#{key}"
         when FalseClass, NilClass
@@ -182,7 +185,7 @@ module Sprockets
     def parse_uri_query_params(query)
       query.to_s.split('&'.freeze).reduce({}) do |h, p|
         k, v = p.split('='.freeze, 2)
-        v = URI::Generic::DEFAULT_PARSER.unescape(v) if v
+        v = URI_PARSER.unescape(v) if v
         h[k.to_sym] = v || true
         h
       end


### PR DESCRIPTION
This pull request addresses the `warning: URI::RFC3986_PARSER` warnings against ruby 3.4.0dev

* Steps to reproduce

```ruby
$ ruby -v
ruby 3.4.0dev (2024-10-21T16:48:53Z master 5131fb5dbe) +PRISM [x86_64-linux]
$ bundle exec rake 2>&1 |grep 'warning: URI::RFC3986_PARSER'
```

* Warnings addressed by this commit:
```ruby
/path/to/sprockets/lib/sprockets/uri_utils.rb:48: warning: URI::RFC3986_PARSER.unescape is obsoleted. Use URI::RFC2396_PARSER.unescape explicitly.
/path/to/sprockets/lib/sprockets/uri_utils.rb:66: warning: URI::RFC3986_PARSER.escape is obsoleted. Use URI::RFC2396_PARSER.escape explicitly.
/path/to/sprockets/lib/sprockets/uri_utils.rb:165: warning: URI::RFC3986_PARSER.escape is obsoleted. Use URI::RFC2396_PARSER.escape explicitly.
/path/to/sprockets/lib/sprockets/uri_utils.rb:185: warning: URI::RFC3986_PARSER.unescape is obsoleted. Use URI::RFC2396_PARSER.unescape explicitly.
```

Refer to the following URL for the background of this change:

- URI::Generic should use URI::RFC3986_PARSER instead of URI::DEFAULT_PARSER https://bugs.ruby-lang.org/issues/19266
- Use RFC3986_Parser by default https://github.com/ruby/uri/pull/107
- Warn compatibility methods in RFC3986_PARSER https://github.com/ruby/uri/pull/114