### PR TITLE
Allow disabling the cache limits

### DIFF
--- a/lib/sprockets/cache/file_store.rb
+++ b/lib/sprockets/cache/file_store.rb
@@ -36,13 +36,13 @@ module Sprockets
       #
       # root     - A String path to a directory to persist cached values to.
       # max_size - A Integer of the maximum size the store will hold (in bytes).
-      #            (default: 25MB).
+      #            (default: 25MB). Can be set to +false+ for no limit.
       # logger   - The logger to which some info will be printed.
       #            (default logger level is FATAL and won't output anything).
       def initialize(root, max_size = DEFAULT_MAX_SIZE, logger = self.class.default_logger)
         @root     = root
         @max_size = max_size
-        @gc_size  = max_size * 0.75
+        @gc_size  = max_size * 0.75 if max_size
         @logger   = logger
       end
 
@@ -111,11 +111,13 @@ module Sprockets
         # Write data
         PathUtils.atomic_write(path) do |f|
           f.write(raw)
-          @size = size + f.size unless exists
+          if defined?(@size) && !exists
+            @size += f.size
+          end
         end
 
         # GC if necessary
-        gc! if size > @max_size
+        gc! if @max_size && size > @max_size
 
         value
       end

--- a/lib/sprockets/cache/memory_store.rb
+++ b/lib/sprockets/cache/memory_store.rb
@@ -18,7 +18,7 @@ module Sprockets
       # Public: Initialize the cache store.
       #
       # max_size - A Integer of the maximum number of keys the store will hold.
-      #            (default: 1000).
+      #            (default: 1000). Can be set to +false+ for no limit.
       def initialize(max_size = DEFAULT_MAX_SIZE)
         @max_size = max_size
         @cache = {}
@@ -56,7 +56,7 @@ module Sprockets
         @mutex.synchronize do
           @cache.delete(key)
           @cache[key] = value
-          @cache.shift if @cache.size > @max_size
+          @cache.shift if @max_size && @cache.size > @max_size
         end
         value
       end


### PR DESCRIPTION
In environments where assets rarely change, sprockets spends more time computing the cache size to know if it has to clean it, than to do actual work.

Hacing to `stat()` thousands of cache entries is quite expensive, so it might not be worth it.

Another option would to only count the number of entries and ignore their size, but that would only remove half the overhead.