### PR TITLE
ci: add explicit workflow-level permissions to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds an explicit workflow-level `permissions:` block to `ci.yml`.

Scope set: `contents: read` (the minimum for checkout + the read-only steps this workflow runs).

Checklist:

- [x] Workflow does not push commits, create releases, or write issues/PRs
- [x] No `pull_request_target` trigger; this is a regular `push`/`pull_request` workflow
- [x] No `actions/cache@v3+` save path (would need `actions: write`)
- [x] YAML re-parses with `yaml.safe_load`
- [x] Matches the pattern recommended in GitHub's [token hardening docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)

This is one of the lowest-effort items on the OpenSSF Scorecard Token-Permissions check, and one of the cheaper defenses against incidents like tj-actions/changed-files compromise in March 2025 (CVE-2025-30066).
