### PR TITLE
Add logger as dependency to address warnings against Ruby 3.4.0dev

### DIFF
--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rack",            ">= 2.2.4", "< 4"
   s.add_dependency "concurrent-ruby", "~> 1.0"
+  s.add_dependency "logger"
 
   s.add_development_dependency "m", ">= 0"
   s.add_development_dependency "babel-transpiler", "~> 0.6"


### PR DESCRIPTION
This commit addresses the `warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.` against Ruby 3.4.0dev

* Steps to reproduce

```ruby
$ ruby -v
ruby 3.4.0dev (2024-10-21T16:48:53Z master 5131fb5dbe) +PRISM [x86_64-linux]
$ bundle exec rake 2>&1 |grep 'warning: logger'
```

* Warnings addressed by this commit:

```ruby
/path/to/sprockets/lib/sprockets/base.rb:4: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
/path/to/sprockets/lib/sprockets/cache/file_store.rb:3: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
/path/to/sprockets/lib/sprockets/cache.rb:2: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
/path/to/sprockets/lib/sprockets/manifest_utils.rb:3: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
/path/to/sprockets/lib/sprockets.rb:5: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
```

* Refer to the following URL for the background of this change: https://bugs.ruby-lang.org/issues/20309
https://github.com/ruby/ruby/commit/d7e558e3c48c213d0e8bedca4fb547db55613f7c