### PR TITLE
Fix compatible rubocop performance infractions

### DIFF
--- a/lib/sprockets/path_utils.rb
+++ b/lib/sprockets/path_utils.rb
@@ -91,6 +91,8 @@ module Sprockets
       SEPARATOR_PATTERN = "#{Regexp.quote(File::SEPARATOR)}"
     end
 
+    RELATIVE_PATH_PATTERN = /^\.\.?($|#{SEPARATOR_PATTERN})/
+
     # Public: Check if path is explicitly relative.
     # Starts with "./" or "../".
     #
@@ -98,7 +100,7 @@ module Sprockets
     #
     # Returns true if path is relative, otherwise false.
     def relative_path?(path)
-      path.match?(/^\.\.?($|#{SEPARATOR_PATTERN})/) ? true : false
+      path.match?(RELATIVE_PATH_PATTERN) ? true : false
     end
 
     # Public: Get relative path from `start` to `dest`.

--- a/test/test_coffee_script_processor.rb
+++ b/test/test_coffee_script_processor.rb
@@ -23,7 +23,7 @@ class TestCoffeeScriptProcessor < Minitest::Test
       metadata: { mapping: [] }
     }
     result = Sprockets::CoffeeScriptProcessor.call(input)
-    assert result[:data].match(/var square/)
+    assert result[:data].include?('var square')
     assert_equal 13, Sprockets::SourceMapUtils.decode_source_map(result[:map])[:mappings].size
     assert_equal ["squared.source.coffee"], result[:map]["sources"]
   end

--- a/test/test_eco_processor.rb
+++ b/test/test_eco_processor.rb
@@ -10,7 +10,7 @@ class TestEcoProcessor < Minitest::Test
       data: "<span>Hello, <%= name %></p>",
       cache: Sprockets::Cache.new
     }
-    assert Sprockets::EcoProcessor.call(input).match(/<span>Hello, /)
+    assert Sprockets::EcoProcessor.call(input).include?('<span>Hello, ')
   end
 
   def test_cache_key

--- a/test/test_ejs_processor.rb
+++ b/test/test_ejs_processor.rb
@@ -10,7 +10,7 @@ class TestEjsProcessor < Minitest::Test
       data: "<span>Hello, <%= name %></p>",
       cache: Sprockets::Cache.new
     }
-    assert Sprockets::EjsProcessor.call(input).match(/<span>Hello, /)
+    assert Sprockets::EjsProcessor.call(input).include?('<span>Hello, ')
   end
 
   def test_cache_key

--- a/test/test_require.rb
+++ b/test/test_require.rb
@@ -6,10 +6,12 @@ class TestRequire < Minitest::Test
 
   ROOT = File.expand_path("../..", __FILE__)
 
+  JRUBY_UNSUPPORTED_FILES = ['zopfli.rb', 'jsminc.rb', 'sassc.rb']
+
   Dir["#{ROOT}/lib/**/*.rb"].each do |fn|
     basename = File.basename(fn)
     next if basename == "version.rb"
-    next if RUBY_PLATFORM.include?('java') && ['zopfli.rb', 'jsminc.rb', 'sassc.rb'].include?(basename)
+    next if RUBY_PLATFORM.include?('java') && JRUBY_UNSUPPORTED_FILES.include?(basename)
 
     define_method "test_require_individual_library_files: #{fn}" do
       system "ruby", "-I#{ROOT}/lib", fn

--- a/test/test_utils.rb
+++ b/test/test_utils.rb
@@ -103,7 +103,7 @@ class TestUtils < Minitest::Test
   end
 
   def apply_concat_javascript_sources(*args)
-    args.reduce(+"", &method(:concat_javascript_sources))
+    args.reduce(+"") { |buf, source| concat_javascript_sources(buf, source) }
   end
 
 


### PR DESCRIPTION
This PR applies some rubocop performance fixes that still work with older rubies. The test ones are pretty negligible in terms of performance improvement but the path_utils change can save us on object allocations resulting in less frequent garbage collection.