### PR TITLE
Exclude rack 3.2.6 on Ruby 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source "https://rubygems.org"
 gemspec
+
+gem "rack", "!= 3.2.6" if RUBY_VERSION < "2.6"


### PR DESCRIPTION
The Ruby 2.5 CI job currently fails at require time, which blocks #827 and any other pull request:

https://github.com/rails/sprockets/actions/runs/27955713071/job/87812447285?pr=827

```
rack-3.2.6/lib/rack/utils.rb:149:in `to_h': wrong element type String at 0 (expected array) (TypeError)
```

rack 3.2.6 added a block form of `Array#to_h`, introduced in Ruby 2.6, to `lib/rack/utils.rb` as part of the Forwarded header parser rewrite, while its gemspec still declares `required_ruby_version >= 2.4.0`. Bundler therefore resolves rack 3.2.6 on Ruby 2.5 and `require "sprockets"` fails. The weekly runs on the `main` branch turned from success (2026-07-06) to failure (2026-07-13) for the same reason, so re-running the failed job does not help.

Upstream already restored Ruby 2.4/2.5 compatibility on the 3-2-stable branch (rack/rack#2450, rack/rack@108405ea9fec02dc14c8317e25619d1001ffe4a9), but no release including the fix is available yet. This change excludes only 3.2.6 on Ruby 2.5, so the next rack release applies automatically.

Verified in a ruby:2.5 container: rack resolves to 3.2.5 and the test suite loads and runs (the failure above happens before any test runs).