### PR TITLE
Do not set variable GZip#mtime but do always set File#mtime

### DIFF
--- a/lib/sprockets/encoding_utils.rb
+++ b/lib/sprockets/encoding_utils.rb
@@ -50,6 +50,8 @@ module Sprockets
       Marshal.load(marshaled)
     end
 
+    GZIP_MTIME = RUBY_VERSION >= "2.7" ? 0 : 1
+
     # Public: Use gzip to compress data.
     #
     # str - String data
@@ -58,7 +60,7 @@ module Sprockets
     def gzip(str)
       io = StringIO.new
       gz = Zlib::GzipWriter.new(io, Zlib::BEST_COMPRESSION)
-      gz.mtime = 1
+      gz.mtime = Sprockets::EncodingUtils::GZIP_MTIME
       gz << str
       gz.finish
       io.string

--- a/test/test_encoding_utils.rb
+++ b/test/test_encoding_utils.rb
@@ -15,7 +15,7 @@ class TestDigestUtils < Minitest::Test
   def test_gzip
     output = gzip("foobar")
     assert_equal 26, output.length
-    assert_equal [31, 139, 8, 0, 1, 0, 0, 0], output.bytes.take(8)
+    assert_equal [31, 139, 8, 0, Sprockets::EncodingUtils::GZIP_MTIME, 0, 0, 0], output.bytes.take(8)
   end
 
   def test_base64


### PR DESCRIPTION
This revisits the discussion in #197 to handle gzipped assets appropriately in the context of web assets.

- Sets the GZip `mtime` header value to a fixed value. By spec this should be `0`, but Ruby < 2.7 had a ZLib bug that caused a `0` value to be equivalent to unset which results in it being set to the current time. So `1` is used instead. The same [compromise was just merged into Rack::Deflater](https://github.com/rack/rack/pull/2372#issuecomment-3247238371).
- Sets the correct File mtime for both GZip and Zopfli compressed files. It looks like that was overlooked when [Zopfli support was added](https://github.com/rails/sprockets/pull/233).

## Why

The GZip mtime is a header value of the compressed file; changing the header file changes the contents (content integrity hash) of the file. That's annoying when writing to Docker or Git (#707) that just look at the file contents and can affect caching/cacheability (not strictly Conditional Requests). It's not necessary to set this GZip header to an accurate value. I documented this more [over in the Rack::Deflater PR](https://github.com/rack/rack/pull/2372#issuecomment-3246205527), but briefly:

- Apache `mod_deflate` sets gzip mtime to `0`
- nginx `ngx_http_gzip_module` uses `deflateInit2` with a setting that sets mtime to `0`
- Zopfli sets the header [to zero](https://github.com/google/zopfli/issues/89) ([code](https://github.com/google/zopfli/blob/ccf9f0588d4a4509cb1040310ec122243e670ee6/src/zopfli/gzip_container.c#L94-L98)).

We _do_ want to set the File `mtime` because that is used for setting the `last-modified` http header, and this ensures that the uncompressed source and the compressed file share the same `last-modified` value. This change aligns the lifecycle of the uncompressed and compressed files so that both `last-modified` and file contents change together.