### PR TITLE
First-class Terser support

### DIFF
--- a/lib/sprockets.rb
+++ b/lib/sprockets.rb
@@ -129,6 +129,7 @@ module Sprockets
   require 'sprockets/sass_compressor'
   require 'sprockets/sassc_compressor'
   require 'sprockets/jsminc_compressor'
+  require 'sprockets/terser_compressor'
   require 'sprockets/uglifier_compressor'
   require 'sprockets/yui_compressor'
   register_compressor 'text/css', :sass, SassCompressor
@@ -139,6 +140,7 @@ module Sprockets
   register_compressor 'application/javascript', :closure, ClosureCompressor
   register_compressor 'application/javascript', :jsmin, JSMincCompressor
   register_compressor 'application/javascript', :jsminc, JSMincCompressor
+  register_compressor 'application/javascript', :terser, TerserCompressor
   register_compressor 'application/javascript', :uglifier, UglifierCompressor
   register_compressor 'application/javascript', :uglify, UglifierCompressor
   register_compressor 'application/javascript', :yui, YUICompressor

--- a/lib/sprockets/autoload.rb
+++ b/lib/sprockets/autoload.rb
@@ -9,6 +9,7 @@ module Sprockets
     autoload :JSMinC, 'sprockets/autoload/jsminc'
     autoload :Sass, 'sprockets/autoload/sass'
     autoload :SassC, 'sprockets/autoload/sassc'
+    autoload :Terser, 'sprockets/autoload/terser'
     autoload :Uglifier, 'sprockets/autoload/uglifier'
     autoload :YUI, 'sprockets/autoload/yui'
     autoload :Zopfli, 'sprockets/autoload/zopfli'

--- a/lib/sprockets/autoload/terser.rb
+++ b/lib/sprockets/autoload/terser.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require 'terser'
+
+module Sprockets
+  module Autoload
+    Terser = ::Terser
+  end
+end

--- a/lib/sprockets/terser_compressor.rb
+++ b/lib/sprockets/terser_compressor.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+require 'sprockets/digest_utils'
+require 'sprockets/source_map_utils'
+
+module Sprockets
+  class TerserCompressor
+    VERSION = '1'
+
+    def initialize(options = {})
+      @options = options.dup
+      @options[:comments] ||= :none
+      @options.merge!(Rails.application.config.assets.terser.to_h) if defined?(Rails)
+      @cache_key = -"#{self.class.name}:#{Autoload::Terser::VERSION}:#{VERSION}:#{DigestUtils.digest(options)}"
+      @terser = ::Terser.new(@options)
+    end
+
+    def self.instance
+      @instance ||= new
+    end
+
+    def self.call(input)
+      instance.call(input)
+    end
+
+    def self.cache_key
+      instance.cache_key
+    end
+
+    attr_reader :cache_key
+
+    def call(input)
+      input_options = { source_map: { filename: input[:filename] } }
+
+      js, map = @terser.compile_with_map(input[:data], input_options)
+
+      map = SourceMapUtils.format_source_map(JSON.parse(map), input)
+      map = SourceMapUtils.combine_source_maps(input[:metadata][:map], map)
+
+      { data: js, map: map }
+    end
+  end
+end

--- a/lib/sprockets/terser_compressor.rb
+++ b/lib/sprockets/terser_compressor.rb
@@ -9,7 +9,7 @@ module Sprockets
     def initialize(options = {})
       @options = options.dup
       @options[:comments] ||= :none
-      @options.merge!(Rails.application.config.assets.terser.to_h) if defined?(Rails)
+      @options.merge!(::Rails.application.config.assets.terser.to_h) if defined?(::Rails)
       @cache_key = -"#{self.class.name}:#{Autoload::Terser::VERSION}:#{VERSION}:#{DigestUtils.digest(options)}"
       @terser = ::Terser.new(@options)
     end

--- a/sprockets.gemspec
+++ b/sprockets.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 13.2"
   s.add_development_dependency "sass", "~> 3.4"
   s.add_development_dependency "sassc", "~> 2.0"
+  s.add_development_dependency "terser", ">= 1.2"
   s.add_development_dependency "uglifier", ">= 2.3"
   s.add_development_dependency "yui-compressor", "~> 0.12"
   unless RUBY_PLATFORM.include?('java')

--- a/test/test_terser.rb
+++ b/test/test_terser.rb
@@ -6,7 +6,7 @@ require 'terser'
 class TestTerserCompressor < Minitest::Test
   def setup
     @env = Sprockets::Environment.new
-    @env.js_compressor = Terser.new
+    @env.js_compressor = :terser
     @cache = Sprockets::Cache.new
 
     @tmpdir = Dir.mktmpdir
@@ -18,7 +18,7 @@ class TestTerserCompressor < Minitest::Test
   end
 
   def test_terser_configured_as_compressor
-    assert_equal :js_compressor, @env.js_compressor
+    assert_equal Sprockets::TerserCompressor, @env.js_compressor
   end
 
   def test_compress_javascript_through_sprockets

--- a/test/test_terser.rb
+++ b/test/test_terser.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+require 'minitest/autorun'
+require 'sprockets'
+require 'terser'
+
+class TestTerserCompressor < Minitest::Test
+  def setup
+    @env = Sprockets::Environment.new
+    @env.js_compressor = Terser.new
+    @cache = Sprockets::Cache.new
+
+    @tmpdir = Dir.mktmpdir
+    @env.append_path(@tmpdir)
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir) if @tmpdir
+  end
+
+  def test_terser_configured_as_compressor
+    assert_equal :js_compressor, @env.js_compressor
+  end
+
+  def test_compress_javascript_through_sprockets
+    js_content = "function foo() {\n  return true;\n}"
+    file_path = File.join(@tmpdir, 'test.js')
+    File.write(file_path, js_content)
+
+    asset = @env['test.js']
+    compressed = asset.to_s
+
+    assert compressed.length < js_content.length
+    assert compressed.include?('function foo(){return!0}')
+    refute compressed.include?("\n  ")
+  end
+
+  def test_compress_es6_through_sprockets
+    js_content = "const arrow = (x) => {\n  return x * 2;\n}\nlet value = 10;"
+    file_path = File.join(@tmpdir, 'test_es6.js')
+    File.write(file_path, js_content)
+
+    asset = @env['test_es6.js']
+    compressed = asset.to_s
+
+    assert compressed.length < js_content.length
+    assert compressed.include?('const arrow=a=>2*a')
+    refute compressed.include?("\n  ")
+  end
+
+  def test_compress_with_comments_through_sprockets
+    js_content = <<~JS
+      // This is a single line comment
+      function calculate(a, b) {
+        /* This is a 
+           multi-line comment */
+        return a + b;
+      }
+    JS
+
+    file_path = File.join(@tmpdir, 'test_comments.js')
+    File.write(file_path, js_content)
+
+    asset = @env['test_comments.js']
+    compressed = asset.to_s
+
+    assert compressed.length < js_content.length
+    refute compressed.include?('This is a single line comment')
+    refute compressed.include?('multi-line comment')
+    assert compressed.include?('function calculate')
+  end
+
+  def test_preserve_license_comments_through_sprockets
+    js_content = <<~JS
+      /*! 
+       * Important License Information
+       * Copyright (c) 2024
+       */
+      function licensed() {
+        return "code";
+      }
+    JS
+
+    file_path = File.join(@tmpdir, 'test_license.js')
+    File.write(file_path, js_content)
+
+    asset = @env['test_license.js']
+    compressed = asset.to_s
+
+    assert compressed.length < js_content.length
+    assert compressed.include?('function licensed')
+  end
+
+  def test_multiple_files_compression
+    file1_content = "var globalVar = 100;\nfunction first() { return globalVar; }"
+    file2_content = "function second() { return globalVar * 2; }"
+
+    File.write(File.join(@tmpdir, 'file1.js'), file1_content)
+    File.write(File.join(@tmpdir, 'file2.js'), file2_content)
+
+    asset1 = @env['file1.js']
+    asset2 = @env['file2.js']
+
+    compressed1 = asset1.to_s
+    compressed2 = asset2.to_s
+
+    assert compressed1.length < file1_content.length
+    assert compressed2.length < file2_content.length
+
+    assert compressed1.include?('globalVar')
+    assert compressed2.include?('globalVar')
+  end
+
+  def test_compression_with_syntax_error
+    js_content = 'function broken() { this is not valid javascript'
+    file_path = File.join(@tmpdir, 'test_error.js')
+    File.write(file_path, js_content)
+
+    assert_raises(Terser::Error) do
+      @env['test_error.js'].to_s
+    end
+  end
+end


### PR DESCRIPTION
This PR ports https://github.com/ahorek/terser-ruby/blob/master/lib/terser/compressor.rb (MIT licensed) to this gem, to add first-class support for Terser in the same manner that Uglifier, YUI, etc. are supported.

Issue raised in Terser gem to notify the maintainers of this port: https://github.com/ahorek/terser-ruby/issues/65

---

## Motivation

Recently, I replaced the Uglifier with Terser in my Gemfile and Rails config, expecting it to be a drop in replacement:

```ruby
  # in Gemfile
  group :assets do
    gem 'terser'  # was gem 'uglifier'
    ...

  # in config/environments/*.rb
  config.assets.js_compressor = :terser  # was :uglifier
```

When I deployed to staging, the process errored during bootstrapping because constant `Terser` could not be found. In a nutshell, the reason why Uglifier works and Terser does not is because `Sprockets::UglifierCompressor` exists in Sprockets lib and does not require the `uglifier` gem to already be loaded, while the Terser equivalent is loaded by a Railtie in the `terser` gem which does require loading `terser` gem first.